### PR TITLE
Add iOS Share Extension

### DIFF
--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -26,6 +26,14 @@ struct BitchatApp: App {
                 .environmentObject(chatViewModel)
                 .onAppear {
                     NotificationDelegate.shared.chatViewModel = chatViewModel
+                    #if os(iOS)
+                    appDelegate.chatViewModel = chatViewModel
+                    #endif
+                    // Check for shared content
+                    checkForSharedContent()
+                }
+                .onOpenURL { url in
+                    handleURL(url)
                 }
         }
         #if os(macOS)
@@ -33,10 +41,57 @@ struct BitchatApp: App {
         .windowResizability(.contentSize)
         #endif
     }
+    
+    private func handleURL(_ url: URL) {
+        if url.scheme == "bitchat" && url.host == "share" {
+            // Handle shared content
+            checkForSharedContent()
+        }
+    }
+    
+    private func checkForSharedContent() {
+        // Check app group for shared content from extension
+        guard let userDefaults = UserDefaults(suiteName: "group.chat.bitchat"),
+              let sharedContent = userDefaults.string(forKey: "sharedContent"),
+              let sharedDate = userDefaults.object(forKey: "sharedContentDate") as? Date else {
+            return
+        }
+        
+        // Only process if shared within last 30 seconds
+        if Date().timeIntervalSince(sharedDate) < 30 {
+            let contentType = userDefaults.string(forKey: "sharedContentType") ?? "text"
+            
+            // Clear the shared content
+            userDefaults.removeObject(forKey: "sharedContent")
+            userDefaults.removeObject(forKey: "sharedContentType")
+            userDefaults.removeObject(forKey: "sharedContentDate")
+            userDefaults.synchronize()
+            
+            // Show notification about shared content
+            DispatchQueue.main.async {
+                // Add system message about sharing
+                let systemMessage = BitchatMessage(
+                    sender: "system",
+                    content: "preparing to share \(contentType)...",
+                    timestamp: Date(),
+                    isRelay: false
+                )
+                self.chatViewModel.messages.append(systemMessage)
+            }
+            
+            // Send the shared content after a short delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                let prefix = contentType == "url" ? "Shared link: " : ""
+                self.chatViewModel.sendMessage(prefix + sharedContent)
+            }
+        }
+    }
 }
 
 #if os(iOS)
 class AppDelegate: NSObject, UIApplicationDelegate {
+    weak var chatViewModel: ChatViewModel?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return true
     }

--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -40,5 +40,16 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bitchat</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>chat.bitchat</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/bitchat/bitchat.entitlements
+++ b/bitchat/bitchat.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.bitchat</string>
+	</array>
+</dict>
+</plist>

--- a/bitchatShareExtension/Info.plist
+++ b/bitchatShareExtension/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>bitchat</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/bitchatShareExtension/bitchatShareExtension.entitlements
+++ b/bitchatShareExtension/bitchatShareExtension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.bitchat</string>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -47,6 +47,32 @@ targets:
       CODE_SIGNING_ALLOWED: YES
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS: YES
+      CODE_SIGN_ENTITLEMENTS: bitchat/bitchat.entitlements
+    dependencies:
+      - target: bitchatShareExtension
+        platformFilter: ios
+        embed: true
+        
+  bitchatShareExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - bitchatShareExtension
+    info:
+      path: bitchatShareExtension/Info.plist
+      properties:
+        CFBundleDisplayName: bitchat
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: chat.bitchat.ShareExtension
+      INFOPLIST_FILE: bitchatShareExtension/Info.plist
+      SWIFT_VERSION: 5.0
+      IPHONEOS_DEPLOYMENT_TARGET: 16.0
+      CODE_SIGN_STYLE: Automatic
+      CODE_SIGNING_REQUIRED: YES
+      CODE_SIGNING_ALLOWED: YES
+      CODE_SIGN_ENTITLEMENTS: bitchatShareExtension/bitchatShareExtension.entitlements
 
   bitchatTests_iOS:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- Add share extension to enable sharing content to bitchat from other iOS apps
- Appears in the iOS share sheet when sharing text, URLs, or images

## Features
- Share text content directly to bitchat
- Share URLs with automatic "Shared link:" prefix
- Prepare for future image sharing support
- Uses app groups for secure data transfer between extension and main app
- Displays system message when content is being shared

## Implementation Details
- Created ShareViewController using SLComposeServiceViewController for native iOS share UI
- Added app group entitlements for both main app and extension
- Implemented URL scheme handling for potential future direct app launching
- Share extension validates content before enabling the Post button
- Main app checks for shared content on launch and when returning from background

## Configuration
- App Group: group.chat.bitchat
- URL Scheme: bitchat://
- Bundle ID: chat.bitchat.ShareExtension

## Test plan
- [ ] Build and run on iOS device/simulator
- [ ] Open Safari or Notes app, select some text
- [ ] Tap share button and verify bitchat appears in share sheet
- [ ] Share text and verify it appears in bitchat
- [ ] Share a URL and verify it appears with "Shared link:" prefix
- [ ] Test sharing when bitchat is not running
- [ ] Test sharing when bitchat is in background
- [ ] Verify system message appears before shared content