### PR TITLE
Adds swift-secp256k1 to project.yml

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -9,6 +9,11 @@ options:
 settings:
   MARKETING_VERSION: 1.0.0
   CURRENT_PROJECT_VERSION: 1
+
+packages:
+  P256K:
+    url: https://github.com/21-DOT-DEV/swift-secp256k1
+    majorVersion: 0.21.1
   
 targets:
   bitchat_iOS:
@@ -62,6 +67,7 @@ targets:
     dependencies:
       - target: bitchatShareExtension
         embed: true
+      - package: P256K
         
   bitchat_macOS:
     type: application
@@ -104,7 +110,9 @@ targets:
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS: YES
       CODE_SIGN_ENTITLEMENTS: bitchat/bitchat-macOS.entitlements
-        
+    dependencies:
+      - package: P256K
+
   bitchatShareExtension:
     type: app-extension
     platform: iOS


### PR DESCRIPTION
`just run` does not work right now because `swift-secp256k1` is not specified in `project.yml`. This PR fixes it