### PR TITLE
Dynamic type support

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1173,7 +1173,7 @@ class ChatViewModel: ObservableObject {
                 let beforeText = String(contentText[lastEndIndex..<range.lowerBound])
                 if !beforeText.isEmpty {
                     var normalStyle = AttributeContainer()
-                    normalStyle.font = .system(size: 14, design: .monospaced)
+                    normalStyle.font = .scalableMonospaced(size: 14)
                     normalStyle.foregroundColor = isDark ? Color.white : Color.black
                     processedContent.append(AttributedString(beforeText).mergingAttributes(normalStyle))
                 }
@@ -1181,7 +1181,7 @@ class ChatViewModel: ObservableObject {
                 // Add the match with appropriate styling
                 let matchText = String(contentText[range])
                 var matchStyle = AttributeContainer()
-                matchStyle.font = .system(size: 14, weight: .semibold, design: .monospaced)
+                matchStyle.font = .scalableMonospaced(size: 14, weight: .semibold)
                 
                 if matchType == "mention" {
                     matchStyle.foregroundColor = Color.orange
@@ -1201,7 +1201,7 @@ class ChatViewModel: ObservableObject {
         if lastEndIndex < contentText.endIndex {
             let remainingText = String(contentText[lastEndIndex...])
             var normalStyle = AttributeContainer()
-            normalStyle.font = .system(size: 14, design: .monospaced)
+            normalStyle.font = .scalableMonospaced(size: 14)
             normalStyle.foregroundColor = isDark ? Color.white : Color.black
             processedContent.append(AttributedString(remainingText).mergingAttributes(normalStyle))
         }
@@ -1226,7 +1226,7 @@ class ChatViewModel: ObservableObject {
         let timestamp = AttributedString("[\(formatTimestamp(message.timestamp))] ")
         var timestampStyle = AttributeContainer()
         timestampStyle.foregroundColor = message.sender == "system" ? Color.gray : secondaryColor
-        timestampStyle.font = .system(size: 12, design: .monospaced)
+        timestampStyle.font = .scalableMonospaced(size: 12)
         result.append(timestamp.mergingAttributes(timestampStyle))
         
         if message.sender != "system" {
@@ -1238,7 +1238,7 @@ class ChatViewModel: ObservableObject {
             senderStyle.foregroundColor = primaryColor
             // Bold the user's own nickname
             let fontWeight: Font.Weight = message.sender == nickname ? .bold : .medium
-            senderStyle.font = .system(size: 14, weight: fontWeight, design: .monospaced)
+            senderStyle.font = .scalableMonospaced(size: 14, weight: fontWeight)
             result.append(sender.mergingAttributes(senderStyle))
             
             // Process content with hashtags and mentions
@@ -1281,7 +1281,7 @@ class ChatViewModel: ObservableObject {
                     if !beforeText.isEmpty {
                         var beforeStyle = AttributeContainer()
                         beforeStyle.foregroundColor = primaryColor
-                        beforeStyle.font = .system(size: 14, design: .monospaced)
+                        beforeStyle.font = .scalableMonospaced(size: 14)
                         if isMentioned {
                             beforeStyle.font = beforeStyle.font?.bold()
                         }
@@ -1291,7 +1291,7 @@ class ChatViewModel: ObservableObject {
                     // Add styled match
                     let matchText = String(content[nsRange])
                     var matchStyle = AttributeContainer()
-                    matchStyle.font = .system(size: 14, weight: .semibold, design: .monospaced)
+                    matchStyle.font = .scalableMonospaced(size: 14, weight: .semibold)
                     
                     if type == "hashtag" {
                         matchStyle.foregroundColor = Color.blue
@@ -1313,7 +1313,7 @@ class ChatViewModel: ObservableObject {
                 let remainingText = String(content[lastEnd...])
                 var remainingStyle = AttributeContainer()
                 remainingStyle.foregroundColor = primaryColor
-                remainingStyle.font = .system(size: 14, design: .monospaced)
+                remainingStyle.font = .scalableMonospaced(size: 14)
                 if isMentioned {
                     remainingStyle.font = remainingStyle.font?.bold()
                 }
@@ -1324,7 +1324,7 @@ class ChatViewModel: ObservableObject {
             var contentStyle = AttributeContainer()
             contentStyle.foregroundColor = Color.gray
             let content = AttributedString("* \(message.content) *")
-            contentStyle.font = .system(size: 12, design: .monospaced).italic()
+            contentStyle.font = .scalableMonospaced(size: 12).italic()
             result.append(content.mergingAttributes(contentStyle))
         }
         
@@ -1344,14 +1344,14 @@ class ChatViewModel: ObservableObject {
         let timestamp = AttributedString("[\(formatTimestamp(message.timestamp))] ")
         var timestampStyle = AttributeContainer()
         timestampStyle.foregroundColor = message.sender == "system" ? Color.gray : secondaryColor
-        timestampStyle.font = .system(size: 12, design: .monospaced)
+        timestampStyle.font = .scalableMonospaced(size: 12)
         result.append(timestamp.mergingAttributes(timestampStyle))
         
         if message.sender == "system" {
             let content = AttributedString("* \(message.content) *")
             var contentStyle = AttributeContainer()
             contentStyle.foregroundColor = Color.gray
-            contentStyle.font = .system(size: 12, design: .monospaced).italic()
+            contentStyle.font = .scalableMonospaced(size: 12).italic()
             result.append(content.mergingAttributes(contentStyle))
         } else {
             let sender = AttributedString("<\(message.sender)> ")
@@ -1361,7 +1361,7 @@ class ChatViewModel: ObservableObject {
             senderStyle.foregroundColor = primaryColor
             // Bold the user's own nickname
             let fontWeight: Font.Weight = message.sender == nickname ? .bold : .medium
-            senderStyle.font = .system(size: 12, weight: fontWeight, design: .monospaced)
+            senderStyle.font = .scalableMonospaced(size: 12, weight: fontWeight)
             result.append(sender.mergingAttributes(senderStyle))
             
             
@@ -1382,7 +1382,7 @@ class ChatViewModel: ObservableObject {
                     let beforeText = String(contentText[lastEndIndex..<range.lowerBound])
                     if !beforeText.isEmpty {
                         var normalStyle = AttributeContainer()
-                        normalStyle.font = .system(size: 14, design: .monospaced)
+                        normalStyle.font = .scalableMonospaced(size: 14)
                         normalStyle.foregroundColor = isDark ? Color.white : Color.black
                         processedContent.append(AttributedString(beforeText).mergingAttributes(normalStyle))
                     }
@@ -1390,7 +1390,7 @@ class ChatViewModel: ObservableObject {
                     // Add the mention with highlight
                     let mentionText = String(contentText[range])
                     var mentionStyle = AttributeContainer()
-                    mentionStyle.font = .system(size: 14, weight: .semibold, design: .monospaced)
+                    mentionStyle.font = .scalableMonospaced(size: 14, weight: .semibold)
                     mentionStyle.foregroundColor = Color.orange
                     processedContent.append(AttributedString(mentionText).mergingAttributes(mentionStyle))
                     
@@ -1402,7 +1402,7 @@ class ChatViewModel: ObservableObject {
             if lastEndIndex < contentText.endIndex {
                 let remainingText = String(contentText[lastEndIndex...])
                 var normalStyle = AttributeContainer()
-                normalStyle.font = .system(size: 14, design: .monospaced)
+                normalStyle.font = .scalableMonospaced(size: 14)
                 normalStyle.foregroundColor = isDark ? Color.white : Color.black
                 processedContent.append(AttributedString(remainingText).mergingAttributes(normalStyle))
             }
@@ -1413,7 +1413,7 @@ class ChatViewModel: ObservableObject {
                 let relay = AttributedString(" (via \(originalSender))")
                 var relayStyle = AttributeContainer()
                 relayStyle.foregroundColor = secondaryColor
-                relayStyle.font = .system(size: 11, design: .monospaced)
+                relayStyle.font = .scalableMonospaced(size: 11)
                 result.append(relay.mergingAttributes(relayStyle))
             }
         }

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -100,11 +100,11 @@ struct AppInfoView: View {
             // Header
             VStack(alignment: .center, spacing: 8) {
                 Text(Strings.appName)
-                    .font(.system(size: 32, weight: .bold, design: .monospaced))
+                    .font(.scalableMonospaced(size: 32, weight: .bold))
                     .foregroundColor(textColor)
                 
                 Text(Strings.tagline)
-                    .font(.system(size: 16, design: .monospaced))
+                    .font(.scalableMonospaced(size: 16))
                     .foregroundColor(secondaryTextColor)
             }
             .frame(maxWidth: .infinity)
@@ -161,7 +161,7 @@ struct AppInfoView: View {
                         Text(instruction)
                     }
                 }
-                .font(.system(size: 14, design: .monospaced))
+                .font(.scalableMonospaced(size: 14))
                 .foregroundColor(textColor)
             }
             
@@ -171,7 +171,7 @@ struct AppInfoView: View {
                     .foregroundColor(Color.red)
                 
                 Text(Strings.Warning.message)
-                    .font(.system(size: 14, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14))
                     .foregroundColor(Color.red)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -201,7 +201,7 @@ struct SectionHeader: View {
     
     var body: some View {
         Text(title)
-            .font(.system(size: 16, weight: .bold, design: .monospaced))
+            .font(.scalableMonospaced(size: 16, weight: .bold))
             .foregroundColor(textColor)
             .padding(.top, 8)
     }
@@ -230,11 +230,11 @@ struct FeatureRow: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14, weight: .semibold))
                     .foregroundColor(textColor)
                 
                 Text(description)
-                    .font(.system(size: 12, design: .monospaced))
+                    .font(.scalableMonospaced(size: 12))
                     .foregroundColor(secondaryTextColor)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -383,7 +383,7 @@ struct ContentView: View {
                         }) {
                             HStack {
                                 Text("@\(suggestion)")
-                                    .font(.system(size: 11, design: .monospaced))
+                                    .font(.scalableMonospaced(size: 11))
                                     .foregroundColor(textColor)
                                     .fontWeight(.medium)
                                 Spacer()
@@ -434,14 +434,14 @@ struct ContentView: View {
                                 HStack {
                                     // Show all aliases together
                                     Text(info.commands.joined(separator: ", "))
-                                        .font(.system(size: 11, design: .monospaced))
+                                        .font(.scalableMonospaced(size: 11))
                                         .foregroundColor(textColor)
                                         .fontWeight(.medium)
                                     
                                     // Show syntax if any
                                     if let syntax = info.syntax {
                                         Text(syntax)
-                                            .font(.system(size: 10, design: .monospaced))
+                                            .font(.scalableMonospaced(size: 10))
                                             .foregroundColor(secondaryTextColor.opacity(0.8))
                                     }
                                     
@@ -449,7 +449,7 @@ struct ContentView: View {
                                     
                                     // Show description
                                     Text(info.description)
-                                        .font(.system(size: 10, design: .monospaced))
+                                        .font(.scalableMonospaced(size: 10))
                                         .foregroundColor(secondaryTextColor)
                                 }
                                 .padding(.horizontal, 12)
@@ -472,7 +472,7 @@ struct ContentView: View {
             HStack(alignment: .center, spacing: 4) {
             TextField("type a message...", text: $messageText)
                 .textFieldStyle(.plain)
-                .font(.system(size: 14, design: .monospaced))
+                .font(.scalableMonospaced(size: 14))
                 .foregroundColor(textColor)
                 .focused($isTextFieldFocused)
                 .padding(.leading, 12)
@@ -581,7 +581,7 @@ struct ContentView: View {
                 // Header - match main toolbar height
                 HStack {
                     Text("NETWORK")
-                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 16, weight: .bold))
                         .foregroundColor(textColor)
                     Spacer()
                 }
@@ -603,7 +603,7 @@ struct ContentView: View {
                                     .font(.system(size: 10))
                                     .accessibilityHidden(true)
                                 Text("PEOPLE")
-                                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                    .font(.scalableMonospaced(size: 11, weight: .bold))
                             }
                             .foregroundColor(secondaryTextColor)
                             .padding(.horizontal, 12)
@@ -611,7 +611,7 @@ struct ContentView: View {
                         
                         if viewModel.connectedPeers.isEmpty {
                             Text("nobody around...")
-                                .font(.system(size: 14, design: .monospaced))
+                                .font(.scalableMonospaced(size: 14))
                                 .foregroundColor(secondaryTextColor)
                                 .padding(.horizontal)
                         } else {
@@ -680,14 +680,14 @@ struct ContentView: View {
                                 if peer.isMe {
                                     HStack {
                                         Text(peer.displayName + " (you)")
-                                            .font(.system(size: 14, design: .monospaced))
+                                            .font(.scalableMonospaced(size: 14))
                                             .foregroundColor(textColor)
                                         
                                         Spacer()
                                     }
                                 } else {
                                     Text(peer.displayName)
-                                        .font(.system(size: 14, design: .monospaced))
+                                        .font(.scalableMonospaced(size: 14))
                                         .foregroundColor(peerNicknames[peer.id] != nil ? textColor : secondaryTextColor)
                                     
                                     // Encryption status icon (after peer name)
@@ -815,7 +815,7 @@ struct ContentView: View {
     private var mainHeaderView: some View {
         HStack(spacing: 0) {
             Text("bitchat/")
-                .font(.system(size: 18, weight: .medium, design: .monospaced))
+                .font(.scalableMonospaced(size: 18, weight: .medium))
                 .foregroundColor(textColor)
                 .onTapGesture(count: 3) {
                     // PANIC: Triple-tap to clear all data
@@ -828,12 +828,12 @@ struct ContentView: View {
             
             HStack(spacing: 0) {
                 Text("@")
-                    .font(.system(size: 14, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14))
                     .foregroundColor(secondaryTextColor)
                 
                 TextField("nickname", text: $viewModel.nickname)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 14, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14))
                     .frame(maxWidth: 100)
                     .foregroundColor(textColor)
                     .focused($isNicknameFieldFocused)
@@ -871,7 +871,7 @@ struct ContentView: View {
                         .font(.system(size: 11))
                         .accessibilityLabel("\(otherPeersCount) connected \(otherPeersCount == 1 ? "person" : "people")")
                     Text("\(otherPeersCount)")
-                        .font(.system(size: 12, design: .monospaced))
+                        .font(.scalableMonospaced(size: 12))
                         .accessibilityHidden(true)
                 }
                 .foregroundColor(viewModel.isConnected ? textColor : Color.red)
@@ -903,7 +903,7 @@ struct ContentView: View {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 12))
                             Text("back")
-                                .font(.system(size: 14, design: .monospaced))
+                                .font(.scalableMonospaced(size: 14))
                         }
                         .foregroundColor(textColor)
                     }
@@ -917,7 +917,7 @@ struct ContentView: View {
                     }) {
                         HStack(spacing: 6) {
                             Text("\(privatePeerNick)")
-                                .font(.system(size: 16, weight: .medium, design: .monospaced))
+                                .font(.scalableMonospaced(size: 16, weight: .medium))
                                 .foregroundColor(Color.orange)
                             // Dynamic encryption status icon
                             let encryptionStatus = viewModel.getEncryptionStatus(for: privatePeerID)
@@ -999,16 +999,16 @@ struct MessageContentView: View {
             if segment.type == "hashtag" {
                 // Note: We can't have clickable links in concatenated Text, so hashtags won't be clickable
                 result = result + Text(segment.text)
-                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14, weight: .semibold))
                     .foregroundColor(Color.blue)
                     .underline()
             } else if segment.type == "mention" {
                 result = result + Text(segment.text)
-                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14, weight: .semibold))
                     .foregroundColor(Color.orange)
             } else {
                 result = result + Text(segment.text)
-                    .font(.system(size: 14, design: .monospaced))
+                    .font(.scalableMonospaced(size: 14))
                     .fontWeight(isMentioned ? .bold : .regular)
             }
         }
@@ -1133,7 +1133,7 @@ struct DeliveryStatusView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10))
                 Text("\(reached)/\(total)")
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.scalableMonospaced(size: 10))
             }
             .foregroundColor(secondaryTextColor.opacity(0.6))
             .help("Delivered to \(reached) of \(total) members")

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -27,7 +27,7 @@ struct FingerprintView: View {
             // Header
             HStack {
                 Text("SECURITY VERIFICATION")
-                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .font(.scalableMonospaced(size: 16, weight: .bold))
                     .foregroundColor(textColor)
                 
                 Spacer()
@@ -53,11 +53,11 @@ struct FingerprintView: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(peerNickname)
-                            .font(.system(size: 18, weight: .semibold, design: .monospaced))
+                            .font(.scalableMonospaced(size: 18, weight: .semibold))
                             .foregroundColor(textColor)
                         
                         Text(encryptionStatus.description)
-                            .font(.system(size: 12, design: .monospaced))
+                            .font(.scalableMonospaced(size: 12))
                             .foregroundColor(textColor.opacity(0.7))
                     }
                     
@@ -70,12 +70,12 @@ struct FingerprintView: View {
                 // Their fingerprint
                 VStack(alignment: .leading, spacing: 8) {
                     Text("THEIR FINGERPRINT:")
-                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 12, weight: .bold))
                         .foregroundColor(textColor.opacity(0.7))
                     
                     if let fingerprint = viewModel.getFingerprint(for: peerID) {
                         Text(formatFingerprint(fingerprint))
-                            .font(.system(size: 14, design: .monospaced))
+                            .font(.scalableMonospaced(size: 14))
                             .foregroundColor(textColor)
                             .multilineTextAlignment(.leading)
                             .lineLimit(nil)
@@ -96,7 +96,7 @@ struct FingerprintView: View {
                             }
                     } else {
                         Text("not available - handshake in progress")
-                            .font(.system(size: 14, design: .monospaced))
+                            .font(.scalableMonospaced(size: 14))
                             .foregroundColor(Color.orange)
                             .padding()
                     }
@@ -105,12 +105,12 @@ struct FingerprintView: View {
                 // My fingerprint
                 VStack(alignment: .leading, spacing: 8) {
                     Text("YOUR FINGERPRINT:")
-                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 12, weight: .bold))
                         .foregroundColor(textColor.opacity(0.7))
                     
                     let myFingerprint = viewModel.getMyFingerprint()
                     Text(formatFingerprint(myFingerprint))
-                        .font(.system(size: 14, design: .monospaced))
+                        .font(.scalableMonospaced(size: 14))
                         .foregroundColor(textColor)
                         .multilineTextAlignment(.leading)
                         .lineLimit(nil)
@@ -137,14 +137,14 @@ struct FingerprintView: View {
                     
                     VStack(spacing: 12) {
                         Text(isVerified ? "✓ VERIFIED" : "⚠️ NOT VERIFIED")
-                            .font(.system(size: 14, weight: .bold, design: .monospaced))
+                            .font(.scalableMonospaced(size: 14, weight: .bold))
                             .foregroundColor(isVerified ? Color.green : Color.orange)
                             .frame(maxWidth: .infinity)
                         
                         Text(isVerified ? 
                              "you have verified this person's identity." :
                              "compare these fingerprints with \(peerNickname) using a secure channel.")
-                            .font(.system(size: 12, design: .monospaced))
+                            .font(.scalableMonospaced(size: 12))
                             .foregroundColor(textColor.opacity(0.7))
                             .multilineTextAlignment(.center)
                             .lineLimit(nil)
@@ -157,7 +157,7 @@ struct FingerprintView: View {
                                 dismiss()
                             }) {
                                 Text("MARK AS VERIFIED")
-                                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                                    .font(.scalableMonospaced(size: 14, weight: .bold))
                                     .foregroundColor(.white)
                                     .padding(.horizontal, 20)
                                     .padding(.vertical, 10)

--- a/bitchat/Views/Fonts.swift
+++ b/bitchat/Views/Fonts.swift
@@ -1,0 +1,67 @@
+//
+//  Fonts.swift
+//  bitchat
+//
+//  Created by Tim Johnsen on 7/29/25.
+//
+
+import UIKit
+import SwiftUI
+
+extension Font {
+    static func scalableMonospaced(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        relativeTo textStyle: Font.TextStyle = .caption
+    ) -> Font {
+#if os(iOS)
+        let baseFont = UIFont.monospacedSystemFont(ofSize: size, weight: weight.toUIFontWeight())
+        let scaledFont = UIFontMetrics(forTextStyle: textStyle.toUIFontTextStyle())
+            .scaledFont(for: baseFont)
+        return Font(scaledFont)
+#else
+        // macOS: dynamic type isn't supported the same way, return plain monospaced font
+        return .system(size: size, weight: weight, design: .monospaced)
+#endif
+    }
+}
+
+#if os(iOS)
+import UIKit
+
+private extension Font.Weight {
+    func toUIFontWeight() -> UIFont.Weight {
+        switch self {
+        case .ultraLight: return .ultraLight
+        case .thin: return .thin
+        case .light: return .light
+        case .regular: return .regular
+        case .medium: return .medium
+        case .semibold: return .semibold
+        case .bold: return .bold
+        case .heavy: return .heavy
+        case .black: return .black
+        default: return .regular
+        }
+    }
+}
+
+private extension Font.TextStyle {
+    func toUIFontTextStyle() -> UIFont.TextStyle {
+        switch self {
+        case .largeTitle: return .largeTitle
+        case .title: return .title1
+        case .title2: return .title2
+        case .title3: return .title3
+        case .headline: return .headline
+        case .subheadline: return .subheadline
+        case .body: return .body
+        case .callout: return .callout
+        case .footnote: return .footnote
+        case .caption: return .caption1
+        case .caption2: return .caption2
+        @unknown default: return .body
+        }
+    }
+}
+#endif

--- a/bitchat/Views/LinkPreviewView.swift
+++ b/bitchat/Views/LinkPreviewView.swift
@@ -177,13 +177,13 @@ struct LinkPreviewView: View {
                     // Title
                     #if os(iOS)
                     Text(cachedTitle ?? metadata?.title ?? title ?? url.host ?? "Link")
-                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 14, weight: .semibold))
                         .foregroundColor(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     #else
                     Text(title ?? url.host ?? "Link")
-                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 14, weight: .semibold))
                         .foregroundColor(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
@@ -192,12 +192,12 @@ struct LinkPreviewView: View {
                     // Host
                     #if os(iOS)
                     Text(cachedHost ?? url.host ?? url.absoluteString)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(.scalableMonospaced(size: 11))
                         .foregroundColor(textColor.opacity(0.6))
                         .lineLimit(1)
                     #else
                     Text(url.host ?? url.absoluteString)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(.scalableMonospaced(size: 11))
                         .foregroundColor(textColor.opacity(0.6))
                         .lineLimit(1)
                     #endif
@@ -237,14 +237,14 @@ struct LinkPreviewView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     // Title
                     Text(title ?? url.host ?? "Link")
-                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .font(.scalableMonospaced(size: 14, weight: .semibold))
                         .foregroundColor(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     
                     // URL
                     Text(url.absoluteString)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(.scalableMonospaced(size: 11))
                         .foregroundColor(Color.blue)
                         .lineLimit(1)
                         .truncationMode(.middle)


### PR DESCRIPTION
I have very bad eye sight and the fonts currently used in bitchat are a bit hard to read. This PR implements basic dynamic type support, all the existing fonts are scaled up using the `.body` text style.

|Before|After|
|--|--|
|![](https://github.com/user-attachments/assets/b403cdd6-f8ca-49bb-aa66-66057ca549be)|![](https://github.com/user-attachments/assets/330c4a6d-ae3e-460a-8e7d-4d23845f619f)|
|![](https://github.com/user-attachments/assets/61aced5e-a685-4368-b953-46b1bf294c0e)|![](https://github.com/user-attachments/assets/ed2a24e1-5414-4be9-a3f9-b9841d3b8d95)|
