### PR TITLE
Fix Crash when receiving notification from the background

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -3436,7 +3436,9 @@ extension ChatViewModel: BitchatDelegate {
         
         #if os(iOS)
         // Haptic feedback for iOS only
-        
+        guard UIApplication.shared.applicationState == .active else {
+            return
+        }
         // Check if this is a hug message directed at the user
         let isHugForMe = message.content.contains("🫂") && 
                          (message.content.contains("hugs \(nickname)") ||


### PR DESCRIPTION
In my testing the app crashes in the background when receiving a notification. This is probably due to UIFeedbackGenerator requiring the main thread which isn't available