### PR TITLE
Fix macOS App Store keyboard overlay

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -551,7 +551,13 @@ struct ContentView: View {
             .accessibilityHint(messageText.isEmpty ? "Enter a message to send" : "Double tap to send")
             }
             .padding(.vertical, 8)
-            .background(backgroundColor.opacity(0.95))
+            .background {
+                #if os(macOS)
+                backgroundColor
+                #else
+                backgroundColor.opacity(0.95)
+                #endif
+            }
         }
         .onAppear {
             // Delay keyboard focus to avoid iOS constraint warnings


### PR DESCRIPTION
As reported by @AndreiRegiani https://github.com/permissionlesstech/bitchat/pull/234#issuecomment-3127621052
There is a gray bar overlay appearing over the text input field when the keyboard is open on macOS App Store builds, but not when building from Xcode.
<img width="1056" height="660" alt="image" src="https://github.com/user-attachments/assets/be050154-4d3e-4b7f-a43d-f407cc65311c" />

### Root Cause
  Currently investigating further. The issue occurs only in App Store builds, not in local development or sandbox testing. 