### PR TITLE
Modernize API Usage

### DIFF
--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -78,7 +78,6 @@ struct BitchatApp: App {
             userDefaults.removeObject(forKey: "sharedContent")
             userDefaults.removeObject(forKey: "sharedContentType")
             userDefaults.removeObject(forKey: "sharedContentDate")
-            userDefaults.synchronize()
             
             // Show notification about shared content
             DispatchQueue.main.async {

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -209,7 +209,6 @@ class ChatViewModel: ObservableObject {
     
     func saveNickname() {
         userDefaults.set(nickname, forKey: nicknameKey)
-        userDefaults.synchronize() // Force immediate save
         
         // Send announce with new nickname to all peers
         meshService.sendBroadcastAnnounce()
@@ -253,7 +252,6 @@ class ChatViewModel: ObservableObject {
     
     private func saveJoinedChannels() {
         userDefaults.set(Array(joinedChannels), forKey: joinedChannelsKey)
-        userDefaults.synchronize()
     }
     
     private func loadChannelData() {
@@ -304,9 +302,6 @@ class ChatViewModel: ObservableObject {
             _ = KeychainManager.shared.saveChannelPassword(password, for: channel)
         }
         userDefaults.set(channelKeyCommitments, forKey: channelKeyCommitmentsKey)
-        
-        // Force synchronize and add a small delay to ensure writes complete
-        _ = userDefaults.synchronize()
         
         // Verify save worked
         _ = userDefaults.dictionary(forKey: channelCreatorsKey) as? [String: String] != nil
@@ -1551,7 +1546,6 @@ class ChatViewModel: ObservableObject {
     @objc private func appWillResignActive() {
         // Save all channel data
         saveChannelData()
-        userDefaults.synchronize()
     }
     
     @objc func applicationWillTerminate() {
@@ -1561,7 +1555,6 @@ class ChatViewModel: ObservableObject {
         
         // Save all channel data
         saveChannelData()
-        userDefaults.synchronize()
         
         // Verify identity key after save
         _ = KeychainManager.shared.verifyIdentityKeyExists()
@@ -1570,7 +1563,6 @@ class ChatViewModel: ObservableObject {
     @objc private func appWillTerminate() {
         // Save all channel data
         saveChannelData()
-        userDefaults.synchronize()
     }
     
     func markPrivateMessagesAsRead(from peerID: String) {
@@ -1743,20 +1735,13 @@ class ChatViewModel: ObservableObject {
         // This will force creation of a new identity (new fingerprint) on next launch
         meshService.emergencyDisconnectAll()
         
-        // Force immediate UserDefaults synchronization
-        userDefaults.synchronize()
-        
         // Force UI update
         objectWillChange.send()
         
     }
     
-    
-    
     func formatTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        return formatter.string(from: date)
+        return date.formatted(date: .omitted, time: .standard)
     }
     
     func getRSSIColor(rssi: Int, colorScheme: ColorScheme) -> Color {

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -26,7 +26,7 @@ struct AppInfoView: View {
                     dismiss()
                 }
                 .buttonStyle(.plain)
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .padding()
             }
             .background(backgroundColor.opacity(0.95))
@@ -37,11 +37,11 @@ struct AppInfoView: View {
                     VStack(alignment: .center, spacing: 8) {
                         Text("bitchat*")
                             .font(.system(size: 32, weight: .bold, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundStyle(textColor)
                         
                         Text("mesh sidegroupchat")
                             .font(.system(size: 16, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundStyle(secondaryTextColor)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical)
@@ -99,7 +99,7 @@ struct AppInfoView: View {
                             Text("• triple-tap the logo for panic mode")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Commands
@@ -119,7 +119,7 @@ struct AppInfoView: View {
                             Text("/slap @name - slap with a trout")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Technical Details
@@ -137,7 +137,7 @@ struct AppInfoView: View {
                             Text("storage: Keychain for passwords, encrypted retention")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Version
@@ -145,7 +145,7 @@ struct AppInfoView: View {
                         Spacer()
                         Text("VERSION 1.0.0")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundStyle(secondaryTextColor)
                         Spacer()
                     }
                     .padding(.top)
@@ -163,11 +163,11 @@ struct AppInfoView: View {
                     VStack(alignment: .center, spacing: 8) {
                         Text("bitchat*")
                             .font(.system(size: 32, weight: .bold, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundStyle(textColor)
                         
                         Text("mesh sidegroupchat")
                             .font(.system(size: 16, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundStyle(secondaryTextColor)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical)
@@ -225,7 +225,7 @@ struct AppInfoView: View {
                             Text("• triple-tap the logo for panic mode")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Commands
@@ -245,7 +245,7 @@ struct AppInfoView: View {
                             Text("/slap @name - slap with a trout")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Technical Details
@@ -263,7 +263,7 @@ struct AppInfoView: View {
                             Text("storage: keychain for passwords, encrypted retention")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     
                     // Version
@@ -271,7 +271,7 @@ struct AppInfoView: View {
                         Spacer()
                         Text("VERSION 1.0.0")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundStyle(secondaryTextColor)
                         Spacer()
                     }
                     .padding(.top)
@@ -285,7 +285,7 @@ struct AppInfoView: View {
                     Button("DONE") {
                         dismiss()
                     }
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                 }
             }
         }
@@ -308,7 +308,7 @@ struct SectionHeader: View {
     var body: some View {
         Text(title.uppercased())
             .font(.system(size: 16, weight: .bold, design: .monospaced))
-            .foregroundColor(textColor)
+            .foregroundStyle(textColor)
             .padding(.top, 8)
     }
 }
@@ -331,17 +331,17 @@ struct FeatureRow: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 20))
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .frame(width: 30)
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                 
                 Text(description)
                     .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(secondaryTextColor)
+                    .foregroundStyle(secondaryTextColor)
                     .fixedSize(horizontal: false, vertical: true)
             }
             

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -342,7 +342,7 @@ struct ContentView: View {
                             HStack {
                                 Text("@\(suggestion)")
                                     .font(.system(size: 11, design: .monospaced))
-                                    .foregroundColor(textColor)
+                                    .foregroundStyle(textColor)
                                     .fontWeight(.medium)
                                 Spacer()
                             }
@@ -402,14 +402,14 @@ struct ContentView: View {
                                     // Show all aliases together
                                     Text(info.commands.joined(separator: ", "))
                                         .font(.system(size: 11, design: .monospaced))
-                                        .foregroundColor(textColor)
+                                        .foregroundStyle(textColor)
                                         .fontWeight(.medium)
                                     
                                     // Show syntax if any
                                     if let syntax = info.syntax {
                                         Text(syntax)
                                             .font(.system(size: 10, design: .monospaced))
-                                            .foregroundColor(secondaryTextColor.opacity(0.8))
+                                            .foregroundStyle(secondaryTextColor.opacity(0.8))
                                     }
                                     
                                     Spacer()
@@ -417,7 +417,7 @@ struct ContentView: View {
                                     // Show description
                                     Text(info.description)
                                         .font(.system(size: 10, design: .monospaced))
-                                        .foregroundColor(secondaryTextColor)
+                                        .foregroundStyle(secondaryTextColor)
                                 }
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 3)
@@ -440,21 +440,21 @@ struct ContentView: View {
             if viewModel.selectedPrivateChatPeer != nil {
                 Text("<@\(viewModel.nickname)> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(Color.orange)
+                    .foregroundStyle(Color.orange)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else if let currentChannel = viewModel.currentChannel, viewModel.passwordProtectedChannels.contains(currentChannel) {
                 Text("<@\(viewModel.nickname)> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(Color.orange)
+                    .foregroundStyle(Color.orange)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else {
                 Text("<@\(viewModel.nickname)>")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
@@ -463,7 +463,7 @@ struct ContentView: View {
             TextField("", text: $messageText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 14, design: .monospaced))
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .autocorrectionDisabled()
                 .focused($isTextFieldFocused)
                 .onChange(of: messageText) { newValue in
@@ -529,7 +529,7 @@ struct ContentView: View {
             Button(action: sendMessage) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 20))
-                    .foregroundColor(messageText.isEmpty ? Color.gray :
+                    .foregroundStyle(messageText.isEmpty ? Color.gray :
                                             (viewModel.selectedPrivateChatPeer != nil ||
                                              (viewModel.currentChannel != nil && viewModel.passwordProtectedChannels.contains(viewModel.currentChannel ?? "")))
                                              ? Color.orange : textColor)
@@ -563,7 +563,7 @@ struct ContentView: View {
                     Text("CHANNELS")
                         .font(.system(size: 11, weight: .bold, design: .monospaced))
                 }
-                .foregroundColor(secondaryTextColor)
+                .foregroundStyle(secondaryTextColor)
                 .padding(.horizontal, 12)
                 
                 ForEach(Array(viewModel.joinedChannels).sorted(), id: \.self) { channel in
@@ -594,13 +594,13 @@ struct ContentView: View {
                 if viewModel.passwordProtectedChannels.contains(channel) {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10))
-                        .foregroundColor(secondaryTextColor)
+                        .foregroundStyle(secondaryTextColor)
                         .accessibilityLabel("Password protected")
                 }
                 
                 Text(channel)
                     .font(.system(size: 14, design: .monospaced))
-                    .foregroundColor(viewModel.currentChannel == channel ? Color.blue : textColor)
+                    .foregroundStyle(viewModel.currentChannel == channel ? Color.blue : textColor)
                 
                 Spacer()
                 
@@ -608,7 +608,7 @@ struct ContentView: View {
                 if let unreadCount = viewModel.unreadChannelMessages[channel], unreadCount > 0 {
                     Text("\(unreadCount)")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundColor(backgroundColor)
+                        .foregroundStyle(backgroundColor)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(Color.orange)
@@ -646,7 +646,7 @@ struct ContentView: View {
                         Image(systemName: viewModel.passwordProtectedChannels.contains(channel) ? "lock.fill" : "lock")
                             .font(.system(size: 10))
                     }
-                    .foregroundColor(viewModel.passwordProtectedChannels.contains(channel) ? backgroundColor : secondaryTextColor)
+                    .foregroundStyle(viewModel.passwordProtectedChannels.contains(channel) ? backgroundColor : secondaryTextColor)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 2)
                     .background(viewModel.passwordProtectedChannels.contains(channel) ? Color.orange : Color.clear)
@@ -665,7 +665,7 @@ struct ContentView: View {
             }) {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(Color.red.opacity(0.6))
+                    .foregroundStyle(Color.red.opacity(0.6))
             }
             .buttonStyle(.plain)
             .alert("leave channel", isPresented: $showLeaveChannelAlert) {
@@ -691,7 +691,7 @@ struct ContentView: View {
                 HStack {
                     Text("YOUR NETWORK")
                         .font(.system(size: 16, weight: .bold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     Spacer()
                 }
                 .frame(height: 44) // Match header height
@@ -717,7 +717,7 @@ struct ContentView: View {
                         if let currentChannel = viewModel.currentChannel {
                             Text("IN \(currentChannel.uppercased())")
                                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundStyle(secondaryTextColor)
                                 .padding(.horizontal, 12)
                         } else if !viewModel.connectedPeers.isEmpty {
                             HStack(spacing: 4) {
@@ -727,21 +727,21 @@ struct ContentView: View {
                                 Text("PEOPLE")
                                     .font(.system(size: 11, weight: .bold, design: .monospaced))
                             }
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundStyle(secondaryTextColor)
                             .padding(.horizontal, 12)
                         }
                         
                         if viewModel.connectedPeers.isEmpty {
                             Text("no one connected...")
                                 .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundStyle(secondaryTextColor)
                                 .padding(.horizontal)
                         } else if let currentChannel = viewModel.currentChannel,
                                   let channelMemberIDs = viewModel.channelMembers[currentChannel],
                                   channelMemberIDs.isEmpty {
                             Text("no one in this channel yet...")
                                 .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundStyle(secondaryTextColor)
                                 .padding(.horizontal)
                         } else {
                             let peerNicknames = viewModel.meshService.getPeerNicknames()
@@ -794,17 +794,17 @@ struct ContentView: View {
                                 if isMe {
                                     Image(systemName: "person.fill")
                                         .font(.system(size: 10))
-                                        .foregroundColor(textColor)
+                                        .foregroundStyle(textColor)
                                         .accessibilityLabel("You")
                                 } else if viewModel.unreadPrivateMessages.contains(peerID) {
                                     Image(systemName: "envelope.fill")
                                         .font(.system(size: 12))
-                                        .foregroundColor(Color.orange)
+                                        .foregroundStyle(Color.orange)
                                         .accessibilityLabel("Unread message from \(displayName)")
                                 } else {
                                     Image(systemName: "radiowaves.left")
                                         .font(.system(size: 12))
-                                        .foregroundColor(viewModel.getRSSIColor(rssi: rssi, colorScheme: colorScheme))
+                                        .foregroundStyle(viewModel.getRSSIColor(rssi: rssi, colorScheme: colorScheme))
                                         .accessibilityLabel("Signal strength: \(rssi > -60 ? "excellent" : rssi > -70 ? "good" : rssi > -80 ? "fair" : "poor")")
                                 }
                                 
@@ -813,7 +813,7 @@ struct ContentView: View {
                                     HStack {
                                         Text(displayName + " (you)")
                                             .font(.system(size: 14, design: .monospaced))
-                                            .foregroundColor(textColor)
+                                            .foregroundStyle(textColor)
                                         
                                         Spacer()
                                     }
@@ -829,7 +829,7 @@ struct ContentView: View {
                                     }) {
                                         Text(displayName)
                                             .font(.system(size: 14, design: .monospaced))
-                                            .foregroundColor(peerNicknames[peerID] != nil ? textColor : secondaryTextColor)
+                                            .foregroundStyle(peerNicknames[peerID] != nil ? textColor : secondaryTextColor)
                                     }
                                     .buttonStyle(.plain)
                                     .disabled(peerNicknames[peerID] == nil)
@@ -842,7 +842,7 @@ struct ContentView: View {
                                     let encryptionStatus = viewModel.getEncryptionStatus(for: peerID)
                                     Image(systemName: encryptionStatus.icon)
                                         .font(.system(size: 10))
-                                        .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
+                                        .foregroundStyle(encryptionStatus == .noiseVerified ? Color.green : 
                                                        encryptionStatus == .noiseSecured ? textColor :
                                                        encryptionStatus == .noiseHandshaking ? Color.orange :
                                                        Color.red)
@@ -856,7 +856,7 @@ struct ContentView: View {
                                     }) {
                                         Image(systemName: isFavorite ? "star.fill" : "star")
                                             .font(.system(size: 12))
-                                            .foregroundColor(isFavorite ? Color.yellow : secondaryTextColor)
+                                            .foregroundStyle(isFavorite ? Color.yellow : secondaryTextColor)
                                     }
                                     .buttonStyle(.plain)
                                     .accessibilityLabel(isFavorite ? "Remove \(displayName) from favorites" : "Add \(displayName) to favorites")
@@ -888,7 +888,7 @@ struct ContentView: View {
             inputView
         }
         .background(backgroundColor)
-        .foregroundColor(textColor)
+        .foregroundStyle(textColor)
         .gesture(
             DragGesture()
                 .onChanged { value in
@@ -935,7 +935,7 @@ struct ContentView: View {
                 inputView
             }
             .background(backgroundColor)
-            .foregroundColor(textColor)
+            .foregroundStyle(textColor)
         }
     }
     
@@ -954,7 +954,7 @@ struct ContentView: View {
                 inputView
             }
             .background(backgroundColor)
-            .foregroundColor(textColor)
+            .foregroundStyle(textColor)
         }
     }
     
@@ -962,7 +962,7 @@ struct ContentView: View {
         HStack(spacing: 4) {
             Text("bitchat*")
                 .font(.system(size: 18, weight: .medium, design: .monospaced))
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .onTapGesture(count: 3) {
                     // PANIC: Triple-tap to clear all data
                     viewModel.panicClearAllData()
@@ -975,13 +975,13 @@ struct ContentView: View {
             HStack(spacing: 0) {
                 Text("@")
                     .font(.system(size: 14, design: .monospaced))
-                    .foregroundColor(secondaryTextColor)
+                    .foregroundStyle(secondaryTextColor)
                 
                 TextField("nickname", text: $viewModel.nickname)
                     .textFieldStyle(.plain)
                     .font(.system(size: 14, design: .monospaced))
                     .frame(maxWidth: 100)
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                     .onChange(of: viewModel.nickname) { _ in
                         viewModel.saveNickname()
                     }
@@ -1000,14 +1000,14 @@ struct ContentView: View {
                 if hasUnreadChannelMessages {
                     Image(systemName: "number")
                         .font(.system(size: 12))
-                        .foregroundColor(Color.blue)
+                        .foregroundStyle(Color.blue)
                         .accessibilityLabel("Unread channel messages")
                 }
                 
                 if !viewModel.unreadPrivateMessages.isEmpty {
                     Image(systemName: "envelope.fill")
                         .font(.system(size: 12))
-                        .foregroundColor(Color.orange)
+                        .foregroundStyle(Color.orange)
                         .accessibilityLabel("Unread private messages")
                 }
                 
@@ -1035,7 +1035,7 @@ struct ContentView: View {
                             .accessibilityHidden(true)
                     }
                 }
-                .foregroundColor(viewModel.isConnected ? textColor : Color.red)
+                .foregroundStyle(viewModel.isConnected ? textColor : Color.red)
             }
             .onTapGesture {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -1066,7 +1066,7 @@ struct ContentView: View {
                             Text("back")
                                 .font(.system(size: 14, design: .monospaced))
                         }
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Back to main chat")
@@ -1079,12 +1079,12 @@ struct ContentView: View {
                         HStack(spacing: 6) {
                             Text("\(privatePeerNick)")
                                 .font(.system(size: 16, weight: .medium, design: .monospaced))
-                                .foregroundColor(Color.orange)
+                                .foregroundStyle(Color.orange)
                             // Dynamic encryption status icon
                             let encryptionStatus = viewModel.getEncryptionStatus(for: privatePeerID)
                             Image(systemName: encryptionStatus.icon)
                                 .font(.system(size: 14))
-                                .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
+                                .foregroundStyle(encryptionStatus == .noiseVerified ? Color.green : 
                                                encryptionStatus == .noiseSecured ? Color.orange :
                                                Color.red)
                                 .accessibilityLabel("Encryption status: \(encryptionStatus == .noiseVerified ? "verified" : encryptionStatus == .noiseSecured ? "secured" : "not encrypted")")
@@ -1103,7 +1103,7 @@ struct ContentView: View {
                     }) {
                         Image(systemName: viewModel.isFavorite(peerID: privatePeerID) ? "star.fill" : "star")
                             .font(.system(size: 16))
-                            .foregroundColor(viewModel.isFavorite(peerID: privatePeerID) ? Color.yellow : textColor)
+                            .foregroundStyle(viewModel.isFavorite(peerID: privatePeerID) ? Color.yellow : textColor)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(viewModel.isFavorite(peerID: privatePeerID) ? "Remove from favorites" : "Add to favorites")
@@ -1134,7 +1134,7 @@ struct ContentView: View {
                         Text("back")
                             .font(.system(size: 14, design: .monospaced))
                     }
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Back to main chat")
@@ -1151,13 +1151,13 @@ struct ContentView: View {
                         if viewModel.passwordProtectedChannels.contains(currentChannel) {
                             Image(systemName: "lock.fill")
                                 .font(.system(size: 14))
-                                .foregroundColor(Color.orange)
+                                .foregroundStyle(Color.orange)
                                 .accessibilityLabel("Password protected channel")
                         }
                         
                         Text(currentChannel)
                             .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.orange : Color.blue)
+                            .foregroundStyle(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.orange : Color.blue)
                         
                         // Verification status indicator after channel name
                         if viewModel.passwordProtectedChannels.contains(currentChannel),
@@ -1170,15 +1170,15 @@ struct ContentView: View {
                             case .verified:
                                 Image(systemName: "checkmark.circle.fill")
                                     .font(.system(size: 12))
-                                    .foregroundColor(Color.green)
+                                    .foregroundStyle(Color.green)
                             case .failed:
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.system(size: 12))
-                                    .foregroundColor(Color.red)
+                                    .foregroundStyle(Color.red)
                             case .unverified:
                                 Image(systemName: "questionmark.circle")
                                     .font(.system(size: 12))
-                                    .foregroundColor(Color.gray)
+                                    .foregroundStyle(Color.gray)
                                     .help("Password verification pending")
                             }
                         }
@@ -1204,7 +1204,7 @@ struct ContentView: View {
                         }) {
                             Image(systemName: viewModel.passwordProtectedChannels.contains(currentChannel) ? "lock.fill" : "lock")
                                 .font(.system(size: 16))
-                                .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.yellow : textColor)
+                                .foregroundStyle(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.yellow : textColor)
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel(viewModel.passwordProtectedChannels.contains(currentChannel) ? "Remove channel password" : "Set channel password")
@@ -1216,7 +1216,7 @@ struct ContentView: View {
                     }) {
                         Image(systemName: "xmark.circle")
                             .font(.system(size: 16))
-                            .foregroundColor(Color.red.opacity(0.8))
+                            .foregroundStyle(Color.red.opacity(0.8))
                     }
                     .buttonStyle(.plain)
                     .alert("leave channel?", isPresented: $showLeaveChannelAlert) {
@@ -1365,12 +1365,12 @@ struct DeliveryStatusView: View {
         case .sending:
             Image(systemName: "circle")
                 .font(.system(size: 10))
-                .foregroundColor(secondaryTextColor.opacity(0.6))
+                .foregroundStyle(secondaryTextColor.opacity(0.6))
             
         case .sent:
             Image(systemName: "checkmark")
                 .font(.system(size: 10))
-                .foregroundColor(secondaryTextColor.opacity(0.6))
+                .foregroundStyle(secondaryTextColor.opacity(0.6))
             
         case .delivered(let nickname, _):
             HStack(spacing: -2) {
@@ -1379,7 +1379,7 @@ struct DeliveryStatusView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10))
             }
-            .foregroundColor(textColor.opacity(0.8))
+            .foregroundStyle(textColor.opacity(0.8))
             .help("Delivered to \(nickname)")
             
         case .read(let nickname, _):
@@ -1389,13 +1389,13 @@ struct DeliveryStatusView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10, weight: .bold))
             }
-            .foregroundColor(Color(red: 0.0, green: 0.478, blue: 1.0))  // Bright blue
+            .foregroundStyle(Color(red: 0.0, green: 0.478, blue: 1.0))  // Bright blue
             .help("Read by \(nickname)")
             
         case .failed(let reason):
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 10))
-                .foregroundColor(Color.red.opacity(0.8))
+                .foregroundStyle(Color.red.opacity(0.8))
                 .help("Failed: \(reason)")
             
         case .partiallyDelivered(let reached, let total):
@@ -1405,7 +1405,7 @@ struct DeliveryStatusView: View {
                 Text("\(reached)/\(total)")
                     .font(.system(size: 10, design: .monospaced))
             }
-            .foregroundColor(secondaryTextColor.opacity(0.6))
+            .foregroundStyle(secondaryTextColor.opacity(0.6))
             .help("Delivered to \(reached) of \(total) members")
         }
     }

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -28,14 +28,14 @@ struct FingerprintView: View {
             HStack {
                 Text("SECURITY VERIFICATION")
                     .font(.system(size: 16, weight: .bold, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                 
                 Spacer()
                 
                 Button("DONE") {
                     dismiss()
                 }
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
             }
             .padding()
             
@@ -47,16 +47,16 @@ struct FingerprintView: View {
                 HStack {
                     Image(systemName: encryptionStatus.icon)
                         .font(.system(size: 20))
-                        .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : textColor)
+                        .foregroundStyle(encryptionStatus == .noiseVerified ? Color.green : textColor)
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(peerNickname)
                             .font(.system(size: 18, weight: .semibold, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundStyle(textColor)
                         
                         Text(encryptionStatus.description)
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(textColor.opacity(0.7))
+                            .foregroundStyle(textColor.opacity(0.7))
                     }
                     
                     Spacer()
@@ -69,12 +69,12 @@ struct FingerprintView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("THEIR FINGERPRINT:")
                         .font(.system(size: 12, weight: .bold, design: .monospaced))
-                        .foregroundColor(textColor.opacity(0.7))
+                        .foregroundStyle(textColor.opacity(0.7))
                     
                     if let fingerprint = viewModel.getFingerprint(for: peerID) {
                         Text(formatFingerprint(fingerprint))
                             .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundStyle(textColor)
                             .multilineTextAlignment(.leading)
                             .lineLimit(nil)
                             .fixedSize(horizontal: false, vertical: true)
@@ -95,7 +95,7 @@ struct FingerprintView: View {
                     } else {
                         Text("not available - handshake in progress")
                             .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(Color.orange)
+                            .foregroundStyle(Color.orange)
                             .padding()
                     }
                 }
@@ -104,12 +104,12 @@ struct FingerprintView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("YOUR FINGERPRINT:")
                         .font(.system(size: 12, weight: .bold, design: .monospaced))
-                        .foregroundColor(textColor.opacity(0.7))
+                        .foregroundStyle(textColor.opacity(0.7))
                     
                     let myFingerprint = viewModel.getMyFingerprint()
                     Text(formatFingerprint(myFingerprint))
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                         .multilineTextAlignment(.leading)
                         .lineLimit(nil)
                         .fixedSize(horizontal: false, vertical: true)
@@ -136,14 +136,14 @@ struct FingerprintView: View {
                     VStack(spacing: 12) {
                         Text(isVerified ? "✓ VERIFIED" : "⚠️ NOT VERIFIED")
                             .font(.system(size: 14, weight: .bold, design: .monospaced))
-                            .foregroundColor(isVerified ? Color.green : Color.orange)
+                            .foregroundStyle(isVerified ? Color.green : Color.orange)
                             .frame(maxWidth: .infinity)
                         
                         Text(isVerified ? 
                              "you have verified this person's identity." :
                              "compare these fingerprints with \(peerNickname) using a secure channel.")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(textColor.opacity(0.7))
+                            .foregroundStyle(textColor.opacity(0.7))
                             .multilineTextAlignment(.center)
                             .lineLimit(nil)
                             .fixedSize(horizontal: false, vertical: true)
@@ -156,7 +156,7 @@ struct FingerprintView: View {
                             }) {
                                 Text("MARK AS VERIFIED")
                                     .font(.system(size: 14, weight: .bold, design: .monospaced))
-                                    .foregroundColor(.white)
+                                    .foregroundStyle(.white)
                                     .padding(.horizontal, 20)
                                     .padding(.vertical, 10)
                                     .background(Color.green)

--- a/bitchat/Views/LinkPreviewView.swift
+++ b/bitchat/Views/LinkPreviewView.swift
@@ -69,7 +69,7 @@ struct LinkPreviewView: View {
                             .overlay(
                                 Image(systemName: "link")
                                     .font(.system(size: 24))
-                                    .foregroundColor(Color.blue)
+                                    .foregroundStyle(Color.blue)
                             )
                     }
                     #else
@@ -79,7 +79,7 @@ struct LinkPreviewView: View {
                         .overlay(
                             Image(systemName: "link")
                                 .font(.system(size: 24))
-                                .foregroundColor(Color.blue)
+                                .foregroundStyle(Color.blue)
                         )
                     #endif
                 }
@@ -89,7 +89,7 @@ struct LinkPreviewView: View {
                     #if os(iOS)
                     Text(metadata?.title ?? title ?? url.host ?? "Link")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     #endif
@@ -97,7 +97,7 @@ struct LinkPreviewView: View {
                     // Host
                     Text(url.host ?? url.absoluteString)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(textColor.opacity(0.6))
+                        .foregroundStyle(textColor.opacity(0.6))
                         .lineLimit(1)
                 }
                 
@@ -129,21 +129,21 @@ struct LinkPreviewView: View {
                 // Link icon
                 Image(systemName: "link.circle.fill")
                     .font(.system(size: 32))
-                    .foregroundColor(Color.blue.opacity(0.8))
+                    .foregroundStyle(Color.blue.opacity(0.8))
                     .frame(width: 40, height: 40)
                 
                 VStack(alignment: .leading, spacing: 4) {
                     // Title
                     Text(title ?? url.host ?? "Link")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundStyle(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     
                     // URL
                     Text(url.absoluteString)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(Color.blue)
+                        .foregroundStyle(Color.blue)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
@@ -153,7 +153,7 @@ struct LinkPreviewView: View {
                 // Arrow indicator
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14))
-                    .foregroundColor(textColor.opacity(0.5))
+                    .foregroundStyle(textColor.opacity(0.5))
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/bitchat/Views/NoiseTestingView.swift
+++ b/bitchat/Views/NoiseTestingView.swift
@@ -27,14 +27,14 @@ struct NoiseTestingView: View {
             // Header
             Text("NOISE PROTOCOL TEST HELPER")
                 .font(.system(size: 16, weight: .bold, design: .monospaced))
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .padding(.bottom)
             
             // Status Overview
             VStack(alignment: .leading, spacing: 8) {
                 Text("CURRENT STATUS:")
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
-                    .foregroundColor(textColor.opacity(0.7))
+                    .foregroundStyle(textColor.opacity(0.7))
                 
                 ForEach(viewModel.connectedPeers, id: \.self) { peerID in
                     let nickname = viewModel.meshService.getPeerNicknames()[peerID] ?? "Unknown"
@@ -43,13 +43,13 @@ struct NoiseTestingView: View {
                     HStack {
                         Image(systemName: status.icon)
                             .font(.system(size: 12))
-                            .foregroundColor(status == .noiseVerified ? Color.green : 
+                            .foregroundStyle(status == .noiseVerified ? Color.green : 
                                            status == .noiseSecured ? textColor :
                                            Color.red)
                         
                         Text("\(nickname): \(status.description)")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundStyle(textColor)
                         
                         Spacer()
                     }
@@ -58,7 +58,7 @@ struct NoiseTestingView: View {
                 if viewModel.connectedPeers.isEmpty {
                     Text("No peers connected")
                         .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(Color.gray)
+                        .foregroundStyle(Color.gray)
                 }
             }
             .padding()
@@ -69,7 +69,7 @@ struct NoiseTestingView: View {
             ScrollView {
                 Text(testChecklist)
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                     .textSelection(.enabled)
             }
             .padding()
@@ -83,7 +83,7 @@ struct NoiseTestingView: View {
                     // This will cause all peers to re-exchange keys
                     viewModel.meshService.sendBroadcastAnnounce()
                 }
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 
                 Button("Clear Sessions") {
                     // Clear all Noise sessions for testing
@@ -93,7 +93,7 @@ struct NoiseTestingView: View {
                     }
                     viewModel.peerEncryptionStatus.removeAll()
                 }
-                .foregroundColor(Color.orange)
+                .foregroundStyle(Color.orange)
                 
                 Button("Copy Logs") {
                     // Copy test results to clipboard
@@ -115,7 +115,7 @@ struct NoiseTestingView: View {
                     NSPasteboard.general.setString(logs, forType: .string)
                     #endif
                 }
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 
                 
                 Spacer()

--- a/bitchatShareExtension/ShareViewController.swift
+++ b/bitchatShareExtension/ShareViewController.swift
@@ -185,8 +185,6 @@ class ShareViewController: SLComposeServiceViewController {
         userDefaults.set(content, forKey: "sharedContent")
         userDefaults.set(type, forKey: "sharedContentType")
         userDefaults.set(Date(), forKey: "sharedContentDate")
-        userDefaults.synchronize()
-        
         
         // Force open the main app
         self.openMainApp()

--- a/bitchatTests/NoiseIdentityPersistenceTests.swift
+++ b/bitchatTests/NoiseIdentityPersistenceTests.swift
@@ -30,7 +30,6 @@ class NoiseIdentityPersistenceTests: XCTestCase {
         // Clear any UserDefaults that might interfere
         UserDefaults.standard.removeObject(forKey: "bitchat.noiseIdentityKey")
         UserDefaults.standard.removeObject(forKey: "bitchat.messageRetentionKey")
-        UserDefaults.standard.synchronize()
     }
     
     // MARK: - Identity Persistence Tests

--- a/bitchatTests/PasswordProtectedChannelTests.swift
+++ b/bitchatTests/PasswordProtectedChannelTests.swift
@@ -40,7 +40,6 @@ class PasswordProtectedChannelTests: XCTestCase {
         defaults.removeObject(forKey: "bitchat_channel_creators")
         defaults.removeObject(forKey: "bitchat_channel_passwords")
         defaults.removeObject(forKey: "bitchat_favorite_peers")
-        defaults.synchronize()
     }
     
     override func tearDown() {


### PR DESCRIPTION
- `synchronize()` is soft-deprecated, because it blocks the calling thread which is no longer necessary and shouldn’t be used.

- `foregroundColor` is also soft-deprecated in favor of `foregroundStyle`

- `DateFormatter` is expensive to create. Using `.formatted` is a better approach