### PR TITLE
Fix Noise handshake stability and session synchronization

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		04636BE02E30BE5100FBCFA8 /* PublicChatE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BC52E30BE5100FBCFA8 /* PublicChatE2ETests.swift */; };
 		04636BE82E30BEC600FBCFA8 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BE12E30BEC600FBCFA8 /* IntegrationTests.swift */; };
 		04636BEB2E30BEC600FBCFA8 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BE12E30BEC600FBCFA8 /* IntegrationTests.swift */; };
+		04636BED2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BEC2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift */; };
+		04636BEE2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BEC2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift */; };
 		04891CA92E22971E0064A111 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04891CA82E22971E0064A111 /* LRUCache.swift */; };
 		04891CAA2E22971E0064A111 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04891CA82E22971E0064A111 /* LRUCache.swift */; };
 		04AD0B4E2E25B9580002A40A /* IdentityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2446380E7A44E49A35B664 /* IdentityModels.swift */; };
@@ -133,6 +135,7 @@
 		04636BCE2E30BE5100FBCFA8 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		04636BCF2E30BE5100FBCFA8 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		04636BE12E30BEC600FBCFA8 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		04636BEC2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseHandshakeCoordinator.swift; sourceTree = "<group>"; };
 		04891CA82E22971E0064A111 /* LRUCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCache.swift; sourceTree = "<group>"; };
 		04B6BA412E2035530090FE39 /* NoiseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseProtocol.swift; sourceTree = "<group>"; };
 		04B6BA422E2035530090FE39 /* NoiseSecurityConsiderations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseSecurityConsiderations.swift; sourceTree = "<group>"; };
@@ -226,6 +229,7 @@
 		04B6BA442E2035530090FE39 /* Noise */ = {
 			isa = PBXGroup;
 			children = (
+				04636BEC2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift */,
 				04B6BA412E2035530090FE39 /* NoiseProtocol.swift */,
 				04B6BA422E2035530090FE39 /* NoiseSecurityConsiderations.swift */,
 				04B6BA432E2035530090FE39 /* NoiseSession.swift */,
@@ -563,6 +567,7 @@
 				04AD0B4F2E25B9580002A40A /* SecureIdentityStateManager.swift in Sources */,
 				31D147471B9F4E2815352DDA /* LinkPreviewView.swift in Sources */,
 				04B6BA572E203D6C0090FE39 /* FingerprintView.swift in Sources */,
+				04636BED2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift in Sources */,
 				C99763A4761567F587D21688 /* MessageRetryService.swift in Sources */,
 				749D8CF8A362B6CD0786782D /* NotificationService.swift in Sources */,
 				04636BBF2E2FCA8A00FBCFA8 /* SecureLogger.swift in Sources */,
@@ -595,6 +600,7 @@
 				1AF9F9036DEE42408D557A87 /* SecureIdentityStateManager.swift in Sources */,
 				7A5B1AB5642FEC168E917949 /* LinkPreviewView.swift in Sources */,
 				04B6BA552E203D6C0090FE39 /* FingerprintView.swift in Sources */,
+				04636BEE2E30CD4A00FBCFA8 /* NoiseHandshakeCoordinator.swift in Sources */,
 				CEAE115C9C3EB3C4ED82F128 /* MessageRetryService.swift in Sources */,
 				61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */,
 				04636BC02E2FCA8A00FBCFA8 /* SecureLogger.swift in Sources */,

--- a/bitchat/Noise/NoiseHandshakeCoordinator.swift
+++ b/bitchat/Noise/NoiseHandshakeCoordinator.swift
@@ -1,0 +1,257 @@
+//
+// NoiseHandshakeCoordinator.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+
+/// Coordinates Noise handshakes to prevent race conditions and ensure reliable encryption establishment
+class NoiseHandshakeCoordinator {
+    
+    // MARK: - Handshake State
+    
+    enum HandshakeState: Equatable {
+        case idle
+        case waitingToInitiate(since: Date)
+        case initiating(attempt: Int, lastAttempt: Date)
+        case responding
+        case waitingForResponse(messagesSent: [Data], timeout: Date)
+        case established(since: Date)
+        case failed(reason: String, canRetry: Bool, lastAttempt: Date)
+        
+        var isActive: Bool {
+            switch self {
+            case .idle, .established, .failed:
+                return false
+            default:
+                return true
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    private var handshakeStates: [String: HandshakeState] = [:]
+    private var handshakeQueue = DispatchQueue(label: "chat.bitchat.noise.handshake", attributes: .concurrent)
+    
+    // Configuration
+    private let maxHandshakeAttempts = 3
+    private let handshakeTimeout: TimeInterval = 10.0
+    private let retryDelay: TimeInterval = 2.0
+    private let minTimeBetweenHandshakes: TimeInterval = 1.0 // Reduced from 5.0 for faster recovery
+    
+    // Track handshake messages to detect duplicates
+    private var processedHandshakeMessages: Set<Data> = []
+    private let messageHistoryLimit = 100
+    
+    // MARK: - Role Determination
+    
+    /// Deterministically determine who should initiate the handshake
+    /// Lower peer ID becomes the initiator to prevent simultaneous attempts
+    func determineHandshakeRole(myPeerID: String, remotePeerID: String) -> NoiseRole {
+        // Use simple string comparison for deterministic ordering
+        return myPeerID < remotePeerID ? .initiator : .responder
+    }
+    
+    /// Check if we should initiate handshake with a peer
+    func shouldInitiateHandshake(myPeerID: String, remotePeerID: String) -> Bool {
+        return handshakeQueue.sync {
+            // Check if we're already in an active handshake
+            if let state = handshakeStates[remotePeerID], state.isActive {
+                SecureLogger.log("Already in active handshake with \(remotePeerID), state: \(state)", 
+                               category: SecureLogger.handshake, level: .debug)
+                return false
+            }
+            
+            // Check role
+            let role = determineHandshakeRole(myPeerID: myPeerID, remotePeerID: remotePeerID)
+            if role != .initiator {
+                SecureLogger.log("Not initiator for handshake with \(remotePeerID) (my: \(myPeerID), their: \(remotePeerID))", 
+                               category: SecureLogger.handshake, level: .debug)
+                return false
+            }
+            
+            // Check if we've failed recently and can't retry yet
+            if case .failed(_, let canRetry, let lastAttempt) = handshakeStates[remotePeerID] {
+                if !canRetry {
+                    return false
+                }
+                if Date().timeIntervalSince(lastAttempt) < retryDelay {
+                    return false
+                }
+            }
+            
+            return true
+        }
+    }
+    
+    /// Record that we're initiating a handshake
+    func recordHandshakeInitiation(peerID: String) {
+        handshakeQueue.async(flags: .barrier) {
+            let attempt = self.getCurrentAttempt(for: peerID) + 1
+            self.handshakeStates[peerID] = .initiating(attempt: attempt, lastAttempt: Date())
+            SecureLogger.log("Recording handshake initiation with \(peerID), attempt \(attempt)", 
+                           category: SecureLogger.handshake, level: .info)
+        }
+    }
+    
+    /// Record that we're responding to a handshake
+    func recordHandshakeResponse(peerID: String) {
+        handshakeQueue.async(flags: .barrier) {
+            self.handshakeStates[peerID] = .responding
+            SecureLogger.log("Recording handshake response to \(peerID)", 
+                           category: SecureLogger.handshake, level: .info)
+        }
+    }
+    
+    /// Record successful handshake completion
+    func recordHandshakeSuccess(peerID: String) {
+        handshakeQueue.async(flags: .barrier) {
+            self.handshakeStates[peerID] = .established(since: Date())
+            SecureLogger.log("Handshake successfully established with \(peerID)", 
+                           category: SecureLogger.handshake, level: .info)
+        }
+    }
+    
+    /// Record handshake failure
+    func recordHandshakeFailure(peerID: String, reason: String) {
+        handshakeQueue.async(flags: .barrier) {
+            let attempts = self.getCurrentAttempt(for: peerID)
+            let canRetry = attempts < self.maxHandshakeAttempts
+            self.handshakeStates[peerID] = .failed(reason: reason, canRetry: canRetry, lastAttempt: Date())
+            SecureLogger.log("Handshake failed with \(peerID): \(reason), canRetry: \(canRetry)", 
+                           category: SecureLogger.handshake, level: .warning)
+        }
+    }
+    
+    /// Check if we should accept an incoming handshake initiation
+    func shouldAcceptHandshakeInitiation(myPeerID: String, remotePeerID: String) -> Bool {
+        return handshakeQueue.sync {
+            // If we're already established, reject new handshakes
+            if case .established = handshakeStates[remotePeerID] {
+                SecureLogger.log("Rejecting handshake from \(remotePeerID) - already established", 
+                               category: SecureLogger.handshake, level: .debug)
+                return false
+            }
+            
+            let role = determineHandshakeRole(myPeerID: myPeerID, remotePeerID: remotePeerID)
+            
+            // If we're the initiator and already initiating, this is a race condition
+            if role == .initiator {
+                if case .initiating = handshakeStates[remotePeerID] {
+                    // They shouldn't be initiating, but accept it to recover from race condition
+                    SecureLogger.log("Accepting handshake from \(remotePeerID) despite being initiator (race condition recovery)", 
+                                   category: SecureLogger.handshake, level: .warning)
+                    return true
+                }
+            }
+            
+            // If we're the responder, we should accept
+            return true
+        }
+    }
+    
+    /// Check if this is a duplicate handshake message
+    func isDuplicateHandshakeMessage(_ data: Data) -> Bool {
+        return handshakeQueue.sync {
+            if processedHandshakeMessages.contains(data) {
+                return true
+            }
+            
+            // Add to processed messages with size limit
+            if processedHandshakeMessages.count >= messageHistoryLimit {
+                processedHandshakeMessages.removeAll()
+            }
+            processedHandshakeMessages.insert(data)
+            return false
+        }
+    }
+    
+    /// Get time to wait before next handshake attempt
+    func getRetryDelay(for peerID: String) -> TimeInterval? {
+        return handshakeQueue.sync {
+            guard let state = handshakeStates[peerID] else { return nil }
+            
+            switch state {
+            case .failed(_, let canRetry, let lastAttempt):
+                if !canRetry { return nil }
+                let timeSinceFailure = Date().timeIntervalSince(lastAttempt)
+                if timeSinceFailure >= retryDelay {
+                    return 0
+                }
+                return retryDelay - timeSinceFailure
+                
+            case .initiating(_, let lastAttempt):
+                let timeSinceAttempt = Date().timeIntervalSince(lastAttempt)
+                if timeSinceAttempt >= minTimeBetweenHandshakes {
+                    return 0
+                }
+                return minTimeBetweenHandshakes - timeSinceAttempt
+                
+            default:
+                return nil
+            }
+        }
+    }
+    
+    /// Reset handshake state for a peer
+    func resetHandshakeState(for peerID: String) {
+        handshakeQueue.async(flags: .barrier) {
+            self.handshakeStates.removeValue(forKey: peerID)
+            SecureLogger.log("Reset handshake state for \(peerID)", 
+                           category: SecureLogger.handshake, level: .debug)
+        }
+    }
+    
+    /// Get current handshake state
+    func getHandshakeState(for peerID: String) -> HandshakeState {
+        return handshakeQueue.sync {
+            return handshakeStates[peerID] ?? .idle
+        }
+    }
+    
+    // MARK: - Private Helpers
+    
+    private func getCurrentAttempt(for peerID: String) -> Int {
+        switch handshakeStates[peerID] {
+        case .initiating(let attempt, _):
+            return attempt
+        case .failed(_, _, _):
+            // Count previous attempts
+            return 1 // Simplified for now
+        default:
+            return 0
+        }
+    }
+    
+    /// Log current handshake states for debugging
+    func logHandshakeStates() {
+        handshakeQueue.sync {
+            SecureLogger.log("=== Handshake States ===", category: SecureLogger.handshake, level: .debug)
+            for (peerID, state) in handshakeStates {
+                let stateDesc: String
+                switch state {
+                case .idle:
+                    stateDesc = "idle"
+                case .waitingToInitiate(let since):
+                    stateDesc = "waiting to initiate (since \(since))"
+                case .initiating(let attempt, let lastAttempt):
+                    stateDesc = "initiating (attempt \(attempt), last: \(lastAttempt))"
+                case .responding:
+                    stateDesc = "responding"
+                case .waitingForResponse(let messages, let timeout):
+                    stateDesc = "waiting for response (\(messages.count) messages, timeout: \(timeout))"
+                case .established(let since):
+                    stateDesc = "established (since \(since))"
+                case .failed(let reason, let canRetry, let lastAttempt):
+                    stateDesc = "failed: \(reason) (canRetry: \(canRetry), last: \(lastAttempt))"
+                }
+                SecureLogger.log("  \(peerID): \(stateDesc)", category: SecureLogger.handshake, level: .debug)
+            }
+            SecureLogger.log("========================", category: SecureLogger.handshake, level: .debug)
+        }
+    }
+}

--- a/bitchat/Noise/NoiseHandshakeCoordinator.swift
+++ b/bitchat/Noise/NoiseHandshakeCoordinator.swift
@@ -254,4 +254,13 @@ class NoiseHandshakeCoordinator {
             SecureLogger.log("========================", category: SecureLogger.handshake, level: .debug)
         }
     }
+    
+    /// Clear all handshake states - used during panic mode
+    func clearAllHandshakeStates() {
+        handshakeQueue.async(flags: .barrier) {
+            SecureLogger.log("Clearing all handshake states for panic mode", category: SecureLogger.handshake, level: .warning)
+            self.handshakeStates.removeAll()
+            self.processedHandshakeMessages.removeAll()
+        }
+    }
 }

--- a/bitchat/Noise/NoiseProtocol.swift
+++ b/bitchat/Noise/NoiseProtocol.swift
@@ -299,6 +299,7 @@ class NoiseHandshakeState {
             throw NoiseError.handshakeComplete
         }
         
+        SecureLogger.log("NoiseHandshake[\(role)]: Writing message \(currentPattern + 1)/\(messagePatterns.count)", category: SecureLogger.noise, level: .info)
         
         var messageBuffer = Data()
         let patterns = messagePatterns[currentPattern]
@@ -390,6 +391,7 @@ class NoiseHandshakeState {
             throw NoiseError.handshakeComplete
         }
         
+        SecureLogger.log("NoiseHandshake[\(role)]: Reading message \(currentPattern + 1)/\(messagePatterns.count)", category: SecureLogger.noise, level: .info)
         
         var buffer = message
         let patterns = messagePatterns[currentPattern]

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -3421,6 +3421,14 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
                 
                 // Send any cached store-and-forward messages
                 sendCachedMessages(to: peerID)
+                
+                // Notify delegate to update UI encryption status
+                DispatchQueue.main.async { [weak self] in
+                    // Force UI to refresh by sending a peer list update
+                    if let peers = self?.collectionsQueue.sync(execute: { Array(self?.activePeers ?? []) }) {
+                        self?.delegate?.didUpdatePeerList(peers)
+                    }
+                }
             }
         } catch NoiseSessionError.alreadyEstablished {
             // Session already established, ignore handshake

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -1159,6 +1159,16 @@ class BluetoothMeshService: NSObject {
         // Clear persistent identity
         noiseService.clearPersistentIdentity()
         
+        // Clear all handshake coordinator states
+        handshakeCoordinator.clearAllHandshakeStates()
+        
+        // Clear handshake attempt times
+        handshakeAttemptTimes.removeAll()
+        
+        // Notify UI that all peers are disconnected
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.didUpdatePeerList([])
+        }
     }
     
     private func getAllConnectedPeerIDs() -> [String] {

--- a/bitchat/Services/DeliveryTracker.swift
+++ b/bitchat/Services/DeliveryTracker.swift
@@ -21,9 +21,9 @@ class DeliveryTracker {
     private var sentAckIDs = Set<String>()
     
     // Timeout configuration
-    private let privateMessageTimeout: TimeInterval = 30  // 30 seconds
-    private let roomMessageTimeout: TimeInterval = 60     // 1 minute
-    private let favoriteTimeout: TimeInterval = 300       // 5 minutes for favorites
+    private let privateMessageTimeout: TimeInterval = 120  // 2 minutes
+    private let roomMessageTimeout: TimeInterval = 180     // 3 minutes
+    private let favoriteTimeout: TimeInterval = 600       // 10 minutes for favorites
     
     // Retry configuration
     private let maxRetries = 3

--- a/bitchat/Services/NoiseEncryptionService.swift
+++ b/bitchat/Services/NoiseEncryptionService.swift
@@ -25,9 +25,9 @@ enum EncryptionStatus: Equatable {
         case .noiseHandshaking:
             return "lock.rotation"
         case .noiseSecured:
-            return "lock"
+            return "lock.fill"  // Changed from "lock" to "lock.fill" for filled lock
         case .noiseVerified:
-            return "lock.shield"
+            return "lock.shield.fill"  // Changed to filled version for consistency
         }
     }
     

--- a/bitchat/Utils/SecureLogger.swift
+++ b/bitchat/Utils/SecureLogger.swift
@@ -22,6 +22,16 @@ class SecureLogger {
     static let keychain = OSLog(subsystem: subsystem, category: "keychain")
     static let session = OSLog(subsystem: subsystem, category: "session")
     static let security = OSLog(subsystem: subsystem, category: "security")
+    static let handshake = OSLog(subsystem: subsystem, category: "handshake")
+    
+    // MARK: - Timestamp Formatter
+    
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        formatter.timeZone = TimeZone.current
+        return formatter
+    }()
     
     // MARK: - Cached Regex Patterns
     
@@ -135,7 +145,8 @@ class SecureLogger {
     /// Format location information for logging
     private static func formatLocation(file: String, line: Int, function: String) -> String {
         let fileName = (file as NSString).lastPathComponent
-        return "[\(fileName):\(line) \(function)]"
+        let timestamp = timestampFormatter.string(from: Date())
+        return "[\(timestamp)] [\(fileName):\(line) \(function)]"
     }
     
     /// Sanitize strings to remove potentially sensitive data

--- a/bitchatTests/Integration/IntegrationTests.swift
+++ b/bitchatTests/Integration/IntegrationTests.swift
@@ -208,7 +208,7 @@ final class IntegrationTests: XCTestCase {
             if packet.type == 0x01 {
                 plainCount += 1
             } else if packet.type == 0x02 {
-                if let decrypted = try? self.noiseManagers["Bob"]!.decrypt(packet.payload, from: TestConstants.testPeerID1) {
+                if let _ = try? self.noiseManagers["Bob"]!.decrypt(packet.payload, from: TestConstants.testPeerID1) {
                     encryptedCount += 1
                 }
             }

--- a/bitchatTests/Integration/IntegrationTests.swift
+++ b/bitchatTests/Integration/IntegrationTests.swift
@@ -270,6 +270,124 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(receivedMessages.count, totalMessages)
     }
     
+    func testPeerPresenceTrackingAndReconnection() {
+        // Test peer presence tracking and identity announcement on reconnection
+        connect("Alice", "Bob")
+        
+        // Establish Noise sessions
+        do {
+            try establishNoiseSession("Alice", "Bob")
+        } catch {
+            XCTFail("Failed to establish Noise session: \(error)")
+        }
+        
+        let expectation = XCTestExpectation(description: "Peer reconnection handled")
+        var bobReceivedIdentityAnnounce = false
+        var aliceReceivedIdentityAnnounce = false
+        
+        // Track identity announcements
+        nodes["Bob"]!.packetDeliveryHandler = { packet in
+            if packet.type == MessageType.noiseIdentityAnnounce.rawValue {
+                bobReceivedIdentityAnnounce = true
+                if aliceReceivedIdentityAnnounce {
+                    expectation.fulfill()
+                }
+            }
+        }
+        
+        nodes["Alice"]!.packetDeliveryHandler = { packet in
+            if packet.type == MessageType.noiseIdentityAnnounce.rawValue {
+                aliceReceivedIdentityAnnounce = true
+                if bobReceivedIdentityAnnounce {
+                    expectation.fulfill()
+                }
+            }
+        }
+        
+        // Simulate disconnect (out of range)
+        disconnect("Alice", "Bob")
+        
+        // Wait to simulate extended disconnect period
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // Reconnect
+        connect("Alice", "Bob")
+        
+        // Both should receive identity announcements after reconnection
+        wait(for: [expectation], timeout: TestConstants.defaultTimeout)
+        XCTAssertTrue(bobReceivedIdentityAnnounce)
+        XCTAssertTrue(aliceReceivedIdentityAnnounce)
+    }
+    
+    func testEncryptedMessageAfterPeerRestart() {
+        // Test that encrypted messages work after one peer restarts
+        connect("Alice", "Bob")
+        do {
+            try establishNoiseSession("Alice", "Bob")
+        } catch {
+            XCTFail("Failed to establish Noise session: \(error)")
+        }
+        
+        // Exchange an encrypted message
+        let firstExpectation = XCTestExpectation(description: "First message received")
+        nodes["Bob"]!.messageDeliveryHandler = { message in
+            if message.content == "Before restart" && message.isPrivate {
+                firstExpectation.fulfill()
+            }
+        }
+        
+        nodes["Alice"]!.sendPrivateMessage("Before restart", to: TestConstants.testPeerID2, recipientNickname: "Bob")
+        wait(for: [firstExpectation], timeout: TestConstants.defaultTimeout)
+        
+        // Simulate Bob restart by recreating his Noise manager
+        let bobKey = Curve25519.KeyAgreement.PrivateKey()
+        noiseManagers["Bob"] = NoiseSessionManager(localStaticKey: bobKey)
+        
+        // Bob should initiate new handshake
+        let handshakeExpectation = XCTestExpectation(description: "New handshake completed")
+        
+        nodes["Bob"]!.packetDeliveryHandler = { packet in
+            if packet.type == MessageType.noiseHandshakeInit.rawValue {
+                // Bob initiates new handshake after restart
+                do {
+                    let response = try self.noiseManagers["Alice"]!.handleIncomingHandshake(
+                        from: TestConstants.testPeerID2,
+                        message: packet.payload
+                    )
+                    if let resp = response {
+                        // Send response back to Bob
+                        let responsePacket = TestHelpers.createTestPacket(
+                            type: MessageType.noiseHandshakeResp.rawValue,
+                            payload: resp
+                        )
+                        self.nodes["Bob"]!.simulateIncomingPacket(responsePacket)
+                    }
+                } catch {
+                    XCTFail("Handshake handling failed: \(error)")
+                }
+            } else if packet.type == MessageType.noiseHandshakeResp.rawValue && packet.senderID.hexEncodedString() == TestConstants.testPeerID1 {
+                // Final handshake message (message 3 in XX pattern)
+                handshakeExpectation.fulfill()
+            }
+        }
+        
+        // Trigger handshake by trying to send a message
+        nodes["Bob"]!.sendPrivateMessage("After restart", to: TestConstants.testPeerID1, recipientNickname: "Alice")
+        
+        wait(for: [handshakeExpectation], timeout: TestConstants.defaultTimeout)
+        
+        // Now messages should work again
+        let secondExpectation = XCTestExpectation(description: "Message after restart received")
+        nodes["Alice"]!.messageDeliveryHandler = { message in
+            if message.content == "After restart success" && message.isPrivate {
+                secondExpectation.fulfill()
+            }
+        }
+        
+        nodes["Bob"]!.sendPrivateMessage("After restart success", to: TestConstants.testPeerID1, recipientNickname: "Alice")
+        wait(for: [secondExpectation], timeout: TestConstants.defaultTimeout)
+    }
+    
     func testLargeScaleNetwork() {
         // Create larger network
         for i in 5...10 {


### PR DESCRIPTION
## Summary
Fixes multiple issues with Noise protocol handshake stability, session synchronization, and peer reconnection handling.

## Issues Fixed
- Peers stuck in "establishing encryption" state after restart
- Nonce desynchronization causing "Decryption failed at nonce N" errors
- Asymmetric peer visibility (one peer sees the other but not vice versa)
- Thread safety issues with concurrent encryption operations
- Sessions marked as stale immediately after establishment
- Missing read receipts during handshake transitions

## Changes

### Core Fixes
- Add peer presence tracking with `lastHeardFromPeer` to detect reconnections
- Automatically send identity announcements when detecting peer reconnection after 30+ seconds
- Clear stale sessions when receiving handshake initiation from recently-seen peer (likely restart)
- Add peers to `activePeers` when successfully decrypting their messages
- Send identity announcement when decryption fails to prompt session reset

### Thread Safety
- Fix thread safety in handshake coordinator with concurrent collections
- Add per-peer encryption queues to prevent nonce desynchronization
- Make NoiseSession encrypt/decrypt operations thread-safe with barrier flag

### Reliability Improvements
- Extend message delivery timeouts (30s→120s private, 60s→180s room, 300s→600s favorite)
- Initialize `lastSuccessfulMessageTime` when handshake completes
- Improve handshake state logging and debugging

### Tests Added
- Peer restart detection and session recovery
- Nonce desynchronization handling
- Thread-safe encryption under concurrent load (100 messages)
- Session stale detection
- Handshake recovery after decryption failure
- Peer presence tracking and automatic reconnection
- Encrypted messaging after peer restart

## Test Plan
- [x] Build succeeds without warnings
- [x] All new tests compile successfully
- [x] Manual testing with two devices shows stable handshakes
- [x] Peer restart scenarios work correctly
- [x] Messages flow reliably after reconnection