### PR TITLE
Add InfoPlist.strings localization for Bluetooth permissions in English, Portuguese, Spanish, French, and Simplified Chinese

### DIFF
--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -32,9 +32,9 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>bitchat uses Bluetooth to create a secure mesh network for chatting with nearby users.</string>
+	<string>$(NSBluetoothAlwaysUsageDescription)</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>bitchat uses Bluetooth to discover and connect with other bitchat users nearby.</string>
+	<string>$(NSBluetoothPeripheralUsageDescription)</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/bitchat/en.lproj/InfoPlist.strings
+++ b/bitchat/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSBluetoothAlwaysUsageDescription" = "Bitchat uses Bluetooth to create a secure mesh network for chatting with nearby users.";
+"NSBluetoothPeripheralUsageDescription" = "Bitchat uses Bluetooth to discover and connect with other nearby Bitchat users.";

--- a/bitchat/es.lproj/InfoPlist.strings
+++ b/bitchat/es.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSBluetoothAlwaysUsageDescription" = "Bitchat utiliza Bluetooth para crear una red mesh segura y chatear con usuarios cercanos.";
+"NSBluetoothPeripheralUsageDescription" = "Bitchat utiliza Bluetooth para descubrir y conectarse con otros usuarios de Bitchat cercanos.";

--- a/bitchat/fr.lproj/InfoPlist.strings
+++ b/bitchat/fr.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSBluetoothAlwaysUsageDescription" = "Bitchat utilise le Bluetooth pour créer un réseau maillé sécurisé afin de discuter avec des utilisateurs à proximité.";
+"NSBluetoothPeripheralUsageDescription" = "Bitchat utilise le Bluetooth pour découvrir et se connecter à d'autres utilisateurs Bitchat à proximité.";

--- a/bitchat/pt.lproj/InfoPlist.strings
+++ b/bitchat/pt.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSBluetoothAlwaysUsageDescription" = "O Bitchat usa Bluetooth para criar uma rede mesh segura para conversar com usuários próximos.";
+"NSBluetoothPeripheralUsageDescription" = "O Bitchat usa Bluetooth para descobrir e se conectar com outros usuários Bitchat próximos.";

--- a/bitchat/zh-Hans.lproj/InfoPlist.strings
+++ b/bitchat/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSBluetoothAlwaysUsageDescription" = "Bitchat 使用蓝牙创建安全的网状网络，以便与附近的用户聊天。";
+"NSBluetoothPeripheralUsageDescription" = "Bitchat 使用蓝牙发现并连接附近的其他 Bitchat 用户。";


### PR DESCRIPTION
Issue #108 

This PR adds localization support for Bluetooth permission strings in Info.plist using InfoPlist.strings files for the following languages:

English
Portuguese
Spanish
French
Simplified Chinese
The Info.plist has been updated to use localization keys for Bluetooth permissions. Localization folders and InfoPlist.strings files have been placed alongside the relevant Info.plist. This improves accessibility and follows best practices for internationalization.