### PR TITLE
Improve Developer Onboarding: Add DEVELOPMENT.md, Debugging Checklist, and README Link

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,78 @@
+# Development Guide
+
+This guide is for contributors working on BitChat. It focuses on a fast local setup, safe debugging, and practical troubleshooting – optimized for agentic, incremental changes.
+
+## Prerequisites
+- Xcode 15+
+- macOS 13+
+- Swift toolchain installed (via Xcode)
+- XcodeGen (recommended):
+  ```bash
+  brew install xcodegen
+  ```
+
+## Project Layout (high level)
+- `bitchat/` – app sources (Services, Protocols, Noise, ViewModels, Views)
+- `bitchatTests/` – unit/integration tests
+- `WHITEPAPER.md` – protocol/crypto/system specification
+- `BRING_THE_NOISE.md` – Noise-layer specifics and session notes
+- `PRIVACY_POLICY.md` – privacy guarantees and limits
+- `AI_CONTEXT.md` – architecture + development context
+
+## Setup & Run
+### Option A: XcodeGen (recommended)
+```bash
+cd bitchat
+xcodegen generate
+open bitchat.xcodeproj
+```
+Select target and run.
+
+### Option B: Swift Package Manager
+```bash
+cd bitchat
+open Package.swift
+```
+Select a scheme and run from Xcode.
+
+### Option C: Justfile helpers
+The repo includes a `Justfile` with handy tasks. Try:
+```bash
+just run   # macOS sandbox run helper
+just clean # restore workspace state
+```
+
+## Bluetooth permissions (iOS/macOS)
+Ensure Info.plist contains a Bluetooth usage description (iOS/macOS may differ by version):
+- `NSBluetoothAlwaysUsageDescription` – “BitChat uses Bluetooth to discover nearby peers and relay messages.”
+
+BitChat already includes the correct entitlements in templates; this note is for manual project setups.
+
+## Logging & Security
+- Use structured logs for boundaries: discovery/connect/disconnect, handshake start/end, route selection.
+- Never log secrets: keys, plaintext message content, session material, or relay auth tokens.
+- Prefer redaction when in doubt. (See `WHITEPAPER.md` Security Considerations.)
+
+## Debugging checklist (simple-first)
+1. Bluetooth ON? Permissions granted? App in foreground? (macOS may require specific privacy settings.)
+2. Any peers visible in discovery logs?
+3. If connected but not authenticated, confirm Noise handshake paths (see `BRING_THE_NOISE.md`).
+4. No messages? Check TTL policy and Bloom filter dedupe.
+5. Nostr fallback only works for mutual favorites; verify both sides are favorited.
+
+## Tests
+- Open the Xcode project/workspace
+- Product → Test (⌘U)
+- Start with protocol/encoding tests and expand to services as needed
+
+## Contributor tips (agentic pattern)
+- Make one small change at a time; run and observe
+- Prefer sequential baselines before introducing parallelism
+- Add or improve logs at boundaries before refactors
+- Document new lessons in `AI_CONTEXT.md` or a small `docs/` note
+
+## Useful references
+- `WHITEPAPER.md` – stack, message formats, TTL, Bloom filters
+- `AI_CONTEXT.md` – system architecture and design decisions
+- `BRING_THE_NOISE.md` – Noise protocol details and session lifecycle
+- `PRIVACY_POLICY.md` – privacy scope and limitations

--- a/README.md
+++ b/README.md
@@ -86,5 +86,16 @@ For detailed protocol documentation, see the [Technical Whitepaper](WHITEPAPER.m
 
 ### Option 4: just
 
-Want to try this on macos: `just run` will set it up and run from source. 
+Want to try this on macOS: `just run` will set it up and run from source. 
 Run `just clean` afterwards to restore things to original state for mobile app building and development.
+
+---
+
+## Development
+
+For contributor setup, logging guidance, and troubleshooting, see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+Quick tips:
+- Ensure Bluetooth permissions are granted and the app is in the foreground
+- Prefer sequential baselines when debugging; add logs at connection/handshake boundaries
+- See [WHITEPAPER.md](WHITEPAPER.md) for protocol details and [AI_CONTEXT.md](AI_CONTEXT.md) for architecture


### PR DESCRIPTION
### Summary
- Add a concise DEVELOPMENT.md for contributor setup, safe debugging, and references
- Link it from README under a new Development section
- Minor README copy edit (macOS wording)

### Why
- Lower the barrier to entry for new contributors
- Encode simple-first, incremental debugging practices
- Centralize links to WHITEPAPER, AI_CONTEXT, BRING_THE_NOISE, PRIVACY_POLICY

### What’s in this PR
- New: DEVELOPMENT.md
  - Setup: XcodeGen/SPM/Just
  - Bluetooth permission note (Info.plist)
  - Logging/security do/don’ts (no secrets in logs)
  - Simple-first debugging checklist
  - Testing tips (start with protocol/encoding)
  - References to core docs
- Updated: README.md
  - Add Development section linking to DEVELOPMENT.md
  - Minor copy fix (“macOS”)

### Impact
- Code: none; docs only
- Risk: low
- Audience: contributors and maintainers

### How to review
- Open DEVELOPMENT.md and skim sections: Setup, Debugging, Logging, References
- Confirm README links resolve
- Verify tone/style aligns with project

### How to test locally
- Follow DEVELOPMENT.md Option A (XcodeGen) to generate and open the project
- Confirm Bluetooth permissions guidance is clear
- Run tests (⌘U) if any are present

### Follow-ups (separate PRs)
- Add Troubleshooting section to README with top-5 issues
- Minimal “/status” command for runtime diagnostics (read-only)
- Packet encode/decode unit tests

### Checklist
- [x] Docs build locally
- [x] Links resolve (README → DEVELOPMENT.md; doc references)
- [x] No code changes; safe to merge