### PR TITLE
Fix crash when sending a URL containing @mention.

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2937,6 +2937,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             for (range, type) in allMatches {
                 // Add text before match
                 if let nsRange = Range(range, in: content) {
+                    if lastEnd > nsRange.lowerBound { continue }
                     let beforeText = String(content[lastEnd..<nsRange.lowerBound])
                     if !beforeText.isEmpty {
                         var beforeStyle = AttributeContainer()

--- a/bitchatTests/ViewModels/ChatViewModelTests.swift
+++ b/bitchatTests/ViewModels/ChatViewModelTests.swift
@@ -1,0 +1,43 @@
+//
+// ChatViewModelTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import XCTest
+@testable import bitchat
+
+@MainActor
+final class ChatViewModelTests: XCTestCase {
+    private let sut = ChatViewModel()
+
+    func testFormattingMessageAsTextWithAtInUrl() {
+        let content = "https://www.example.com/@mention"
+        let message = BitchatMessage(
+            id: "",
+            sender: "me",
+            content: content,
+            timestamp: .from(string: "21:37:00")!,
+            isRelay: false,
+            originalSender: nil,
+            isPrivate: false,
+            recipientNickname: nil,
+            senderPeerID: nil,
+            mentions: nil
+        )
+        let attributed = sut.formatMessageAsText(message, colorScheme: .light)
+        let string = String(attributed.characters)
+        XCTAssertEqual(string, "<@me> https://www.example.com/@mention [21:37:00]")
+    }
+}
+
+private extension Date {
+    static func from(string: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+
+        return formatter.date(from: string)
+    }
+}


### PR DESCRIPTION
crashing url: https://www.npmjs.com/package/@capacitor/text-zoom
Screenshot:
<img width="2384" height="944" alt="crash" src="https://github.com/user-attachments/assets/d2ed59f4-8289-46ec-a5e4-49d25cccb63e" />

Evidence that the test passes:
<img width="1318" height="778" alt="evidence" src="https://github.com/user-attachments/assets/0b209b91-66f4-41e3-8538-c902d5c2a956" />

It fixes an issue mentioned in a comment in #348.