### PR TITLE
Added Send button to keyboard action for message sending

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -810,11 +810,12 @@ struct ContentView: View {
             }
             
             HStack(alignment: .center, spacing: 4) {
-            TextField("type a message...", text: $messageText)
+                TextField("type a message...", text: $messageText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 14, design: .monospaced))
                 .foregroundColor(textColor)
                 .focused($isTextFieldFocused)
+                .submitLabel(.send)
                 .padding(.leading, 12)
                 // iOS keyboard autocomplete and capitalization enabled by default
                 .onChange(of: messageText) { newValue in


### PR DESCRIPTION
Added the send button to the keyboard for easier message sending.

<img width="301" alt="image" src="https://github.com/user-attachments/assets/fa8cd611-dc16-4f8c-bcee-a6567ac57e4b" />
