### PR TITLE
Adds swift-secp256k1 to Package.swift 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-secp256k1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/21-DOT-DEV/swift-secp256k1",
+      "state" : {
+        "revision" : "8c62aba8a3011c9bcea232e5ee007fb0b34a15e2",
+        "version" : "0.21.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,15 @@ let package = Package(
             targets: ["bitchat"]
         ),
     ],
+    dependencies:[
+        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", from: "0.21.1"),
+    ],
     targets: [
         .executableTarget(
             name: "bitchat",
+            dependencies: [
+                .product(name: "P256K", package: "swift-secp256k1")
+            ],
             path: "bitchat",
             exclude: [
                 "Info.plist",


### PR DESCRIPTION
Fixes this issue mentioned in https://github.com/permissionlesstech/bitchat/pull/423:

<img width="936" height="184" alt="image" src="https://github.com/user-attachments/assets/0a1a93c5-9a15-4bc6-bdb2-09cbffc09df1" />

