### PR TITLE
BinaryProtocol header comment reports 13 bytes, but is is 14 bytes?

### DIFF
--- a/bitchat/Protocols/BinaryProtocol.swift
+++ b/bitchat/Protocols/BinaryProtocol.swift
@@ -19,7 +19,7 @@ extension Data {
 }
 
 // Binary Protocol Format:
-// Header (Fixed 13 bytes):
+// Header (Fixed 14 bytes):
 // - Version: 1 byte
 // - Type: 1 byte  
 // - TTL: 1 byte


### PR DESCRIPTION
Super tiny issue, barely worth mentioning, but I am counting 14 bytes. Perhaps for technical accuracy we can update this?