### PR TITLE
Implement lazy Noise handshake with notification system

### DIFF
--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -371,4 +371,10 @@ class SecureIdentityStateManager {
             return cache.verifiedFingerprints.contains(fingerprint)
         }
     }
+    
+    func getVerifiedFingerprints() -> Set<String> {
+        queue.sync {
+            return cache.verifiedFingerprints
+        }
+    }
 }

--- a/bitchat/Services/NoiseEncryptionService.swift
+++ b/bitchat/Services/NoiseEncryptionService.swift
@@ -13,15 +13,18 @@ import os.log
 // MARK: - Encryption Status
 
 enum EncryptionStatus: Equatable {
-    case none
-    case noiseHandshaking
-    case noiseSecured
-    case noiseVerified
+    case none                // Failed or incompatible
+    case noHandshake        // No handshake attempted yet
+    case noiseHandshaking   // Currently establishing
+    case noiseSecured       // Established but not verified
+    case noiseVerified      // Established and verified
     
-    var icon: String {
+    var icon: String? {  // Made optional to hide icon when no handshake
         switch self {
         case .none:
-            return "lock.slash"
+            return "lock.slash"  // Failed handshake
+        case .noHandshake:
+            return nil  // No icon when no handshake attempted
         case .noiseHandshaking:
             return "lock.rotation"
         case .noiseSecured:
@@ -34,6 +37,8 @@ enum EncryptionStatus: Equatable {
     var description: String {
         switch self {
         case .none:
+            return "Encryption failed"
+        case .noHandshake:
             return "Not encrypted"
         case .noiseHandshaking:
             return "Establishing encryption..."

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -669,13 +669,15 @@ struct ContentView: View {
                                         .foregroundColor(peerNicknames[peer.id] != nil ? textColor : secondaryTextColor)
                                     
                                     // Encryption status icon (after peer name)
-                                    Image(systemName: peer.encryptionStatus.icon)
-                                        .font(.system(size: 10))
-                                        .foregroundColor(peer.encryptionStatus == .noiseVerified ? Color.green : 
-                                                       peer.encryptionStatus == .noiseSecured ? textColor :
-                                                       peer.encryptionStatus == .noiseHandshaking ? Color.orange :
-                                                       Color.red)
-                                        .accessibilityLabel("Encryption: \(peer.encryptionStatus == .noiseVerified ? "verified" : peer.encryptionStatus == .noiseSecured ? "secured" : peer.encryptionStatus == .noiseHandshaking ? "establishing" : "none")")
+                                    if let icon = peer.encryptionStatus.icon {
+                                        Image(systemName: icon)
+                                            .font(.system(size: 10))
+                                            .foregroundColor(peer.encryptionStatus == .noiseVerified ? Color.green : 
+                                                           peer.encryptionStatus == .noiseSecured ? textColor :
+                                                           peer.encryptionStatus == .noiseHandshaking ? Color.orange :
+                                                           Color.red)
+                                            .accessibilityLabel("Encryption: \(peer.encryptionStatus == .noiseVerified ? "verified" : peer.encryptionStatus == .noiseSecured ? "secured" : peer.encryptionStatus == .noiseHandshaking ? "establishing" : "none")")
+                                    }
                                     
                                     Spacer()
                                     
@@ -897,12 +899,14 @@ struct ContentView: View {
                                 .foregroundColor(Color.orange)
                             // Dynamic encryption status icon
                             let encryptionStatus = viewModel.getEncryptionStatus(for: privatePeerID)
-                            Image(systemName: encryptionStatus.icon)
-                                .font(.system(size: 14))
-                                .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
-                                               encryptionStatus == .noiseSecured ? Color.orange :
-                                               Color.red)
-                                .accessibilityLabel("Encryption status: \(encryptionStatus == .noiseVerified ? "verified" : encryptionStatus == .noiseSecured ? "secured" : "not encrypted")")
+                            if let icon = encryptionStatus.icon {
+                                Image(systemName: icon)
+                                    .font(.system(size: 14))
+                                    .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
+                                                   encryptionStatus == .noiseSecured ? Color.orange :
+                                                   Color.red)
+                                    .accessibilityLabel("Encryption status: \(encryptionStatus == .noiseVerified ? "verified" : encryptionStatus == .noiseSecured ? "secured" : "not encrypted")")
+                            }
                         }
                         .frame(maxWidth: .infinity)
                         .accessibilityLabel("Private chat with \(privatePeerNick)")

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -45,9 +45,11 @@ struct FingerprintView: View {
                 let encryptionStatus = viewModel.getEncryptionStatus(for: peerID)
                 
                 HStack {
-                    Image(systemName: encryptionStatus.icon)
-                        .font(.system(size: 20))
-                        .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : textColor)
+                    if let icon = encryptionStatus.icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 20))
+                            .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : textColor)
+                    }
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(peerNickname)


### PR DESCRIPTION
## Summary
- Make Noise handshake lazy - only establish when sending/receiving private messages
- Add handshake request notifications so recipients know messages are waiting
- Fix verification persistence bug

## Changes
- Add `handshakeRequest` packet type to notify recipients about pending messages
- Only trigger handshake when:
  - Sending a private message
  - Receiving a handshake request
  - Opening a private conversation in UI
- Hide encryption icon when no handshake has been attempted (only show on failure)
- Fix verification persistence by adding forceSave on app termination

## Test plan
- [x] Verify handshake only occurs when needed for private messages
- [x] Test that recipients get notified when messages are pending
- [x] Confirm verification status persists across app restarts
- [x] Check that encryption icons display correctly