### PR TITLE
fix iOS app zoom/compat mode issue (issue #236)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,8 @@ targets:
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - bitchat
+        # xcodegen quirk: include some macOS properties in iOS target
+        LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: chat.bitchat
       PRODUCT_NAME: bitchat
@@ -80,6 +82,14 @@ targets:
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - bitchat
+        # xcodegen quirk: include some iOS properties in macOS target
+        UIBackgroundModes:
+          - bluetooth-central
+          - bluetooth-peripheral
+        UILaunchStoryboardName: LaunchScreen
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        UIRequiresFullScreen: true
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: chat.bitchat
       PRODUCT_NAME: bitchat


### PR DESCRIPTION
Fixes https://github.com/permissionlesstech/bitchat/issues/236 by implementing @wintersixx suggestion at https://github.com/permissionlesstech/bitchat/issues/236#issuecomment-3073044561.

Changes:
- include required iOS properties in macOS target and vice versa

Verification evidence that iOS/macOS targets still build and iOS UI bug is fixed:


<img width="1244" height="1057" alt="Screenshot 2025-07-26 at 5 39 18 PM" src="https://github.com/user-attachments/assets/10522458-8296-4179-8afa-0ccea6f4c84f" />


<img width="60%" height="60%" alt="Screenshot 2025-07-26 at 5 39 18 PM" src="https://github.com/user-attachments/assets/a393c881-f72c-4bf5-8d9f-d5d2f402488d" />