### PR TITLE
chat: fix blanking and gaps when switching geohashes; channel-aware r…

### DIFF
--- a/bitchat/Views/LinkPreviewView.swift
+++ b/bitchat/Views/LinkPreviewView.swift
@@ -424,6 +424,21 @@ extension String {
         
         return urls
     }
+    
+    // Detect if there is an extremely long token (no whitespace/newlines) that could break layout
+    func hasVeryLongToken(threshold: Int) -> Bool {
+        var current = 0
+        for ch in self {
+            if ch.isWhitespace || ch.isNewline {
+                if current >= threshold { return true }
+                current = 0
+            } else {
+                current += 1
+                if current >= threshold { return true }
+            }
+        }
+        return current >= threshold
+    }
 }
 
 #Preview {


### PR DESCRIPTION
…ow IDs + deferred autoscroll\n\n- Add channel-aware UI IDs (mesh|id, geo:<gh>|id, dm:<peer>|id) to prevent SwiftUI reuse gaps\n- Defer scrollTo to next runloop for stability; auto-scroll on appear/switch\n- Collapse very long messages with Show more/less; skip heavy parsing for huge content\n- Simplify LazyLinkPreviewView (remove GeometryReader in list)