### PR TITLE
Remove noisy @ symbol in mention notification

### DIFF
--- a/bitchat/Services/NotificationService.swift
+++ b/bitchat/Services/NotificationService.swift
@@ -54,7 +54,7 @@ class NotificationService {
     }
     
     func sendMentionNotification(from sender: String, message: String) {
-        let title = "＠🫵 you were mentioned by \(sender)"
+        let title = "🫵 you were mentioned by \(sender)"
         let body = message
         let identifier = "mention-\(UUID().uuidString)"
         


### PR DESCRIPTION
Right now the "mentioned" notification includes an extra `@` symbol at the start of the title. This makes the notification a bit crowded since there's an emoji as well. The private message notification starts with an emoji but no `@`.

This PR removes the `@` symbol and leaves just the emoji on the "mentioned" notification.

Here you can see the before (bottom) and the after (top):

![IMG_7607](https://github.com/user-attachments/assets/06d19738-9d23-4462-b2ed-1afd0f5b064c)
