### PR TITLE
Fix TTL inconsistency in mesh routing diagram (Device F)

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -205,7 +205,7 @@ graph LR
     B -->|TTL=2| C[Device C<br/>Relay 2<br/>TTL=1]
     C -->|TTL=1| D[Device D<br/>Final<br/>TTL=0]
     B -->|TTL=2| E[Device E<br/>TTL=1]
-    C -->|TTL=1| F[Device F<br/>TTL=1]
+    C -->|TTL=1| F[Device F<br/>TTL=0]
     
     style A fill:#4caf50,color:#fff
     style D fill:#2196f3,color:#fff


### PR DESCRIPTION
Corrected the TTL shown for Device F in the Mermaid diagram.

Previously, it was shown as `TTL=1` after being forwarded from Device C, which also had `TTL=1`. According to the relay logic in the whitepaper, TTL should decrement on each hop, so Device F should receive the message with `TTL=0`.

This change aligns the diagram with the described behavior of the `shouldRelay(packet)` function.