### PR TITLE
Disable sharing images via extension.

### DIFF
--- a/bitchatShareExtension/Info.plist
+++ b/bitchatShareExtension/Info.plist
@@ -26,8 +26,6 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>


### PR DESCRIPTION
I noticed sharing images via bitchat's share extension seemed supported this morning, but when I tried it nothing happened. This PR removes the flag that enables sharing of images via the share extension.

This _may_ require an xcodegen change too, haven't used the tool before so not sure at the moment!