### PR TITLE
Screenshot Prevention & Detection V2

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		4E778E5A414571ACAC2A0F01 /* MessageRetentionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */; };
 		5D95F2BFBE257A1225998389 /* BatteryOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED176FF3B274E35C2D827894 /* BatteryOptimizer.swift */; };
 		61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448F84BF86A42A3CC4A9379 /* NotificationService.swift */; };
+		6A835A722E1CE12100E0E687 /* ProtectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A835A712E1CE11700E0E687 /* ProtectedView.swift */; };
+		6A835A732E1CE12100E0E687 /* ProtectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A835A712E1CE11700E0E687 /* ProtectedView.swift */; };
 		6DE056E1EE9850E9FBF50157 /* BitchatProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F17B68CFF7AB1BC91C847 /* BitchatProtocol.swift */; };
 		6E7761E21C99F28AE2F9BE5F /* BitchatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF625BB3AD919322C01A46B2 /* BitchatApp.swift */; };
 		739429DFDE5C5829CF70DA7D /* EncryptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC1563390A15C042D059CF9 /* EncryptionService.swift */; };
@@ -82,6 +84,7 @@
 		3FA8FF26ABDC1C642A8C7AE5 /* BitchatMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatMessageTests.swift; sourceTree = "<group>"; };
 		53D535D9CE0B875F47402290 /* BinaryProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryProtocolTests.swift; sourceTree = "<group>"; };
 		67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRetentionService.swift; sourceTree = "<group>"; };
+		6A835A712E1CE11700E0E687 /* ProtectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedView.swift; sourceTree = "<group>"; };
 		6DC1563390A15C042D059CF9 /* EncryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionService.swift; sourceTree = "<group>"; };
 		763E0DBA9492A654FC0CDCB9 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		7EEBDA723E1CFD88758DA4AC /* bitchat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitchat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,6 +163,7 @@
 			children = (
 				763E0DBA9492A654FC0CDCB9 /* AppInfoView.swift */,
 				A08E03AA0C63E97C91749AEC /* ContentView.swift */,
+				6A835A712E1CE11700E0E687 /* ProtectedView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -338,6 +342,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD11E46940D742AEAF547EB2 /* AppInfoView.swift in Sources */,
+				6A835A732E1CE12100E0E687 /* ProtectedView.swift in Sources */,
 				C0A80BA73EC1A372B9338E3C /* BatteryOptimizer.swift in Sources */,
 				4B747085D07A1BCE0F5BA612 /* BinaryProtocol.swift in Sources */,
 				6E7761E21C99F28AE2F9BE5F /* BitchatApp.swift in Sources */,
@@ -361,6 +366,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABAF130D88561F4A646F0430 /* AppInfoView.swift in Sources */,
+				6A835A722E1CE12100E0E687 /* ProtectedView.swift in Sources */,
 				5D95F2BFBE257A1225998389 /* BatteryOptimizer.swift in Sources */,
 				F455F011B3B648ADA233F998 /* BinaryProtocol.swift in Sources */,
 				10E68BB889356219189E38EC /* BitchatApp.swift in Sources */,

--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -74,9 +74,11 @@ enum MessageType: UInt8 {
     case fragmentEnd = 0x07
     case channelAnnounce = 0x08  // Announce password-protected channel status
     case channelRetention = 0x09  // Announce channel retention status
-    case deliveryAck = 0x0A  // Acknowledge message received
-    case deliveryStatusRequest = 0x0B  // Request delivery status update
-    case readReceipt = 0x0C  // Message has been read/viewed
+    case channelScreenshotProtection = 0x0A
+    case privateScreenshotProtection = 0x0B
+    case deliveryAck = 0x0C  // Acknowledge message received
+    case deliveryStatusRequest = 0x0D  // Request delivery status update
+    case readReceipt = 0x0E  // Message has been read/viewed
 }
 
 // Special recipient ID for broadcast messages
@@ -251,6 +253,8 @@ protocol BitchatDelegate: AnyObject {
     func didReceiveChannelLeave(_ channel: String, from peerID: String)
     func didReceivePasswordProtectedChannelAnnouncement(_ channel: String, isProtected: Bool, creatorID: String?, keyCommitment: String?)
     func didReceiveChannelRetentionAnnouncement(_ channel: String, enabled: Bool, creatorID: String?)
+    func didReceiveChannelScreenshotProtectionAnnouncement(_ channel: String, enabled: Bool, creatorID: String?)
+    func didReceivePrivateScreenshotProtectionNotification(_ enabled: Bool, from peerID: String)
     func decryptChannelMessage(_ encryptedContent: Data, channel: String) -> String?
     
     // Optional method to check if a fingerprint belongs to a favorite peer
@@ -277,6 +281,14 @@ extension BitchatDelegate {
     }
     
     func didReceiveChannelRetentionAnnouncement(_ channel: String, enabled: Bool, creatorID: String?) {
+        // Default empty implementation
+    }
+    
+    func didReceiveChannelScreenshotProtectionAnnouncement(_ channel: String, enabled: Bool, creatorID: String?) {
+        // Default empty implementation
+    }
+    
+    func didReceivePrivateScreenshotProtectionNotification(_ enabled: Bool, from peerID: String) {
         // Default empty implementation
     }
     

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -3304,7 +3304,6 @@ extension ChatViewModel: BitchatDelegate {
     }
     
     // Toggle screenshot protection for private chats
-    // Toggle screenshot protection for private chats
     func togglePrivateChatScreenshotProtection(_ enabled: Bool) {
         guard let peerID = selectedPrivateChatPeer,
               let fingerprint = peerIDToPublicKeyFingerprint[peerID],

--- a/bitchat/Views/ProtectedView.swift
+++ b/bitchat/Views/ProtectedView.swift
@@ -1,0 +1,94 @@
+//
+//  ProtectedView.swift
+//  bitchat
+//
+//  This is free and unencumbered software released into the public domain.
+//  For more information, see <https://unlicense.org>
+//
+
+import SwiftUI
+
+#if os(iOS)
+import UIKit
+public typealias PlatformViewRepresentable = UIViewRepresentable
+#elseif os(macOS)
+import AppKit
+public typealias PlatformViewRepresentable = NSViewRepresentable
+#endif
+
+// MARK: - SwiftUI View Modifier
+struct ScreenshotProtectionModifier: ViewModifier {
+    let isProtected: Bool
+    
+    func body(content: Content) -> some View {
+        if isProtected {
+            ProtectedView(isProtected: isProtected) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+}
+
+// MARK: - SwiftUI Extension
+extension View {
+    func screenshotProtection(_ isProtected: Bool = true) -> some View {
+        modifier(ScreenshotProtectionModifier(isProtected: isProtected))
+    }
+}
+
+// MARK: - SwiftUI Wrapper
+
+struct ProtectedView<Content: View>: PlatformViewRepresentable {
+    let isProtected: Bool
+    let content: Content
+    
+    init(isProtected: Bool = true, @ViewBuilder content: () -> Content) {
+        self.isProtected = isProtected
+        self.content = content()
+    }
+    
+    #if os(iOS)
+    
+    func makeUIView(context: Context) -> UIView {
+        let secureTextField = UITextField()
+        secureTextField.isSecureTextEntry = true
+        secureTextField.isUserInteractionEnabled = false
+        
+        guard let secureView = secureTextField.layer.sublayers?.first?.delegate as? UIView else {
+            return UIView()
+        }
+        
+        secureView.subviews.forEach { subview in
+            subview.removeFromSuperview()
+        }
+        
+        let hController = UIHostingController(rootView: self.content)
+        hController.view.backgroundColor = .clear
+        hController.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        secureView.addSubview(hController.view)
+        NSLayoutConstraint.activate([
+            hController.view.topAnchor.constraint(equalTo: secureView.topAnchor),
+            hController.view.bottomAnchor.constraint(equalTo: secureView.bottomAnchor),
+            hController.view.leadingAnchor.constraint(equalTo: secureView.leadingAnchor),
+            hController.view.trailingAnchor.constraint(equalTo: secureView.trailingAnchor)
+        ])
+        
+        return secureView
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {}
+    
+    #elseif os(macOS)
+    
+    func makeNSView(context: Context) -> NSView {
+        let hostingView = NSHostingView(rootView: content)
+        return hostingView
+    }
+    
+    func updateNSView(_ nsView: NSView, context: Context) {}
+    
+    #endif
+}


### PR DESCRIPTION
## Description

This PR aims to introduce some new & improved privacy capabilities to bitchat:

1. **Enhanced Screenshot Detection** - Expanded the detection capabilities to now also include screen recording and external capture methods
2. **Screenshot Prevention** - New functionality to actively (and optionally) prevent screenshots and screen recordings of conversations

Have been loving the app so far, and i think this could be a useful addition onto what you started with #30, let me know what you think 🙏

## Changelog

### 🔍 [Enhancement] Screenshot Detection V2

**Summary**: Improved the existing screenshot detection system to capture more types of screen recording attempts, including external hardware-based recording and system-level screen capture.

**Code Changes**:
- Enhanced detection via `UIScreen.capturedDidChangeNotification` for broader screen capture detection
- Expanded beyond traditional screenshot detection to include screen recordings and external capture devices
- Maintains backward compatibility with existing screenshot detection methods

**Example**: 
<img src="https://github.com/user-attachments/assets/39d1aac7-1e93-4172-866f-84e479cb73ed" width="350">

**How to Test**:
1. **Device A**: Start a conversation in bitchat
2. **Device A**: Attempt to take a screenshot - should trigger detection alert (existing)
3. **Device A**: Start screen recording - should trigger detection alert (new)
4. **Device A**: Connect external capture device (like recording the iPhone screen from Quicktime via USB-C) - should trigger detection alert (new)



### 🛡️ [New Feature] Screenshot Prevention

**Summary**: Brand new feature that actively prevents screenshots and screen recordings by wrapping sensitive content in a secure container that hides from system capture methods.

**Code Changes**:
- **New Protocol Messages**: Added `channelScreenshotProtection` (0x0A) and `privateScreenshotProtection` (0x0B) message types
- **New ProtectedView Component**: SwiftUI view using secure containers to create capture-resistant views
- **Command Interface**: New `/screenshots <allow/block>` command for easy toggle
- **Permission System**: 
  - **Channels**: Only channel owners can enable/disable protection
  - **Private Chats**: Single-party consent model (once enabled by either party, both are protected)
- **Visual Indicators**: Red camera icon shows when protection is active

**Example**: 
<img src="https://github.com/user-attachments/assets/b1392ed2-846e-471c-80df-d27badcb65f5" width="350">

**How to Test**:

**Channel Protection (as owner)**:
1. **Device A**: Create or join a channel where you're the owner
2. **Device A**: Type `/screenshots block` to enable protection
3. **Device A & B**: Notice the red camera icon appears in the header on both devices
4. **Device A or B**: Attempt to screenshot - content should be hidden/black
6. **Device A**: Type `/screenshots allow` to disable protection

**Private Chat Protection**:
1. **Device A & B**: Start a private conversation between the devices
2. **Device A**: Type `/screenshots block` to enable protection  
3. **Device A & B**: Red camera icon should appear for both parties
4. **Device A or B**: Attempt to screenshot - content should be protected/hidden
5. **Device B**: Try `/screenshots allow` - command will be ignored, and a system message indicating why will appear (single-party consent)
7. **Device A**: Type `/screenshots allow` to disable protection

**Visual Verification**:
- Look for red camera badge icon when protection is active
- Screenshots should show black/hidden content instead of messages
- Screen recordings should also be blocked from capturing content