### PR TITLE
Improve BLE connection stability and message reliability

### DIFF
--- a/bitchat/Protocols/BinaryProtocol.swift
+++ b/bitchat/Protocols/BinaryProtocol.swift
@@ -19,12 +19,11 @@ extension Data {
 }
 
 // Binary Protocol Format:
-// Header (Fixed 17 bytes):
+// Header (Fixed 13 bytes):
 // - Version: 1 byte
 // - Type: 1 byte  
 // - TTL: 1 byte
 // - Timestamp: 8 bytes (UInt64)
-// - SequenceNumber: 4 bytes (UInt32)
 // - Flags: 1 byte (bit 0: hasRecipient, bit 1: hasSignature)
 // - PayloadLength: 2 bytes (UInt16)
 //
@@ -35,7 +34,7 @@ extension Data {
 // - Signature: 64 bytes (if hasSignature flag set)
 
 struct BinaryProtocol {
-    static let headerSize = 17
+    static let headerSize = 13
     static let senderIDSize = 8
     static let recipientIDSize = 8
     static let signatureSize = 64
@@ -76,11 +75,6 @@ struct BinaryProtocol {
         // Timestamp (8 bytes, big-endian)
         for i in (0..<8).reversed() {
             data.append(UInt8((packet.timestamp >> (i * 8)) & 0xFF))
-        }
-        
-        // Sequence number (4 bytes, big-endian)
-        for i in (0..<4).reversed() {
-            data.append(UInt8((packet.sequenceNumber >> (i * 8)) & 0xFF))
         }
         
         // Flags
@@ -171,13 +165,6 @@ struct BinaryProtocol {
         }
         offset += 8
         
-        // Sequence number
-        let sequenceData = unpaddedData[offset..<offset+4]
-        let sequenceNumber = sequenceData.reduce(0) { result, byte in
-            (result << 8) | UInt32(byte)
-        }
-        offset += 4
-        
         // Flags
         let flags = unpaddedData[offset]; offset += 1
         let hasRecipient = (flags & Flags.hasRecipient) != 0
@@ -253,8 +240,7 @@ struct BinaryProtocol {
             timestamp: timestamp,
             payload: payload,
             signature: signature,
-            ttl: ttl,
-            sequenceNumber: sequenceNumber
+            ttl: ttl
         )
     }
 }

--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -139,9 +139,8 @@ struct BitchatPacket: Codable {
     let payload: Data
     let signature: Data?
     var ttl: UInt8
-    let sequenceNumber: UInt32  // New field for duplicate detection
     
-    init(type: UInt8, senderID: Data, recipientID: Data?, timestamp: UInt64, payload: Data, signature: Data?, ttl: UInt8, sequenceNumber: UInt32 = 0) {
+    init(type: UInt8, senderID: Data, recipientID: Data?, timestamp: UInt64, payload: Data, signature: Data?, ttl: UInt8) {
         self.version = 1
         self.type = type
         self.senderID = senderID
@@ -150,11 +149,10 @@ struct BitchatPacket: Codable {
         self.payload = payload
         self.signature = signature
         self.ttl = ttl
-        self.sequenceNumber = sequenceNumber
     }
     
     // Convenience initializer for new binary format
-    init(type: UInt8, ttl: UInt8, senderID: String, payload: Data, sequenceNumber: UInt32 = 0) {
+    init(type: UInt8, ttl: UInt8, senderID: String, payload: Data) {
         self.version = 1
         self.type = type
         // Convert hex string peer ID to binary data (8 bytes)
@@ -173,7 +171,6 @@ struct BitchatPacket: Codable {
         self.payload = payload
         self.signature = nil
         self.ttl = ttl
-        self.sequenceNumber = sequenceNumber
     }
     
     var data: Data? {

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -3552,7 +3552,9 @@ class BluetoothMeshService: NSObject {
             }
         }
     }
-}
+}  // End of cleanupOldFragments
+
+}  // End of BluetoothMeshService class
 
 extension BluetoothMeshService: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
@@ -4090,12 +4092,10 @@ extension BluetoothMeshService: CBPeripheralDelegate {
             }
         }
             
-            // Periodically update RSSI
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak peripheral] in
-                guard let peripheral = peripheral, peripheral.state == .connected else { return }
-                peripheral.readRSSI()
-            }
-        } else {
+        // Periodically update RSSI
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak peripheral] in
+            guard let peripheral = peripheral, peripheral.state == .connected else { return }
+            peripheral.readRSSI()
         }
     }
 }

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -2714,7 +2714,6 @@ class BluetoothMeshService: NSObject {
                     if let tempID = tempIDToRemove {
                         // RSSI transfer is handled by updatePeripheralMapping
                         self.peripheralRSSI.removeValue(forKey: tempID)
-                    }
                         
                         // IMPORTANT: Remove old peer ID from activePeers to prevent duplicates
                         collectionsQueue.sync(flags: .barrier) {
@@ -2835,7 +2834,6 @@ class BluetoothMeshService: NSObject {
                         // Just update the peer list
                         self.notifyPeerListUpdate()
                     }
-                } else {
                 }
                 
                 // Relay announce if TTL > 0
@@ -2847,7 +2845,6 @@ class BluetoothMeshService: NSObject {
                     let delay = Double.random(in: 0.1...0.3)
                     self.scheduleRelay(relayPacket, messageID: messageID, delay: delay)
                 }
-            } else {
             }
             
         case .leave:
@@ -3552,8 +3549,6 @@ class BluetoothMeshService: NSObject {
             }
         }
     }
-}  // End of cleanupOldFragments
-
 }  // End of BluetoothMeshService class
 
 extension BluetoothMeshService: CBCentralManagerDelegate {

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -561,7 +561,7 @@ class ChatViewModel: ObservableObject {
         guard let messageID = notification.userInfo?["messageID"] as? String else { return }
         
         // Find the message to retry
-        if let message = displayedMessages.first(where: { $0.id == messageID }) {
+        if let message = messages.first(where: { $0.id == messageID }) {
             SecureLogger.log("Retrying message \(messageID) to \(message.recipientNickname ?? "unknown")", 
                            category: SecureLogger.session, level: .info)
             
@@ -572,7 +572,11 @@ class ChatViewModel: ObservableObject {
                 updateMessageDeliveryStatus(messageID, status: .sending)
                 
                 // Resend via mesh service
-                meshService.sendMessage(message, toPeer: peerID)
+                meshService.sendMessage(message.content, 
+                                      mentions: message.mentions ?? [], 
+                                      to: peerID,
+                                      messageID: messageID,
+                                      timestamp: message.timestamp)
             }
         }
     }

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -103,6 +103,14 @@ class ChatViewModel: ObservableObject {
             .sink { [weak self] (messageID, status) in
                 self?.updateMessageDeliveryStatus(messageID, status: status)
             }
+        
+        // Listen for retry notifications
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRetryMessage),
+            name: Notification.Name("bitchat.retryMessage"),
+            object: nil
+        )
                 
         // When app becomes active, send read receipts for visible messages
         #if os(macOS)
@@ -547,6 +555,26 @@ class ChatViewModel: ObservableObject {
     func endPrivateChat() {
         selectedPrivateChatPeer = nil
         selectedPrivateChatFingerprint = nil
+    }
+    
+    @objc private func handleRetryMessage(_ notification: Notification) {
+        guard let messageID = notification.userInfo?["messageID"] as? String else { return }
+        
+        // Find the message to retry
+        if let message = displayedMessages.first(where: { $0.id == messageID }) {
+            SecureLogger.log("Retrying message \(messageID) to \(message.recipientNickname ?? "unknown")", 
+                           category: SecureLogger.session, level: .info)
+            
+            // Resend the message through mesh service
+            if message.isPrivate,
+               let peerID = getPeerIDForNickname(message.recipientNickname ?? "") {
+                // Update status to sending
+                updateMessageDeliveryStatus(messageID, status: .sending)
+                
+                // Resend via mesh service
+                meshService.sendMessage(message, toPeer: peerID)
+            }
+        }
     }
     
     @objc private func appDidBecomeActive() {

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -23,17 +23,17 @@ struct AppInfoView: View {
         
         enum Features {
             static let title = "FEATURES"
-            static let offlineComm = ("wifi.slash", "offline communication", "works without internet using Bluetooth mesh networking")
+            static let offlineComm = ("wifi.slash", "offline communication", "works without internet using Bluetooth low energy")
             static let encryption = ("lock.shield", "end-to-end encryption", "private messages encrypted with noise protocol")
-            static let extendedRange = ("antenna.radiowaves.left.and.right", "extended range", "messages relay through peers, increasing the distance")
-            static let favorites = ("star.fill", "favorites", "store-and-forward messages for favorite people")
+            static let extendedRange = ("antenna.radiowaves.left.and.right", "extended range", "messages relay through peers, going the distance")
+            static let favorites = ("star.fill", "favorites", "get notified when your favorite people join")
             static let mentions = ("at", "mentions", "use @nickname to notify specific people")
         }
         
         enum Privacy {
             static let title = "PRIVACY"
             static let noTracking = ("eye.slash", "no tracking", "no servers, accounts, or data collection")
-            static let ephemeral = ("shuffle", "ephemeral identity", "new peer ID generated each session")
+            static let ephemeral = ("shuffle", "ephemeral identity", "new peer ID generated regularly")
             static let panic = ("hand.raised.fill", "panic mode", "triple-tap logo to instantly clear all data")
         }
         
@@ -44,8 +44,7 @@ struct AppInfoView: View {
                 "• swipe left for sidebar",
                 "• tap a peer to start a private chat",
                 "• use @nickname to mention someone",
-                "• triple-tap \"bitchat\" for panic mode",
-                "• triple-tap chat messages to clear current chat"
+                "• triple-tap chat to clear"
             ]
         }
         


### PR DESCRIPTION
## Summary
- Fixed peer availability flapping by increasing timeout and fixing check logic
- Added BLE keepalive mechanism to maintain stable connections
- Resolved missing delivery ACKs issue in Noise encrypted messages
- Reduced network spam from identity announcements and keychain operations
- Implemented message retry system for failed deliveries

## Test plan
- [x] Test peer connections remain stable without flapping
- [x] Verify keepalive pings maintain connections
- [x] Confirm all messages receive delivery ACKs
- [x] Check identity announce rate limiting works
- [x] Validate message retries for favorites
- [x] Ensure graceful peer disconnection handling
- [x] Test with multiple connected peers