### PR TITLE
fix(Services): provide cryptographic context for key derivation

### DIFF
--- a/bitchat/Services/EncryptionService.swift
+++ b/bitchat/Services/EncryptionService.swift
@@ -90,10 +90,14 @@ class EncryptionService {
             // Generate shared secret for encryption
             if let publicKey = peerPublicKeys[peerID] {
                 let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
+                var context = Data()
+                let parties = [publicKey.rawRepresentation, peerKeyAgreementPublicKey.rawRepresentation].sorted { $0.lexicographicallyPrecedes($1) }
+    context.append(parties[0])
+    context.append(parties[1])
                 let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
                     using: SHA256.self,
                     salt: "bitchat-v1".data(using: .utf8)!,
-                    sharedInfo: Data(),
+                    sharedInfo: context,
                     outputByteCount: 32
                 )
                 sharedSecrets[peerID] = symmetricKey


### PR DESCRIPTION
### Summary

The use of an empty `sharedInfo` field during the HKDF removes the cryptographic binding between the derived session key and the identities of the parties. This makes the key exchange vulnerable to Man-in-the-Middle (MITM) and Key Compromise Impersonation (KCI) attacks.

### Analysis

The vulnerability originates in the `addPeerPublicKey` function during the session key generation process. The implementation uses  `hkdfDerivedSymmetricKey` function but provides an empty `Data()` object for the `sharedInfo` parameter.

```swift
let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
    using: SHA256.self,
    salt: "bitchat-v1".data(using: .utf8)!,
    sharedInfo: Data(), // HERE Context is empty
    outputByteCount: 32
)
```

The `sharedInfo` (or "context") parameter is critical. Its purpose is to bind the derived key to the specific context of the communication session, which must include the unambiguous identities of the parties (e.g., their public keys). By leaving this empty, the resulting symmetric key is detached from the identities of the peers who generated it.

### Remediation

The `sharedInfo` parameter must be populated with the public keys of both parties involved in the key exchange. This ensures the resulting symmetric key can only be used for communication between those two specific identities. (Public keys should be concatenated in a consistent order).

```swift
var context = Data()
let parties = [publicKey.rawRepresentation, peerKeyAgreementPublicKey.rawRepresentation].sorted { $0.lexicographicallyPrecedes($1) }
    context.append(parties[0])
    context.append(parties[1])
let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
        using: SHA256.self,
        salt: "bitchat-v1".data(using: .utf8)!,
        sharedInfo: context,
        outputByteCount: 32
)
```