### PR TITLE
Assign custom contact names

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -246,6 +246,7 @@ struct ContentView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(viewModel.bluetoothAlertMessage)
+        }
         .onChange(of: isPetnameFieldFocused) { isFocused in
             if !isFocused && editingPetnameForPeer != nil {
                 // Cancel petname editing when focus is lost


### PR DESCRIPTION
### Description
---
Bitchat seems to have been designed with the idea of personal/custom contact names ('petnames' in source code) that you can assign to users, but it was never fully implemented. This PR completes personal/custom contact names by filling in all missing GUI components and code required.

### Fixes
---
This fixes https://github.com/permissionlesstech/bitchat/issues/370 and at a minimum helps improve Bitchat identity which is a bit messy.


### Verification Evidence
---
My iphone is `kevin_ios`. My macbook starts out as `anon42ab`, and I assign the contact name `kevin_macos`.

Before adding contact name:

<img src="https://github.com/user-attachments/assets/acb6ff89-8b0c-48a2-9f07-9549100071cd" width=50% height=50%>


New GUI element in contact dialog to modify personal contact name:

<img src="https://github.com/user-attachments/assets/15e46c3d-71aa-4178-88bc-5cad6eae4d3f" width=50% height=50%>


DM screen now shows contact name at the top and in chat:

<img src="https://github.com/user-attachments/assets/787fe283-dc47-4bf7-9245-8e2d51d2f28e" width=50% height=50%>


Custom contact name is correct in public chat too:

<img src="https://github.com/user-attachments/assets/1c9403bd-caaf-45a5-b726-8ec53d2cf0d9" width=50% height=50%>


Custom contact name can also be modified by long-pressing contact in contacts list. I change the name to `kevin_xyz` just to demo:

<img src="https://github.com/user-attachments/assets/490bb907-f99b-424d-913f-3cbe87e7e0b3" width=50% height=50%>


Still looks right in public chat:

<img src="https://github.com/user-attachments/assets/6cf8fd80-2367-4389-be97-4c27f47a30cd" width=50% height=50%>


I change my claimed nickname to `anon21` on my macbook, which reflects on my iPhone but custom contact name still takes precedence:

<img src="https://github.com/user-attachments/assets/209a9132-dca2-418b-a590-c27ba3adf1d8" width=50% height=50%>

