### PR TITLE
Remove cover traffic functionality

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -148,7 +148,6 @@ BitChat is a decentralized, peer-to-peer messaging application that works over B
 
 ### 4. Privacy Features
 - **Message Padding**: Obscures message length
-- **Cover Traffic**: Optional dummy messages
 - **Timing Obfuscation**: Randomized delays
 - **Emergency Wipe**: Triple-tap to clear all data
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This project is released into the public domain. See the [LICENSE](LICENSE) file
 
 - **Decentralized Mesh Network**: Automatic peer discovery and multi-hop message relay over Bluetooth LE
 - **Privacy First**: No accounts, no phone numbers, no persistent identifiers
-- **Cover Traffic**: Timing obfuscation and dummy messages for enhanced privacy
 - **Private Message End-to-End Encryption**: [Noise Protocol](http://noiseprotocol.org)
 - **Store & Forward**: Messages cached for offline peers and delivered when they reconnect
 - **IRC-Style Commands**: Familiar `/slap`, `/msg`, `/who` style interface


### PR DESCRIPTION
## Summary
- Removes all cover traffic functionality from the codebase
- Simplifies the codebase by removing unused privacy feature

## Changes
- Removed cover traffic variables and timer from BluetoothMeshService
- Removed cover traffic methods: `startCoverTraffic()`, `scheduleCoverTraffic()`, `sendDummyMessage()`, `generateDummyContent()`
- Removed cover traffic initialization in `startSession()`
- Removed cover traffic check in `handleReceivedPacket()` that filtered dummy messages
- Removed cover traffic timer invalidation in `reset()`
- Updated documentation (README.md and AI_CONTEXT.md) to remove cover traffic mentions

## Test plan
- [x] Code compiles without errors
- [ ] App runs without crashes
- [ ] Messages can still be sent and received normally
- [ ] No references to cover traffic remain in the codebase