### PR TITLE
Implement Ed25519 signatures and fix session management

### DIFF
--- a/bitchat/Noise/NoiseSession.swift
+++ b/bitchat/Noise/NoiseSession.swift
@@ -259,6 +259,19 @@ class NoiseSessionManager {
         }
     }
     
+    func migrateSession(from oldPeerID: String, to newPeerID: String) {
+        _ = managerQueue.sync(flags: .barrier) {
+            // Check if we have a session for the old peer ID
+            if let session = sessions[oldPeerID] {
+                // Move the session to the new peer ID
+                sessions[newPeerID] = session
+                sessions.removeValue(forKey: oldPeerID)
+                
+                SecurityLogger.log("Migrated Noise session from \(oldPeerID) to \(newPeerID)", category: SecurityLogger.noise, level: .info)
+            }
+        }
+    }
+    
     func getEstablishedSessions() -> [String: NoiseSession] {
         return managerQueue.sync {
             return sessions.filter { $0.value.isEstablished() }

--- a/bitchat/Noise/NoiseSession.swift
+++ b/bitchat/Noise/NoiseSession.swift
@@ -319,18 +319,11 @@ class NoiseSessionManager {
             var existingSession: NoiseSession? = nil
             
             if let existing = sessions[peerID] {
-                // If we have an established session, we might need to help the other side complete theirs
+                // If we have an established session, reject new handshake attempts
                 if existing.isEstablished() {
-                    // If this is a handshake initiation (32 bytes), the other side doesn't have a session
-                    // We should complete the handshake to help them establish their session
-                    if message.count == 32 {
-                        // Remove existing session and create new one
-                        sessions.removeValue(forKey: peerID)
-                        shouldCreateNew = true
-                    } else {
-                        // For other handshake messages, ignore if already established
-                        throw NoiseSessionError.alreadyEstablished
-                    }
+                    // Don't destroy our working session just because the other side is confused
+                    // They should detect the established session through successful message exchange
+                    throw NoiseSessionError.alreadyEstablished
                 } else {
                     // If we're in the middle of a handshake and receive a new initiation,
                     // reset and start fresh (the other side may have restarted)

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -3368,6 +3368,14 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
         
         SecurityLogger.log("Initiating Noise handshake with \(peerID)", category: SecurityLogger.noise, level: .info)
         
+        // Check if we already have an established session
+        if noiseService.hasEstablishedSession(with: peerID) {
+            SecurityLogger.log("Already have established session with \(peerID)", category: SecurityLogger.noise, level: .debug)
+            // Clear any lingering handshake attempt time
+            handshakeAttemptTimes.removeValue(forKey: peerID)
+            return
+        }
+        
         // Check if we've recently tried to handshake with this peer
         if let lastAttempt = handshakeAttemptTimes[peerID],
            Date().timeIntervalSince(lastAttempt) < handshakeTimeout {

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -364,6 +364,9 @@ class BluetoothMeshService: NSObject {
             
             // Notify about the change if it's a rotation
             if let oldID = oldPeerID {
+                // Migrate Noise session to new peer ID
+                self.noiseService.migratePeerSession(from: oldID, to: newPeerID, fingerprint: fingerprint)
+                
                 self.notifyPeerIDChange(oldPeerID: oldID, newPeerID: newPeerID, fingerprint: fingerprint)
             }
         }

--- a/bitchat/Services/NoiseEncryptionService.swift
+++ b/bitchat/Services/NoiseEncryptionService.swift
@@ -17,6 +17,10 @@ class NoiseEncryptionService {
     private let staticIdentityKey: Curve25519.KeyAgreement.PrivateKey
     public let staticIdentityPublicKey: Curve25519.KeyAgreement.PublicKey
     
+    // Ed25519 signing key (persistent across sessions)
+    private let signingKey: Curve25519.Signing.PrivateKey
+    public let signingPublicKey: Curve25519.Signing.PublicKey
+    
     // Session manager
     private let sessionManager: NoiseSessionManager
     
@@ -63,6 +67,27 @@ class NoiseEncryptionService {
         self.staticIdentityKey = loadedKey
         self.staticIdentityPublicKey = staticIdentityKey.publicKey
         
+        // Load or create signing key pair
+        let loadedSigningKey: Curve25519.Signing.PrivateKey
+        
+        // Try to load from keychain
+        if let signingData = KeychainManager.shared.getIdentityKey(forKey: "ed25519SigningKey"),
+           let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: signingData) {
+            loadedSigningKey = key
+        }
+        // If no signing key exists, create new one
+        else {
+            loadedSigningKey = Curve25519.Signing.PrivateKey()
+            let keyData = loadedSigningKey.rawRepresentation
+            
+            // Save to keychain
+            _ = KeychainManager.shared.saveIdentityKey(keyData, forKey: "ed25519SigningKey")
+        }
+        
+        // Now assign the signing keys
+        self.signingKey = loadedSigningKey
+        self.signingPublicKey = signingKey.publicKey
+        
         // Initialize session manager
         self.sessionManager = NoiseSessionManager(localStaticKey: staticIdentityKey)
         
@@ -82,6 +107,11 @@ class NoiseEncryptionService {
         return staticIdentityPublicKey.rawRepresentation
     }
     
+    /// Get our signing public key for sharing
+    func getSigningPublicKeyData() -> Data {
+        return signingPublicKey.rawRepresentation
+    }
+    
     /// Get our identity fingerprint
     func getIdentityFingerprint() -> String {
         let hash = SHA256.hash(data: staticIdentityPublicKey.rawRepresentation)
@@ -97,25 +127,31 @@ class NoiseEncryptionService {
     func clearPersistentIdentity() {
         // Clear from keychain
         _ = KeychainManager.shared.deleteIdentityKey(forKey: "noiseStaticKey")
+        _ = KeychainManager.shared.deleteIdentityKey(forKey: "ed25519SigningKey")
         // Stop rekey timer
         stopRekeyTimer()
     }
     
-    /// Sign data with our static identity key
+    /// Sign data with our Ed25519 signing key
     func signData(_ data: Data) -> Data? {
-        // For now, use HMAC with the private key as a simple signature
-        // This is not cryptographically ideal but works for identity binding
-        let key = SymmetricKey(data: staticIdentityKey.rawRepresentation)
-        let signature = HMAC<SHA256>.authenticationCode(for: data, using: key)
-        return Data(signature)
+        do {
+            let signature = try signingKey.signature(for: data)
+            return signature
+        } catch {
+            SecurityLogger.logError(error, context: "Failed to sign data", category: SecurityLogger.noise)
+            return nil
+        }
     }
     
-    /// Verify signature with a peer's public key
+    /// Verify signature with a peer's Ed25519 public key
     func verifySignature(_ signature: Data, for data: Data, publicKey: Data) -> Bool {
-        // For verification, we can't use the same HMAC approach since we don't have the private key
-        // For now, we'll skip signature verification but maintain the protocol structure
-        // In production, this should use proper Ed25519 signatures
-        return true  // Temporarily accept all signatures to fix the immediate issue
+        do {
+            let signingPublicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKey)
+            return signingPublicKey.isValidSignature(signature, for: data)
+        } catch {
+            SecurityLogger.logError(error, context: "Failed to verify signature", category: SecurityLogger.noise)
+            return false
+        }
     }
     
     // MARK: - Handshake Management


### PR DESCRIPTION
## Summary
- Implements Ed25519 signatures for identity announcements
- Fixes session persistence during peer ID rotation
- Fixes session destruction race condition causing handshake delays

## Changes

### Ed25519 Signature Implementation
- Added Ed25519 signing key pair to NoiseEncryptionService
- Keys are persisted securely in keychain alongside Noise static keys
- Updated NoiseIdentityAnnouncement to include signingPublicKey field
- Replaced HMAC signatures with proper Ed25519 signatures
- Fixed timestamp synchronization between signing and verification
- Added signature verification in PeerIdentityBinding

### Session Management Fixes
- Added session migration when peer IDs rotate via fingerprint tracking
- Sessions now follow peers across ID changes, preventing "No Noise session" errors
- Fixed race condition where peers would destroy established sessions when receiving new handshake attempts
- Added early check in handshake initiation to skip if session already exists

## Benefits
- **Non-repudiation**: Ed25519 signatures provide cryptographic proof of identity claims
- **Forward secrecy**: Signing keys are separate from encryption keys
- **Identity binding**: Cryptographically binds peer IDs to their Noise static keys
- **Session continuity**: Sessions persist across peer ID rotations
- **Eliminated delays**: No more cascading handshake loops

## Testing
Tested with iOS and Mac devices - handshakes complete properly and sessions persist through peer ID rotation.