### PR TITLE
Fix macOS build - disable views calling visibleGeohashPeople() on mac

### DIFF
--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -164,6 +164,7 @@ class CommandProcessor {
             // Geohash blocked names (prefer visible display names; fallback to #suffix)
             let geoBlocked = Array(SecureIdentityStateManager.shared.getBlockedNostrPubkeys())
             var geoNames: [String] = []
+            #if os(iOS)
             if let vm = chatViewModel {
                 let visible = vm.visibleGeohashPeople()
                 let visibleIndex = Dictionary(uniqueKeysWithValues: visible.map { ($0.id.lowercased(), $0.displayName) })
@@ -176,6 +177,7 @@ class CommandProcessor {
                     }
                 }
             }
+            #endif
 
             let meshList = blockedNicknames.isEmpty ? "none" : blockedNicknames.sorted().joined(separator: ", ")
             let geoList = geoNames.isEmpty ? "none" : geoNames.sorted().joined(separator: ", ")

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -4889,9 +4889,11 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     @MainActor
     func nostrPubkeyForDisplayName(_ name: String) -> String? {
         // Look up current visible geohash participants for an exact displayName match
+        #if os(iOS)
         for p in visibleGeohashPeople() {
             if p.displayName == name { return p.id }
         }
+        #endif
         return nil
     }
     


### PR DESCRIPTION
I have a small contribution here - a fix to disable iOS-specific features for macOS build in case building on mac is still required.

- Wrap geohash-related code in CommandProcessor with #if os(iOS) directive
- Conditionally compile visibleGeohashPeople() calls in ChatViewModel

This prevents build failures when compiling for macOS target

These changes ensure iOS-specific functionality (geohashing methods) are only compiled when building for iOS, allowing the macOS build to complete successfully.