### PR TITLE
Remove connection/disconnection system messages

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -3205,21 +3205,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         // Register ephemeral session with identity manager
         SecureIdentityStateManager.shared.registerEphemeralSession(peerID: peerID)
         
-        // Resolve nickname using helper
-        let displayName = resolveNickname(for: peerID)
-        
-        // Ensure we have a valid display name
-        let finalDisplayName = displayName.isEmpty ? "peer" : displayName
-        
-        let systemMessage = BitchatMessage(
-            sender: "system",
-            content: "\(finalDisplayName) connected",
-            timestamp: Date(),
-            isRelay: false,
-            originalSender: nil
-        )
-        // Add system message
-        addMessage(systemMessage)
+        // Connection messages removed to reduce chat noise
     }
     
     func didDisconnectFromPeer(_ peerID: String) {
@@ -3237,21 +3223,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             }
         }
         
-        // Resolve nickname using helper
-        let displayName = resolveNickname(for: peerID)
-        
-        // Ensure we have a valid display name
-        let finalDisplayName = displayName.isEmpty ? "peer" : displayName
-        
-        let systemMessage = BitchatMessage(
-            sender: "system",
-            content: "\(finalDisplayName) disconnected",
-            timestamp: Date(),
-            isRelay: false,
-            originalSender: nil
-        )
-        // Add system message
-        addMessage(systemMessage)
+        // Disconnection messages removed to reduce chat noise
     }
     
     func didUpdatePeerList(_ peers: [String]) {


### PR DESCRIPTION
## Summary
- Removed system messages that announce when peers connect/disconnect from public chat
- These messages were creating too much noise in the chat

## Changes
- Removed system message generation from `didConnectToPeer()` method
- Removed system message generation from `didDisconnectFromPeer()` method
- Kept all essential functionality (ephemeral session management, read receipt clearing)

## Test plan
- [ ] Connect/disconnect peers and verify no system messages appear
- [ ] Verify peer connections still work properly
- [ ] Verify `/w` command still shows online users
- [ ] Verify private messages still work after reconnection
- [ ] Verify read receipts are properly cleared/resent after disconnection