### PR TITLE
Unify DM notifications and fix geohash self-echo hydration

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -833,16 +833,14 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                             self.sentReadReceipts.insert(messageId)
                         }
                     } else {
-                        // Optionally notify if app backgrounded and message is truly unread
-                        #if os(iOS)
-                        if shouldMarkUnread && UIApplication.shared.applicationState != .active {
+                        // Notify for truly unread and recent messages when not viewing
+                        if shouldMarkUnread {
                             NotificationService.shared.sendPrivateMessageNotification(
                                 from: senderName,
                                 message: pm.content,
                                 peerID: convKey
                             )
                         }
-                        #endif
                     }
                     self.objectWillChange.send()
                 case .delivered:
@@ -1521,19 +1519,14 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                     } else {
                         // pared back: omit defer READ log
                     }
-                    // Notify only when app is backgrounded and not viewing, and only if not already read
-                    #if os(iOS)
+                    // Notify for truly unread and recent messages when not viewing
                     if !isViewing && shouldMarkUnread {
-                        if UIApplication.shared.applicationState != .active {
-                            NotificationService.shared.sendPrivateMessageNotification(
-                                from: senderName,
-                                message: pm.content,
-                                peerID: convKey
-                            )
-                            // pared back: omit notification log
-                        }
+                        NotificationService.shared.sendPrivateMessageNotification(
+                            from: senderName,
+                            message: pm.content,
+                            peerID: convKey
+                        )
                     }
-                    #endif
                     self.objectWillChange.send()
                 default:
                     // Handle delivered/read receipts for our sent messages


### PR DESCRIPTION
Summary

- Unifies private message notifications across transports (mesh + Nostr geohash DMs).
- Sends notifications for truly unread and recent DMs even when the app is foregrounded; the notification delegate suppresses banners when the relevant chat is already open.
- Fixes geohash channel hydration to include the user’s own past kind 20000 events when loading/reloading a channel (skips only very recent self-echoes from relays to avoid duplicates).

Changes

- ChatViewModel
  - DM notifications: remove iOS-only background checks for geohash DMs; notify on unread+recent when not viewing the chat.
  - Geohash subscription handlers: skip only very recent self-echo (<15s); include older self events for hydration.
- Notification handling (unchanged but relevant)
  - NotificationDelegate suppresses banners in foreground if the private chat is already open.
  - Private message notifications include peerID in userInfo so taps open the right chat.

Why

- Prior behavior was inconsistent and hid your own geohash posts after reload. This aligns the UX and improves reliability without duplicate messages.

Verification Steps

- Foreground/Background DMs behave consistently; notifications when not viewing, suppressed if viewing.
- Geohash timeline shows your older posts after reload; immediate self-echo duplicates are avoided.
- Mentions notify; “bitchatters nearby” notifies on rising-edge with 10m reset.

Risk/Impact

- More foreground notifications for DMs (intended); suppression covers open chats.
- Self-echo skip window set to 15s; can tune if needed.