### PR TITLE
Add IRC-style “cover traffic” switch to BitChat interface

### DIFF
--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -488,6 +488,7 @@ class BluetoothMeshService: NSObject {
     private var coverTrafficTimer: Timer?
     private let coverTrafficPrefix = "☂DUMMY☂"  // Prefix to identify dummy messages after decryption
     private var lastCoverTrafficTime = Date()
+    private var isCoverTrafficEnabled = false
     
     // MARK: - Connection State
     
@@ -1354,10 +1355,7 @@ class BluetoothMeshService: NSObject {
         // Setup battery optimizer
         setupBatteryOptimizer()
         
-        // Start cover traffic for privacy (disabled by default for now)
-        // TODO: Make this configurable in settings
-        let coverTrafficEnabled = true
-        if coverTrafficEnabled {
+        if isCoverTrafficEnabled {
             SecureLogger.log("Cover traffic enabled", category: SecureLogger.security, level: .info)
             startCoverTraffic()
         }
@@ -4912,7 +4910,22 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
     }
     
     // MARK: - Cover Traffic
-    
+
+    func setCoverTrafficEnabled(_ enabled: Bool) {
+        if enabled {
+            guard !isCoverTrafficEnabled else { return }
+            isCoverTrafficEnabled = true
+            SecureLogger.log("Cover traffic enabled", category: SecureLogger.security, level: .info)
+            startCoverTraffic()
+        } else {
+            guard isCoverTrafficEnabled else { return }
+            isCoverTrafficEnabled = false
+            SecureLogger.log("Cover traffic disabled", category: SecureLogger.security, level: .info)
+            coverTrafficTimer?.invalidate()
+            coverTrafficTimer = nil
+        }
+    }
+
     private func startCoverTraffic() {
         // Start cover traffic with random interval
         scheduleCoverTraffic()

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -137,6 +137,15 @@ class ChatViewModel: ObservableObject {
     var meshService = BluetoothMeshService()
     private let userDefaults = UserDefaults.standard
     private let nicknameKey = "bitchat.nickname"
+    private let coverTrafficKey = "bitchat.coverTrafficEnabled"
+
+    @Published var coverTrafficEnabled: Bool = false {
+        didSet {
+            userDefaults.set(coverTrafficEnabled, forKey: coverTrafficKey)
+            userDefaults.synchronize()
+            meshService.setCoverTrafficEnabled(coverTrafficEnabled)
+        }
+    }
     
     // MARK: - Caches
     
@@ -174,6 +183,7 @@ class ChatViewModel: ObservableObject {
         loadFavorites()
         loadBlockedUsers()
         loadVerifiedFingerprints()
+        loadCoverTrafficSetting()
         meshService.delegate = self
         
         // Log startup info
@@ -187,6 +197,7 @@ class ChatViewModel: ObservableObject {
         
         // Start mesh service immediately
         meshService.startServices()
+        meshService.setCoverTrafficEnabled(coverTrafficEnabled)
         
         // Set up message retry service
         MessageRetryService.shared.meshService = meshService
@@ -332,6 +343,14 @@ class ChatViewModel: ObservableObject {
     private func saveBlockedUsers() {
         // Blocked users are now saved automatically in SecureIdentityStateManager
         // This method is kept for compatibility
+    }
+
+    private func loadCoverTrafficSetting() {
+        if userDefaults.object(forKey: coverTrafficKey) != nil {
+            coverTrafficEnabled = userDefaults.bool(forKey: coverTrafficKey)
+        } else {
+            coverTrafficEnabled = false
+        }
     }
     
     

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -287,4 +287,5 @@ struct IRCToggle: View {
 
 #Preview {
     AppInfoView()
+        .environmentObject(ChatViewModel())
 }

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AppInfoView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var viewModel: ChatViewModel
     
     private var backgroundColor: Color {
         colorScheme == .dark ? Color.black : Color.white
@@ -51,6 +52,11 @@ struct AppInfoView: View {
         enum Warning {
             static let title = "WARNING"
             static let message = "private message security has not yet been fully audited. do not use for critical situations until this warning disappears."
+        }
+
+        enum Settings {
+            static let title = "SETTINGS"
+            static let coverTraffic = "cover traffic"
         }
     }
     
@@ -164,6 +170,14 @@ struct AppInfoView: View {
                 .font(.system(size: 14, design: .monospaced))
                 .foregroundColor(textColor)
             }
+
+            // Settings
+            VStack(alignment: .leading, spacing: 16) {
+                SectionHeader(Strings.Settings.title)
+
+                IRCToggle(title: Strings.Settings.coverTraffic, isOn: $viewModel.coverTrafficEnabled)
+
+            }
             
             // Warning
             VStack(alignment: .leading, spacing: 6) {
@@ -241,6 +255,33 @@ struct FeatureRow: View {
             
             Spacer()
         }
+    }
+}
+
+struct IRCToggle: View {
+    let title: String
+    @Binding var isOn: Bool
+    @Environment(\.colorScheme) var colorScheme
+    
+    private var textColor: Color {
+        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
+    }
+    
+    var body: some View {
+        Button(action: { isOn.toggle() }) {
+            HStack(spacing: 8) {
+                Text(isOn ? "[X]" : "[ ]")
+                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                    .foregroundColor(textColor)
+                
+                Text(title)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(textColor)
+                
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -182,6 +182,7 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showAppInfo) {
             AppInfoView()
+                .environmentObject(viewModel)
         }
         .sheet(isPresented: Binding(
             get: { viewModel.showingFingerprintFor != nil },


### PR DESCRIPTION
**Closes:** TODO at [line 1358 of BluetoothMeshService.swift](https://github.com/permissionlesstech/bitchat/blob/a438c4681708891be260776839df67db1733c376/bitchat/Services/BluetoothMeshService.swift#L1358)

### What's new

**1. Cover Traffic Toggle**
A switch that, when enabled, injects dummy messages to help obscure real conversation patterns.

**2. Persistent Setting**
The toggle state is saved across app launches, so you don't need to re-enable it every time you open BitChat.

**3. Reusable IRCToggle Component**
A new IRC-inspired SwiftUI element that can be dropped in for future preferences, styled to match BitChat’s aesthetic. I think it looks quite stylish.

### Preview

<img width="166" height="74" alt="image" src="https://github.com/user-attachments/assets/daa212f3-8e24-4037-8cb8-ea2935356003" />
<img width="166" height="74" alt="image" src="https://github.com/user-attachments/assets/8ae527f1-162f-4ecb-9edc-6f0869fe45f9" />

<img width="166" height="74" alt="image" src="https://github.com/user-attachments/assets/0580e6dd-859a-4f4b-9d61-35168abbf596" />
<img width="166" height="74" alt="image" src="https://github.com/user-attachments/assets/1a746535-680b-4ecb-9121-e656ea74c8fe" />

**Tested on:**
- MacOS 26 Tahoe
- iOS 18.1.1