### PR TITLE
Improve UI interactions

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -393,7 +393,7 @@ struct ContentView: View {
             // @mentions autocomplete
             if viewModel.showAutocomplete && !viewModel.autocompleteSuggestions.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(viewModel.autocompleteSuggestions, id: \.self) { suggestion in
+                    ForEach(Array(viewModel.autocompleteSuggestions.prefix(4)), id: \.self) { suggestion in
                         Button(action: {
                             _ = viewModel.completeNickname(suggestion, in: &messageText)
                         }) {
@@ -1049,6 +1049,8 @@ struct ContentView: View {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 12))
                                 .foregroundColor(textColor)
+                                .frame(width: 44, height: 44, alignment: .leading)
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel("Back to main chat")


### PR DESCRIPTION
## Summary
- Improves tap target size for better mobile usability
- Limits autocomplete suggestions for cleaner UI

## Changes
- Increased tap target for back button in private message view from 12pt to 44x44pt while keeping visual size the same
- Limited @mentions autocomplete to show only top 4 matches instead of unlimited

## Test plan
- [ ] Back button in private message view is easier to tap on mobile
- [ ] @mentions autocomplete shows maximum 4 suggestions
- [ ] Autocomplete still works correctly with the limit
- [ ] No visual shift in back button position