### PR TITLE
Allow unicode letter characters in nicknames

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -122,7 +122,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     // MARK: - Autocomplete Properties
     
     // Autocomplete optimization
-    private let mentionRegex = try? NSRegularExpression(pattern: "@([a-zA-Z0-9_]*)$", options: [])
+    private let mentionRegex = try? NSRegularExpression(pattern: "@([\\p{L}0-9_]*)$", options: [])
     private var cachedNicknames: [String] = []
     private var lastNicknameUpdate: Date = .distantPast
     
@@ -1697,7 +1697,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         var processedContent = AttributedString()
         
         // Regular expressions for mentions and hashtags
-        let mentionPattern = "@([a-zA-Z0-9_]+)"
+        let mentionPattern = "@([\\p{L}0-9_]+)"
         let hashtagPattern = "#([a-zA-Z0-9_]+)"
         
         let mentionRegex = try? NSRegularExpression(pattern: mentionPattern, options: [])
@@ -1796,7 +1796,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             let content = message.content
             
             let hashtagPattern = "#([a-zA-Z0-9_]+)"
-            let mentionPattern = "@([a-zA-Z0-9_]+)"
+            let mentionPattern = "@([\\p{L}0-9_]+)"
             
             let hashtagRegex = try? NSRegularExpression(pattern: hashtagPattern, options: [])
             let mentionRegex = try? NSRegularExpression(pattern: mentionPattern, options: [])
@@ -1921,7 +1921,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             var processedContent = AttributedString()
             
             // Regular expression to find @mentions
-            let pattern = "@([a-zA-Z0-9_]+)"
+            let pattern = "@([\\p{L}0-9_]+)"
             let regex = try? NSRegularExpression(pattern: pattern, options: [])
             let matches = regex?.matches(in: contentText, options: [], range: NSRange(location: 0, length: contentText.count)) ?? []
             
@@ -3262,7 +3262,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     // MARK: - Helper Methods
     
     private func parseMentions(from content: String) -> [String] {
-        let pattern = "@([a-zA-Z0-9_]+)"
+        let pattern = "@([\\p{L}0-9_]+)"
         let regex = try? NSRegularExpression(pattern: pattern, options: [])
         let matches = regex?.matches(in: content, options: [], range: NSRange(location: 0, length: content.count)) ?? []
         


### PR DESCRIPTION
The mention regex was defined with `a-zA-Z` which only allows "ASCII" characters. Replace it with `\p{L}` ("Letter" unicode category) to match special caracters like `ç` or `á`.

Note: this PR addresses nicknames/usernames. The same could be done with channels/hashtags names but maybe you want to keep those ascii?

See: https://regexr.com/8gf57

before:
<img width="248" height="68" alt="Screenshot 2025-08-08 at 19 06 34" src="https://github.com/user-attachments/assets/489f88ce-e46e-49b3-9ce3-6ab2f7c885f7" />

after:
<img width="248" height="66" alt="Screenshot 2025-08-08 at 19 05 23" src="https://github.com/user-attachments/assets/2c41d654-94b2-47d1-b590-21a13cdf42d3" />

fixes #343
