### PR TITLE
Fix handshake deadlock and improve connection reliability

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -859,9 +859,11 @@ class ChatViewModel: ObservableObject {
             return primaryColor
         } else if let peerID = message.senderPeerID ?? getPeerIDForNickname(message.sender),
                   let rssi = meshService.getPeerRSSI()[peerID] {
+            // Use actual RSSI value
             return getRSSIColor(rssi: rssi.intValue, colorScheme: colorScheme)
         } else {
-            return primaryColor.opacity(0.9)
+            // No RSSI data available - use a neutral color
+            return primaryColor.opacity(0.7)
         }
     }
     
@@ -960,9 +962,11 @@ class ChatViewModel: ObservableObject {
                 senderColor = primaryColor
             } else if let peerID = message.senderPeerID ?? getPeerIDForNickname(message.sender),
                       let rssi = meshService.getPeerRSSI()[peerID] {
+                // Use actual RSSI value
                 senderColor = getRSSIColor(rssi: rssi.intValue, colorScheme: colorScheme)
             } else {
-                senderColor = primaryColor.opacity(0.9)
+                // No RSSI data available - use a neutral color
+                senderColor = primaryColor.opacity(0.7)
             }
             
             senderStyle.foregroundColor = senderColor
@@ -1103,9 +1107,11 @@ class ChatViewModel: ObservableObject {
                 senderColor = primaryColor
             } else if let peerID = message.senderPeerID ?? getPeerIDForNickname(message.sender),
                       let rssi = meshService.getPeerRSSI()[peerID] {
+                // Use actual RSSI value
                 senderColor = getRSSIColor(rssi: rssi.intValue, colorScheme: colorScheme)
             } else {
-                senderColor = primaryColor.opacity(0.9)
+                // No RSSI data available - use a neutral color
+                senderColor = primaryColor.opacity(0.7)
             }
             
             senderStyle.foregroundColor = senderColor

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -495,7 +495,7 @@ struct ContentView: View {
                         
                         ForEach(sortedPeers, id: \.self) { peerID in
                             let displayName = peerID == myPeerID ? viewModel.nickname : (peerNicknames[peerID] ?? "anon\(peerID.prefix(4))")
-                            let rssi = peerRSSI[peerID]?.intValue ?? -100
+                            let rssi = peerRSSI[peerID]?.intValue
                             let isFavorite = viewModel.isFavorite(peerID: peerID)
                             let isMe = peerID == myPeerID
                             
@@ -511,11 +511,17 @@ struct ContentView: View {
                                         .font(.system(size: 12))
                                         .foregroundColor(Color.orange)
                                         .accessibilityLabel("Unread message from \(displayName)")
-                                } else {
+                                } else if let rssi = rssi {
                                     Image(systemName: "circle.fill")
                                         .font(.system(size: 8))
                                         .foregroundColor(viewModel.getRSSIColor(rssi: rssi, colorScheme: colorScheme))
                                         .accessibilityLabel("Signal strength: \(rssi > -60 ? "excellent" : rssi > -70 ? "good" : rssi > -80 ? "fair" : "poor")")
+                                } else {
+                                    // No RSSI data available
+                                    Image(systemName: "circle")
+                                        .font(.system(size: 8))
+                                        .foregroundColor(Color.secondary.opacity(0.5))
+                                        .accessibilityLabel("Signal strength: unknown")
                                 }
                                 
                                 // Peer name


### PR DESCRIPTION
## Summary
- Fixed handshake deadlock when one peer clears session but other rejects new handshake
- Improved connection state handling after disconnection/reconnection
- Added comprehensive logging for peer join/leave events

## Changes

### Core Fixes
1. **Always accept handshake initiations** - Even if we have a valid session, accept new handshakes since the peer must have cleared their session for a good reason (decryption failure, restart, etc.)

2. **Fixed NACK handler** - Properly initiates handshake after clearing session on decryption failure

3. **Fixed identity announce relay** - Identity announce packets are now properly relayed through mesh network

4. **Improved handshake retry logic** - Added connection state checks and retry limits to prevent infinite loops

### Tests Added
- `testHandshakeAlwaysAcceptedWithExistingSession` - Verifies handshakes are accepted with existing sessions
- `testNonceDesynchronizationCausesRehandshake` - Tests recovery from nonce desync
- `testHandshakeAfterNACKDecryptionFailure` - Tests full NACK → handshake flow

## Test Results
Core handshake tests are passing. This fixes the issue where Jack would get stuck in "no encryption state" after reconnection.