### PR TITLE
Fix iOS background Bluetooth connectivity

### DIFF
--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -40,6 +40,7 @@
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 		<string>remote-notification</string>
+		<string>background-processing</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/bitchat/Utils/BatteryOptimizer.swift
+++ b/bitchat/Utils/BatteryOptimizer.swift
@@ -184,13 +184,15 @@ class BatteryOptimizer {
             // When charging, use performance mode unless battery is critical
             currentPowerMode = batteryLevel < 0.1 ? .balanced : .performance
         } else if isInBackground {
-            // In background, always use power saving
-            if batteryLevel < 0.2 {
+            // In background, be less aggressive with power management
+            // Don't force ultra-low power mode until battery is below 10%
+            // Use balanced mode in background above 30% battery
+            if batteryLevel < 0.1 {
                 currentPowerMode = .ultraLowPower
-            } else if batteryLevel < 0.5 {
+            } else if batteryLevel < 0.3 {
                 currentPowerMode = .powerSaver
             } else {
-                currentPowerMode = .balanced
+                currentPowerMode = .balanced  // Use balanced mode above 30% in background
             }
         } else {
             // Foreground, not charging


### PR DESCRIPTION
## Summary
Comprehensive fixes for iOS background Bluetooth connectivity issues. The app now maintains mesh connectivity when backgrounded instead of losing all Bluetooth functionality.

## Problem
Users reported that "the phone doesn't seem like it's using bluetooth in the background" and mesh connectivity was lost until the app was brought back to foreground.

## Root Causes Identified
1. No Core Bluetooth state restoration
2. Aggressive scan duty cycling (89-97% pause time in background)
3. No background task protection
4. Overly aggressive battery optimization
5. Missing background/foreground state notifications

## Changes
- **Core Bluetooth State Restoration**: Added restoration identifiers and delegate methods
- **Background Task Management**: Protected critical operations with background tasks
- **Fixed Battery Optimization**: Less aggressive in background (balanced mode >30% battery)
- **Fixed Scan Duty Cycling**: Continuous scanning in background vs duty-cycled foreground
- **Proper State Handling**: Added didEnterBackground/willEnterForeground observers
- **Smart Advertising**: Only stops at <10% battery (was 20%)
- **Info.plist**: Added background-processing entitlement
- **Optimized Scanning**: AllowDuplicates=false in background for efficiency

## Technical Details
The most critical fix was disabling scan duty cycling in background. The app was pausing scanning for 8-20 seconds at a time, during which iOS would suspend it completely. Now uses continuous scanning with battery-efficient parameters.

State restoration ensures Core Bluetooth can resume operations after iOS terminates the app in background.

## Testing
- [x] Builds successfully with xcodebuild
- [ ] Maintains mesh connectivity in background
- [ ] Receives messages while backgrounded
- [ ] Resumes properly after termination
- [ ] Battery usage acceptable