### PR TITLE
Add screenshot detection notifications

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -190,7 +190,7 @@ struct ContentView: View {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 14))
                         .foregroundColor(Color.orange)
-                    Text("private: \(privatePeerNick)")
+                    Text("\(privatePeerNick)")
                         .font(.system(size: 16, weight: .medium, design: .monospaced))
                         .foregroundColor(Color.orange)
                 }


### PR DESCRIPTION
## Summary
- Detect when users take screenshots on iOS
- Send system notifications to inform other participants
- Works across all chat contexts: public, channels, and private messages

## Implementation Details
- Uses UIApplication.userDidTakeScreenshotNotification on iOS
- Sends formatted message "* <nickname> took a screenshot *"
- Recipients see the notification as a system message
- User who took screenshot sees "you took a screenshot" locally

## Behavior by Context
- **Public chat**: Notification sent to all connected peers
- **Channel**: Notification sent only to channel members
- **Private message**: Notification sent only to the other person in conversation

## UI Updates
- Removed "private:" prefix from private chat header
- Private chats now show only lock icon and peer name

## Test plan
- [ ] Test screenshot in public chat - verify all users see notification as system message
- [ ] Test screenshot in channel - verify only channel members see it
- [ ] Test screenshot in private message - verify only the other person sees it
- [ ] Verify notifications display as system messages with gray text
- [ ] Test that the person taking screenshot sees "you took a screenshot"
- [ ] Verify no notifications sent when app is in background
- [ ] Verify private chat header shows only lock icon and name