### PR TITLE
Is the packet header 13 bytes (as per the docs) or 14 bytes?

### DIFF
--- a/bitchat/Protocols/BinaryProtocol.swift
+++ b/bitchat/Protocols/BinaryProtocol.swift
@@ -19,7 +19,7 @@ extension Data {
 }
 
 // Binary Protocol Format:
-// Header (Fixed 13 bytes):
+// Header (Fixed 14 bytes):
 // - Version: 1 byte
 // - Type: 1 byte  
 // - TTL: 1 byte


### PR DESCRIPTION
The comments report the packet header to be 13 bytes when it appears to be 14 bytes.