### PR TITLE
Fix spurious handshake requests from rotated peers and cover traffic

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -737,14 +737,20 @@
 				CODE_SIGN_ENTITLEMENTS = bitchatShareExtension/bitchatShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = bitchatShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -760,6 +766,7 @@
 				CODE_SIGN_ENTITLEMENTS = bitchat/bitchat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = bitchat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
@@ -769,6 +776,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
@@ -814,6 +822,7 @@
 				CODE_SIGN_ENTITLEMENTS = bitchat/bitchat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = bitchat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
@@ -823,6 +832,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
@@ -1025,14 +1035,20 @@
 				CODE_SIGN_ENTITLEMENTS = bitchatShareExtension/bitchatShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = bitchatShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -371,4 +371,10 @@ class SecureIdentityStateManager {
             return cache.verifiedFingerprints.contains(fingerprint)
         }
     }
+    
+    func getVerifiedFingerprints() -> Set<String> {
+        queue.sync {
+            return cache.verifiedFingerprints
+        }
+    }
 }

--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDisplayName</key>
 	<string>bitchat</string>
 	<key>CFBundleExecutable</key>

--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CFBundleDisplayName</key>
 	<string>bitchat</string>
 	<key>CFBundleExecutable</key>

--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -709,12 +709,10 @@ class BluetoothMeshService: NSObject {
                     self.peerNicknames.removeValue(forKey: existingPeerID)
                 }
                 
-                // Update active peers set
-                if self.activePeers.contains(existingPeerID) {
-                    self.activePeers.remove(existingPeerID)
-                    // Don't pre-insert the new peer ID - let the announce packet handle it
-                    // This ensures the connect message logic works properly
-                }
+                // Update active peers set - always remove old peer ID
+                self.activePeers.remove(existingPeerID)
+                // Don't pre-insert the new peer ID - let the announce packet handle it
+                // This ensures the connect message logic works properly
                 
                 // Transfer any connected peripherals
                 if let peripheral = self.connectedPeripherals[existingPeerID] {
@@ -733,6 +731,14 @@ class BluetoothMeshService: NSObject {
                     self.lastHeardFromPeer.removeValue(forKey: existingPeerID)
                     self.lastHeardFromPeer[newPeerID] = lastHeard
                 }
+                
+                // Clean up connection state for old peer ID
+                self.peerConnectionStates.removeValue(forKey: existingPeerID)
+                // Don't transfer connection state - let it be re-established naturally
+                
+                // Clean up any pending messages for old peer ID
+                self.pendingPrivateMessages.removeValue(forKey: existingPeerID)
+                // Don't transfer pending messages - they would be stale anyway
             }
             
             // Add new mapping
@@ -1161,8 +1167,15 @@ class BluetoothMeshService: NSObject {
         // Setup battery optimizer
         setupBatteryOptimizer()
         
-        // Start cover traffic for privacy
-        startCoverTraffic()
+        // Start cover traffic for privacy (disabled by default for now)
+        // TODO: Make this configurable in settings
+        let coverTrafficEnabled = false
+        if coverTrafficEnabled {
+            SecureLogger.log("Cover traffic enabled", category: SecureLogger.security, level: .info)
+            startCoverTraffic()
+        } else {
+            SecureLogger.log("Cover traffic disabled", category: SecureLogger.security, level: .info)
+        }
     }
     
     func sendBroadcastAnnounce() {
@@ -4759,22 +4772,32 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
     }
     
     private func sendDummyMessage() {
-        // Only send dummy messages if we have connected peers
-        let peers = getAllConnectedPeerIDs()
-        guard !peers.isEmpty else { return }
+        // Only send dummy messages if we have connected peers with established sessions
+        let peersWithSessions = getAllConnectedPeerIDs().filter { peerID in
+            return noiseService.hasEstablishedSession(with: peerID)
+        }
+        
+        guard !peersWithSessions.isEmpty else { 
+            SecureLogger.log("Cover traffic: No peers with established sessions, skipping dummy message", 
+                           category: SecureLogger.security, level: .debug)
+            return 
+        }
         
         // Skip if battery is low
         if currentBatteryLevel < 0.2 {
+            SecureLogger.log("Cover traffic: Battery low, skipping dummy message", 
+                           category: SecureLogger.security, level: .debug)
             return
         }
         
-        // Pick a random peer to send to
-        guard let randomPeer = peers.randomElement() else { return }
+        // Pick a random peer with an established session to send to
+        guard let randomPeer = peersWithSessions.randomElement() else { return }
         
         // Generate random dummy content
         let dummyContent = generateDummyContent()
         
-        // Sending cover traffic
+        SecureLogger.log("Cover traffic: Sending dummy message to \(randomPeer)", 
+                       category: SecureLogger.security, level: .info)
         
         // Send as a private message so it's encrypted
         let recipientNickname = collectionsQueue.sync {
@@ -4892,18 +4915,42 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
     private func sendKeepAlivePings() {
         let connectedPeers = collectionsQueue.sync {
             return Array(activePeers).filter { peerID in
-                // Only send keepalive to authenticated peers
+                // Only send keepalive to authenticated peers that still exist
+                // Check if this peer ID is still current (not rotated)
+                guard let fingerprint = peerIDToFingerprint[peerID],
+                      let currentPeerID = fingerprintToPeerID[fingerprint],
+                      currentPeerID == peerID else {
+                    // This peer ID has rotated, skip it
+                    SecureLogger.log("Skipping keepalive for rotated peer ID: \(peerID)", 
+                                   category: SecureLogger.session, level: .debug)
+                    return false
+                }
+                
+                // Check if we actually have a Noise session with this peer
+                guard noiseService.hasEstablishedSession(with: peerID) else {
+                    SecureLogger.log("Skipping keepalive for \(peerID) - no established session", 
+                                   category: SecureLogger.session, level: .debug)
+                    return false
+                }
+                
                 return peerConnectionStates[peerID] == .authenticated
             }
         }
+        
+        SecureLogger.log("Keep-alive timer: checking \(connectedPeers.count) peers for pings", 
+                       category: SecureLogger.session, level: .debug)
         
         for peerID in connectedPeers {
             // Don't spam if we recently heard from them
             if let lastHeard = lastHeardFromPeer[peerID], 
                Date().timeIntervalSince(lastHeard) < keepAliveInterval / 2 {
+                SecureLogger.log("Skipping keepalive for \(peerID) - heard recently", 
+                               category: SecureLogger.session, level: .debug)
                 continue  // Skip if we heard from them in the last 10 seconds
             }
             
+            SecureLogger.log("Sending keepalive ping to \(peerID)", 
+                           category: SecureLogger.session, level: .debug)
             validateNoiseSession(with: peerID)
         }
     }
@@ -6103,6 +6150,9 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
     
     // Send private message using Noise Protocol
     private func sendPrivateMessageViaNoise(_ content: String, to recipientPeerID: String, recipientNickname: String, messageID: String? = nil) {
+        SecureLogger.log("sendPrivateMessageViaNoise called - content: '\(content.prefix(50))...', to: \(recipientPeerID), messageID: \(messageID ?? "nil")", 
+                       category: SecureLogger.noise, level: .info)
+        
         // Use per-peer encryption queue to prevent nonce desynchronization
         let encryptionQueue = getEncryptionQueue(for: recipientPeerID)
         
@@ -6117,16 +6167,16 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
             // Check if session is stale (no successful communication for a while)
             var sessionIsStale = false
             if hasSession {
-            let lastSuccess = lastSuccessfulMessageTime[recipientPeerID] ?? Date.distantPast
-            let sessionAge = Date().timeIntervalSince(lastSuccess)
-            // Increase session validity to 24 hours - sessions should persist across temporary disconnects
-            if sessionAge > 86400.0 { // More than 24 hours since last successful message
-                sessionIsStale = true
-                SecureLogger.log("Session with \(recipientPeerID) is stale (last success: \(Int(sessionAge))s ago), will re-establish", category: SecureLogger.noise, level: .info)
+                let lastSuccess = lastSuccessfulMessageTime[recipientPeerID] ?? Date.distantPast
+                let sessionAge = Date().timeIntervalSince(lastSuccess)
+                // Increase session validity to 24 hours - sessions should persist across temporary disconnects
+                if sessionAge > 86400.0 { // More than 24 hours since last successful message
+                    sessionIsStale = true
+                    SecureLogger.log("Session with \(recipientPeerID) is stale (last success: \(Int(sessionAge))s ago), will re-establish", category: SecureLogger.noise, level: .info)
+                }
             }
-        }
-        
-        if !hasSession || sessionIsStale {
+            
+            if !hasSession || sessionIsStale {
             if sessionIsStale {
                 // Clear stale session first
                 cleanupPeerCryptoState(recipientPeerID)

--- a/bitchat/Services/NoiseEncryptionService.swift
+++ b/bitchat/Services/NoiseEncryptionService.swift
@@ -13,15 +13,18 @@ import os.log
 // MARK: - Encryption Status
 
 enum EncryptionStatus: Equatable {
-    case none
-    case noiseHandshaking
-    case noiseSecured
-    case noiseVerified
+    case none                // Failed or incompatible
+    case noHandshake        // No handshake attempted yet
+    case noiseHandshaking   // Currently establishing
+    case noiseSecured       // Established but not verified
+    case noiseVerified      // Established and verified
     
-    var icon: String {
+    var icon: String? {  // Made optional to hide icon when no handshake
         switch self {
         case .none:
-            return "lock.slash"
+            return "lock.slash"  // Failed handshake
+        case .noHandshake:
+            return nil  // No icon when no handshake attempted
         case .noiseHandshaking:
             return "lock.rotation"
         case .noiseSecured:
@@ -34,6 +37,8 @@ enum EncryptionStatus: Equatable {
     var description: String {
         switch self {
         case .none:
+            return "Encryption failed"
+        case .noHandshake:
             return "Not encrypted"
         case .noiseHandshaking:
             return "Establishing encryption..."

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -610,8 +610,17 @@ class ChatViewModel: ObservableObject {
         if let peerID = selectedPrivateChatPeer {
             // In private chat - send to the other person
             if let peerNickname = meshService.getPeerNicknames()[peerID] {
-                // Send the message directly without going through sendPrivateMessage to avoid local echo
-                meshService.sendPrivateMessage(screenshotMessage, to: peerID, recipientNickname: peerNickname)
+                // Only send screenshot notification if we have an established session
+                // This prevents triggering handshake requests for screenshot notifications
+                let sessionState = meshService.getNoiseSessionState(for: peerID)
+                switch sessionState {
+                case .established:
+                    // Send the message directly without going through sendPrivateMessage to avoid local echo
+                    meshService.sendPrivateMessage(screenshotMessage, to: peerID, recipientNickname: peerNickname)
+                default:
+                    // Don't send screenshot notification if no session exists
+                    SecureLogger.log("Skipping screenshot notification to \(peerID) - no established session", category: SecureLogger.security, level: .debug)
+                }
             }
             
             // Show local notification immediately as system message

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -669,13 +669,15 @@ struct ContentView: View {
                                         .foregroundColor(peerNicknames[peer.id] != nil ? textColor : secondaryTextColor)
                                     
                                     // Encryption status icon (after peer name)
-                                    Image(systemName: peer.encryptionStatus.icon)
-                                        .font(.system(size: 10))
-                                        .foregroundColor(peer.encryptionStatus == .noiseVerified ? Color.green : 
-                                                       peer.encryptionStatus == .noiseSecured ? textColor :
-                                                       peer.encryptionStatus == .noiseHandshaking ? Color.orange :
-                                                       Color.red)
-                                        .accessibilityLabel("Encryption: \(peer.encryptionStatus == .noiseVerified ? "verified" : peer.encryptionStatus == .noiseSecured ? "secured" : peer.encryptionStatus == .noiseHandshaking ? "establishing" : "none")")
+                                    if let icon = peer.encryptionStatus.icon {
+                                        Image(systemName: icon)
+                                            .font(.system(size: 10))
+                                            .foregroundColor(peer.encryptionStatus == .noiseVerified ? Color.green : 
+                                                           peer.encryptionStatus == .noiseSecured ? textColor :
+                                                           peer.encryptionStatus == .noiseHandshaking ? Color.orange :
+                                                           Color.red)
+                                            .accessibilityLabel("Encryption: \(peer.encryptionStatus == .noiseVerified ? "verified" : peer.encryptionStatus == .noiseSecured ? "secured" : peer.encryptionStatus == .noiseHandshaking ? "establishing" : "none")")
+                                    }
                                     
                                     Spacer()
                                     
@@ -897,12 +899,14 @@ struct ContentView: View {
                                 .foregroundColor(Color.orange)
                             // Dynamic encryption status icon
                             let encryptionStatus = viewModel.getEncryptionStatus(for: privatePeerID)
-                            Image(systemName: encryptionStatus.icon)
-                                .font(.system(size: 14))
-                                .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
-                                               encryptionStatus == .noiseSecured ? Color.orange :
-                                               Color.red)
-                                .accessibilityLabel("Encryption status: \(encryptionStatus == .noiseVerified ? "verified" : encryptionStatus == .noiseSecured ? "secured" : "not encrypted")")
+                            if let icon = encryptionStatus.icon {
+                                Image(systemName: icon)
+                                    .font(.system(size: 14))
+                                    .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : 
+                                                   encryptionStatus == .noiseSecured ? Color.orange :
+                                                   Color.red)
+                                    .accessibilityLabel("Encryption status: \(encryptionStatus == .noiseVerified ? "verified" : encryptionStatus == .noiseSecured ? "secured" : "not encrypted")")
+                            }
                         }
                         .frame(maxWidth: .infinity)
                         .accessibilityLabel("Private chat with \(privatePeerNick)")

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -45,9 +45,11 @@ struct FingerprintView: View {
                 let encryptionStatus = viewModel.getEncryptionStatus(for: peerID)
                 
                 HStack {
-                    Image(systemName: encryptionStatus.icon)
-                        .font(.system(size: 20))
-                        .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : textColor)
+                    if let icon = encryptionStatus.icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 20))
+                            .foregroundColor(encryptionStatus == .noiseVerified ? Color.green : textColor)
+                    }
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(peerNickname)


### PR DESCRIPTION
## Summary
- Prevent "wants to send you X message" notifications when no messages were actually sent
- Fix issues caused by peer ID rotation leaving stale connection states
- Disable cover traffic by default which was sending dummy messages without user knowledge

## Changes
- Clean up connection states and pending messages during peer ID rotation
- Filter out rotated peer IDs in keep-alive timer
- Only send cover traffic to peers with established sessions
- Disable cover traffic by default (was automatically sending dummy messages)
- Add screenshot notification session check
- Add logging to track automatic message triggers

## Test Plan
- [x] Build succeeds for iOS and macOS
- [ ] No spurious handshake requests after peer ID rotation
- [ ] Keep-alive pings only sent to current peer IDs with sessions
- [ ] Cover traffic disabled by default
- [ ] Screenshot notifications only sent with active sessions