### PR TITLE
Fully implement personal names (petnames)

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -375,6 +375,59 @@ class ChatViewModel: ObservableObject {
         return SecureIdentityStateManager.shared.isFavorite(fingerprint: fp)
     }
     
+    // MARK: - Petname Management
+    
+    func setPetname(peerID: String, petname: String?) {
+        // First try to get fingerprint from mesh service (supports peer ID rotation)
+        var fingerprint: String? = meshService.getFingerprint(for: peerID)
+        
+        // Fallback to local mapping if not found in mesh service
+        if fingerprint == nil {
+            fingerprint = peerIDToPublicKeyFingerprint[peerID]
+        }
+        
+        guard let fp = fingerprint else {
+            return
+        }
+        
+        // Get existing social identity or create new one
+        var identity = SecureIdentityStateManager.shared.getSocialIdentity(for: fp) ?? SocialIdentity(
+            fingerprint: fp,
+            localPetname: nil,
+            claimedNickname: meshService.getPeerNicknames()[peerID] ?? "Unknown",
+            trustLevel: .unknown,
+            isFavorite: false,
+            isBlocked: false,
+            notes: nil
+        )
+        
+        // Update petname
+        identity.localPetname = petname?.isEmpty == true ? nil : petname
+        
+        // Save the updated identity
+        SecureIdentityStateManager.shared.updateSocialIdentity(identity)
+    }
+    
+    func getPetname(peerID: String) -> String? {
+        // First try to get fingerprint from mesh service (supports peer ID rotation)
+        var fingerprint: String? = meshService.getFingerprint(for: peerID)
+        
+        // Fallback to local mapping if not found in mesh service
+        if fingerprint == nil {
+            fingerprint = peerIDToPublicKeyFingerprint[peerID]
+        }
+        
+        guard let fp = fingerprint else {
+            return nil
+        }
+        
+        return SecureIdentityStateManager.shared.getSocialIdentity(for: fp)?.localPetname
+    }
+    
+    func clearPetname(peerID: String) {
+        setPetname(peerID: peerID, petname: nil)
+    }
+    
     // MARK: - Public Key and Identity Management
     
     // Called when we receive a peer's public key
@@ -1230,8 +1283,9 @@ class ChatViewModel: ObservableObject {
         result.append(timestamp.mergingAttributes(timestampStyle))
         
         if message.sender != "system" {
-            // Sender
-            let sender = AttributedString("<@\(message.sender)> ")
+            // Sender - use display name (petname if available)
+            let displayName = message.senderPeerID != nil ? resolveNickname(for: message.senderPeerID!) : message.sender
+            let sender = AttributedString("<@\(displayName)> ")
             var senderStyle = AttributeContainer()
             
             // Use consistent color for all senders
@@ -1354,7 +1408,9 @@ class ChatViewModel: ObservableObject {
             contentStyle.font = .system(size: 12, design: .monospaced).italic()
             result.append(content.mergingAttributes(contentStyle))
         } else {
-            let sender = AttributedString("<\(message.sender)> ")
+            // Sender - use display name (petname if available)
+            let displayName = message.senderPeerID != nil ? resolveNickname(for: message.senderPeerID!) : message.sender
+            let sender = AttributedString("<\(displayName)> ")
             var senderStyle = AttributeContainer()
             
             // Use consistent color for all senders
@@ -1682,13 +1738,19 @@ class ChatViewModel: ObservableObject {
             return peerID
         }
         
-        // First try direct peer nicknames from mesh service
+        // First try direct peer nicknames from mesh service (claimed names)
         let peerNicknames = meshService.getPeerNicknames()
         if let nickname = peerNicknames[peerID] {
+            // Check if we have a petname for this peer (only if we have fingerprint)
+            if let fingerprint = getFingerprint(for: peerID),
+               let identity = SecureIdentityStateManager.shared.getSocialIdentity(for: fingerprint),
+               let petname = identity.localPetname {
+                return petname
+            }
             return nickname
         }
         
-        // Try to resolve through fingerprint and social identity
+        // Fallback: try to resolve through fingerprint and social identity
         if let fingerprint = getFingerprint(for: peerID) {
             if let identity = SecureIdentityStateManager.shared.getSocialIdentity(for: fingerprint) {
                 // Prefer local petname if set

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1283,8 +1283,14 @@ class ChatViewModel: ObservableObject {
         result.append(timestamp.mergingAttributes(timestampStyle))
         
         if message.sender != "system" {
-            // Sender - use display name (petname if available)
-            let displayName = message.senderPeerID != nil ? resolveNickname(for: message.senderPeerID!) : message.sender
+            // Sender - use display name (petname if available), but always use actual nickname for ourselves
+            let displayName = if message.sender == nickname {
+                nickname
+            } else if let senderPeerID = message.senderPeerID {
+                resolveNickname(for: senderPeerID)
+            } else {
+                message.sender
+            }
             let sender = AttributedString("<@\(displayName)> ")
             var senderStyle = AttributeContainer()
             
@@ -1408,8 +1414,14 @@ class ChatViewModel: ObservableObject {
             contentStyle.font = .system(size: 12, design: .monospaced).italic()
             result.append(content.mergingAttributes(contentStyle))
         } else {
-            // Sender - use display name (petname if available)
-            let displayName = message.senderPeerID != nil ? resolveNickname(for: message.senderPeerID!) : message.sender
+            // Sender - use display name (petname if available), but always use actual nickname for ourselves
+            let displayName = if message.sender == nickname {
+                nickname  
+            } else if let senderPeerID = message.senderPeerID {
+                resolveNickname(for: senderPeerID)
+            } else {
+                message.sender
+            }
             let sender = AttributedString("<\(displayName)> ")
             var senderStyle = AttributeContainer()
             

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -14,6 +14,9 @@ struct FingerprintView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
     
+    @State private var petnameText: String = ""
+    @FocusState private var isPetnameFieldFocused: Bool
+    
     private var textColor: Color {
         colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
     }
@@ -66,6 +69,61 @@ struct FingerprintView: View {
                 .padding()
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
+                
+                // Petname management
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("PERSONAL NAME:")
+                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .foregroundColor(textColor.opacity(0.7))
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            TextField("enter a name for this person", text: $petnameText)
+                                .textFieldStyle(.plain)
+                                .font(.system(size: 14, design: .monospaced))
+                                .foregroundColor(textColor)
+                                .focused($isPetnameFieldFocused)
+                                .autocorrectionDisabled(true)
+                                #if os(iOS)
+                                .textInputAutocapitalization(.never)
+                                #endif
+                                .onSubmit {
+                                    viewModel.setPetname(peerID: peerID, petname: petnameText.isEmpty ? nil : petnameText)
+                                }
+                                .onChange(of: petnameText) { newValue in
+                                    // Auto-save as user types (debounced)
+                                    viewModel.setPetname(peerID: peerID, petname: newValue.isEmpty ? nil : newValue)
+                                }
+                            
+                            if !petnameText.isEmpty || viewModel.getPetname(peerID: peerID) != nil {
+                                Button("CLEAR") {
+                                    petnameText = ""
+                                    viewModel.clearPetname(peerID: peerID)
+                                }
+                                .font(.system(size: 12, weight: .bold, design: .monospaced))
+                                .foregroundColor(Color.red)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color.red.opacity(0.1))
+                                .cornerRadius(6)
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        
+                        Text("claimed name: \(peerNickname)")
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(textColor.opacity(0.6))
+                        
+                        Text("this personal name is stored locally and only you can see it. it will persist even if they change their claimed name or peer id.")
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundColor(textColor.opacity(0.5))
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
+                }
                 
                 // Their fingerprint
                 VStack(alignment: .leading, spacing: 8) {
@@ -181,6 +239,10 @@ struct FingerprintView: View {
         .background(backgroundColor)
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
+        .onAppear {
+            // Initialize petname text field with existing petname
+            petnameText = viewModel.getPetname(peerID: peerID) ?? ""
+        }
     }
     
     private func formatFingerprint(_ fingerprint: String) -> String {


### PR DESCRIPTION
### Description
---
Bitchat seems to have been designed with the idea of personal names (petnames) that you can assign to users. There's evidence of it in the `SocialIdentity` struct amongst other places, but it was never fully implemented. This PR completes personal names by filling in all missing GUI components and code required.


### Verification Evidence
---
My iPhone is `kevin_ios` and my Macbook is `anon42`. Screenshot from my phone before adding personal name:
![IMG_4915](https://github.com/user-attachments/assets/341a7c5d-1411-48bc-8dcf-ee999164b64b)

New input box has been added to assign a personal name to a contact:
![IMG_4917](https://github.com/user-attachments/assets/66cfbc8f-44ee-471f-a724-ca7c070ad3d7)

Personal name takes hold after saving (you can see in both the chat title and message):
![IMG_4918](https://github.com/user-attachments/assets/3fdcef78-3565-4bc7-9bd5-50b77a82653b)

As well as in public chats:
![IMG_4919](https://github.com/user-attachments/assets/ef4528f1-2657-4e53-b436-3011c08d001b)

Finally in the contacts list, you see them by their personal name, but also see their 'claimed' nickname:
![IMG_4920](https://github.com/user-attachments/assets/adf45004-5429-448d-a4a2-dfff852fd135)

### Fixes
---
This PR likely fixes a number of issues (such as https://github.com/permissionlesstech/bitchat/issues/370) and helps improve the identity system of bitchat a bit, which is right now a spaghetti mess.