### PR TITLE
Add Bluetooth status alerts

### DIFF
--- a/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat/Services/BluetoothMeshService.swift
@@ -1937,6 +1937,15 @@ class BluetoothMeshService: NSObject {
         cleanupStaleSessions()
         cleanupUnknownPeers()
         
+        // Report initial Bluetooth state to delegate
+        if let chatViewModel = delegate as? ChatViewModel {
+            // Use the central manager state as primary indicator
+            let currentState = centralManager?.state ?? .unknown
+            Task { @MainActor in
+                chatViewModel.updateBluetoothState(currentState)
+            }
+        }
+        
         // Starting services
         // Start both central and peripheral services
         if centralManager?.state == .poweredOn {
@@ -4988,6 +4997,13 @@ extension BluetoothMeshService: CBCentralManagerDelegate {
         @unknown default: break
         }
         
+        // Notify ChatViewModel of Bluetooth state change
+        if let chatViewModel = delegate as? ChatViewModel {
+            Task { @MainActor in
+                chatViewModel.updateBluetoothState(central.state)
+            }
+        }
+        
         if central.state == .unsupported {
         } else if central.state == .unauthorized {
         } else if central.state == .poweredOff {
@@ -5538,6 +5554,13 @@ extension BluetoothMeshService: CBPeripheralManagerDelegate {
         case .poweredOff: break
         case .poweredOn: break
         @unknown default: break
+        }
+        
+        // Notify ChatViewModel of Bluetooth state change
+        if let chatViewModel = delegate as? ChatViewModel {
+            Task { @MainActor in
+                chatViewModel.updateBluetoothState(peripheral.state)
+            }
         }
         
         switch peripheral.state {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -7,6 +7,9 @@
 //
 
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 // MARK: - Supporting Types
 
@@ -226,6 +229,18 @@ struct ContentView: View {
             }
             
             Button("cancel", role: .cancel) {}
+        }
+        .alert("Bluetooth Required", isPresented: $viewModel.showBluetoothAlert) {
+            Button("Settings") {
+                #if os(iOS)
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+                #endif
+            }
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.bluetoothAlertMessage)
         }
         .onDisappear {
             // Clean up timers


### PR DESCRIPTION
## Summary
- Added alerts to notify users when Bluetooth is disabled or unauthorized
- Implemented real-time Bluetooth state monitoring
- Added Settings button for easy access to system Bluetooth settings

## Changes
- **ChatViewModel**: Added Bluetooth state management and alert properties
- **BluetoothMeshService**: Reports Bluetooth state changes to the view model
- **ContentView**: Shows alert dialog with appropriate messages based on Bluetooth state

## Test plan
- [ ] Launch app with Bluetooth turned off - verify alert appears
- [ ] Turn on Bluetooth while app is running - verify alert dismisses
- [ ] Test with Bluetooth permission denied - verify appropriate message
- [ ] Test Settings button opens system settings (iOS)
- [ ] Verify no alerts shown when Bluetooth is enabled