### PR TITLE
Reduce fragment size

### DIFF
--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -171,7 +171,7 @@ class BluetoothMeshService: NSObject {
     // Fragment handling with security limits
     private var incomingFragments: [String: [Int: Data]] = [:]  // fragmentID -> [index: data]
     private var fragmentMetadata: [String: (originalType: UInt8, totalFragments: Int, timestamp: Date)] = [:]
-    private let maxFragmentSize = 500  // Optimized for BLE 5.0 extended data length
+    private let maxFragmentSize = 469 // 512 bytes max MTU - 43 bytes for headers and metadata
     private let maxConcurrentFragmentSessions = 20  // Limit concurrent fragment sessions to prevent DoS
     private let fragmentTimeout: TimeInterval = 30  // 30 seconds timeout for incomplete fragments
     


### PR DESCRIPTION
### Problem
With 500-byte fragments, the total packet size after adding metadata (13 bytes) and protocol headers (~30 bytes) exceeds 512 bytes. This leads to transmission failures with larger messages.

```
📦 BLE Transmit: type=announce, size=256 bytes ✅
📦 BLE Transmit: type=fragmentStart, size=543 bytes ⚠️ EXCEEDS MTU
📦 BLE Transmit: type=fragmentContinue, size=543 bytes ⚠️ EXCEEDS MTU
📦 BLE Transmit: type=fragmentEnd, size=256 bytes ✅
📦 BLE Transmit: type=fragmentStart, size=543 bytes ⚠️ EXCEEDS MTU
📦 BLE Transmit: type=fragmentEnd, size=256 bytes ✅
```

### Solution
- Changed `maxFragmentSize` from 500 to 469 bytes
- Ensures packets stay within BLE 5.0's 512-byte MTU after all overhead
- Enables faster `.withoutResponse` transmission
- Prevents silent write failures and double fragmentation