### PR TITLE
QR verification: live challenge/response over Noise; persistence, offline badges, and UX/perf polish

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -142,6 +142,10 @@
 		FBC409E105493C491531B59A /* NostrProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5A9FF4AEA8A923317ED26A /* NostrProtocol.swift */; };
 		A1B2C3D44E5F60718293A4B5 /* XChaCha20Poly1305Compat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */; };
 		A1B2C3D54E5F60718293A4B6 /* XChaCha20Poly1305Compat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */; };
+		AA77BB11CC22DD33EE44FF55 /* VerificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */; };
+		AA77BB12CC22DD33EE44FF56 /* VerificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */; };
+		AA77BB14CC22DD33EE44FF58 /* VerificationViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA77BB13CC22DD33EE44FF57 /* VerificationViews.swift */; };
+		AA77BB15CC22DD33EE44FF59 /* VerificationViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA77BB13CC22DD33EE44FF57 /* VerificationViews.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -261,6 +265,8 @@
 		FE7CCF2BD78A3F3DAE6DA145 /* MockBLEService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBLEService.swift; sourceTree = "<group>"; };
 		FF7AF93D874001FBD94C8306 /* bitchat-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "bitchat-macOS.entitlements"; sourceTree = "<group>"; };
 		A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XChaCha20Poly1305Compat.swift; sourceTree = "<group>"; };
+		AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationService.swift; sourceTree = "<group>"; };
+		AA77BB13CC22DD33EE44FF57 /* VerificationViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationViews.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -431,6 +437,7 @@
 		A55126E93155456CAA8D6656 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				AA77BB13CC22DD33EE44FF57 /* VerificationViews.swift */,
 				047502B22E55FED60083520F /* GeohashPeopleList.swift */,
 				047502B32E55FED60083520F /* MeshPeerList.swift */,
 				0475028E2E5417660083520F /* LocationChannelsSheet.swift */,
@@ -504,6 +511,7 @@
 		D98A3186D7E4C72E35BDF7FE /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */,
 				047502B82E560F690083520F /* RelayController.swift */,
 				0475028B2E54171C0083520F /* LocationChannelManager.swift */,
 				049BD3B02E51F319001A566B /* MessageRouter.swift */,
@@ -724,6 +732,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA77BB12CC22DD33EE44FF56 /* VerificationService.swift in Sources */,
+				AA77BB15CC22DD33EE44FF59 /* VerificationViews.swift in Sources */,
 				A1B2C3D54E5F60718293A4B6 /* XChaCha20Poly1305Compat.swift in Sources */,
 				AD11E46940D742AEAF547EB2 /* AppInfoView.swift in Sources */,
 				9B51E9B63A3EA59B1A7874BD /* BinaryEncodingUtils.swift in Sources */,
@@ -779,6 +789,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA77BB11CC22DD33EE44FF55 /* VerificationService.swift in Sources */,
+				AA77BB14CC22DD33EE44FF58 /* VerificationViews.swift in Sources */,
 				A1B2C3D44E5F60718293A4B5 /* XChaCha20Poly1305Compat.swift in Sources */,
 				ABAF130D88561F4A646F0430 /* AppInfoView.swift in Sources */,
 				AFB6AEFCABBE97441CB3102B /* BinaryEncodingUtils.swift in Sources */,

--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -31,6 +31,13 @@ struct BitchatApp: App {
                 .environmentObject(chatViewModel)
                 .onAppear {
                     NotificationDelegate.shared.chatViewModel = chatViewModel
+                    // Inject live Noise service into VerificationService to avoid creating new BLE instances
+                    VerificationService.shared.configure(with: chatViewModel.meshService.getNoiseService())
+                    // Prewarm Nostr identity and QR to make first VERIFY sheet fast
+                    DispatchQueue.global(qos: .utility).async {
+                        let npub = try? NostrIdentityBridge.getCurrentNostrIdentity()?.npub
+                        _ = VerificationService.shared.buildMyQRString(nickname: chatViewModel.nickname, npub: npub)
+                    }
                     #if os(iOS)
                     appDelegate.chatViewModel = chatViewModel
                     #elseif os(macOS)

--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -37,6 +37,8 @@
 	<string>bitchat uses Bluetooth to discover and connect with other bitchat users nearby.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>bitchat uses the camera to scan QR codes to verify peers.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -155,12 +155,17 @@ enum NoisePayloadType: UInt8 {
     case privateMessage = 0x01      // Private chat message
     case readReceipt = 0x02         // Message was read
     case delivered = 0x03           // Message was delivered
+    // Verification (QR-based OOB binding)
+    case verifyChallenge = 0x10     // Verification challenge
+    case verifyResponse  = 0x11     // Verification response
     
     var description: String {
         switch self {
         case .privateMessage: return "privateMessage"
         case .readReceipt: return "readReceipt"
         case .delivered: return "delivered"
+        case .verifyChallenge: return "verifyChallenge"
+        case .verifyResponse: return "verifyResponse"
         }
     }
 }

--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -165,8 +165,12 @@ class CommandProcessor {
             let geoBlocked = Array(SecureIdentityStateManager.shared.getBlockedNostrPubkeys())
             var geoNames: [String] = []
             if let vm = chatViewModel {
+                #if os(iOS)
                 let visible = vm.visibleGeohashPeople()
                 let visibleIndex = Dictionary(uniqueKeysWithValues: visible.map { ($0.id.lowercased(), $0.displayName) })
+                #else
+                let visibleIndex: [String: String] = [:]
+                #endif
                 for pk in geoBlocked {
                     if let name = visibleIndex[pk.lowercased()] {
                         geoNames.append(name)

--- a/bitchat/Services/Transport.swift
+++ b/bitchat/Services/Transport.swift
@@ -46,9 +46,18 @@ protocol Transport: AnyObject {
     func sendBroadcastAnnounce()
     func sendDeliveryAck(for messageID: String, to peerID: String)
 
+    // QR verification (optional for transports)
+    func sendVerifyChallenge(to peerID: String, noiseKeyHex: String, nonceA: Data)
+    func sendVerifyResponse(to peerID: String, noiseKeyHex: String, nonceA: Data)
+
     // Peer snapshots (for non-UI services)
     var peerSnapshotPublisher: AnyPublisher<[TransportPeerSnapshot], Never> { get }
     func currentPeerSnapshots() -> [TransportPeerSnapshot]
+}
+
+extension Transport {
+    func sendVerifyChallenge(to peerID: String, noiseKeyHex: String, nonceA: Data) {}
+    func sendVerifyResponse(to peerID: String, noiseKeyHex: String, nonceA: Data) {}
 }
 
 protocol TransportPeerEventsDelegate: AnyObject {

--- a/bitchat/Services/VerificationService.swift
+++ b/bitchat/Services/VerificationService.swift
@@ -1,0 +1,151 @@
+import Foundation
+import CryptoKit
+
+/// QR verification scaffolding: schema, signing, and basic challenge/response helpers.
+@MainActor
+final class VerificationService {
+    static let shared = VerificationService()
+
+    private let noise: NoiseEncryptionService = {
+        // We reuse the singleton inside BLEService normally; for scaffolding we access a cached instance.
+        // In production, inject the transport's Noise service.
+        return BLEService().getNoiseService()
+    }()
+
+    /// Encapsulates the data encoded into a verification QR
+    struct VerificationQR: Codable {
+        let v: Int
+        let noiseKeyHex: String
+        let signKeyHex: String
+        let npub: String?
+        let nickname: String
+        let ts: Int64
+        let nonceB64: String
+        let sigHex: String
+
+        static let context = "bitchat-verify-v1"
+
+        /// Canonical bytes used for signature (deterministic ordering)
+        func canonicalBytes() -> Data {
+            var out = Data()
+            func appendField(_ s: String) {
+                let d = s.data(using: .utf8) ?? Data()
+                out.append(UInt8(min(d.count, 255)))
+                out.append(d.prefix(255))
+            }
+            appendField(Self.context)
+            appendField(String(v))
+            appendField(noiseKeyHex.lowercased())
+            appendField(signKeyHex.lowercased())
+            appendField(npub ?? "")
+            appendField(nickname)
+            appendField(String(ts))
+            appendField(nonceB64)
+            return out
+        }
+
+        func toURLString() -> String {
+            var comps = URLComponents()
+            comps.scheme = "bitchat"
+            comps.host = "verify"
+            comps.queryItems = [
+                URLQueryItem(name: "v", value: String(v)),
+                URLQueryItem(name: "noise", value: noiseKeyHex),
+                URLQueryItem(name: "sign", value: signKeyHex),
+                URLQueryItem(name: "nick", value: nickname),
+                URLQueryItem(name: "ts", value: String(ts)),
+                URLQueryItem(name: "nonce", value: nonceB64),
+                URLQueryItem(name: "sig", value: sigHex)
+            ] + (npub != nil ? [URLQueryItem(name: "npub", value: npub)] : [])
+            return comps.string ?? ""
+        }
+
+        static func fromURL(_ url: URL) -> VerificationQR? {
+            guard url.scheme == "bitchat", url.host == "verify",
+                  let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else { return nil }
+            func val(_ name: String) -> String? { items.first(where: { $0.name == name })?.value }
+            guard let vStr = val("v"), let v = Int(vStr),
+                  let noise = val("noise"), let sign = val("sign"),
+                  let nick = val("nick"), let tsStr = val("ts"), let ts = Int64(tsStr),
+                  let nonce = val("nonce"), let sig = val("sig") else { return nil }
+            return VerificationQR(v: v, noiseKeyHex: noise, signKeyHex: sign, npub: val("npub"), nickname: nick, ts: ts, nonceB64: nonce, sigHex: sig)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Build a signed QR string for the current identity
+    func buildMyQRString(nickname: String, npub: String?) -> String? {
+        let noiseKey = noise.getStaticPublicKeyData().hexEncodedString()
+        let signKey = noise.getSigningPublicKeyData().hexEncodedString()
+        let ts = Int64(Date().timeIntervalSince1970)
+        var nonce = Data(count: 16)
+        _ = nonce.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, 16, $0.baseAddress!) }
+        let nonceB64 = nonce.base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+        let payload = VerificationQR(v: 1, noiseKeyHex: noiseKey, signKeyHex: signKey, npub: npub, nickname: nickname, ts: ts, nonceB64: nonceB64, sigHex: "")
+        let msg = payload.canonicalBytes()
+        guard let sig = noise.signData(msg) else { return nil }
+        var signed = payload
+        signed.sigHex = sig.hexEncodedString()
+        return signed.toURLString()
+    }
+
+    /// Verify a scanned QR and return the parsed payload if valid (signature + freshness checks)
+    func verifyScannedQR(_ urlString: String, maxAge: TimeInterval = 5 * 60) -> VerificationQR? {
+        guard let url = URL(string: urlString), let qr = VerificationQR.fromURL(url) else { return nil }
+        // Freshness
+        let now = Date().timeIntervalSince1970
+        if now - Double(qr.ts) > maxAge { return nil }
+        // Verify signature using embedded ed25519 signKey
+        guard let sig = Data(hexString: qr.sigHex), let signKey = Data(hexString: qr.signKeyHex) else { return nil }
+        let ok = noise.verifySignature(sig, for: qr.canonicalBytes(), publicKey: signKey)
+        return ok ? qr : nil
+    }
+
+    // MARK: - Noise payloads (scaffold only)
+
+    func buildVerifyChallenge(noiseKeyHex: String, nonceA: Data) -> Data {
+        // TLV: [0x01 len noiseKeyHex ascii] [0x02 len nonceA]
+        var tlv = Data()
+        let n0: [UInt8] = [0x01, UInt8(min(noiseKeyHex.count, 255))]
+        tlv.append(contentsOf: n0)
+        tlv.append(noiseKeyHex.data(using: .utf8)!.prefix(255))
+        tlv.append(0x02)
+        tlv.append(UInt8(min(nonceA.count, 255)))
+        tlv.append(nonceA.prefix(255))
+        return NoisePayload(type: .verifyChallenge, data: tlv).encode()
+    }
+
+    func buildVerifyResponse(noiseKeyHex: String, nonceA: Data) -> Data? {
+        // Sign context: verify-response | noiseKeyHex | nonceA
+        var msg = Data("bitchat-verify-resp-v1".utf8)
+        let nk = noiseKeyHex.data(using: .utf8) ?? Data()
+        msg.append(UInt8(min(nk.count, 255))); msg.append(nk.prefix(255))
+        msg.append(nonceA)
+        guard let sig = noise.signData(msg) else { return nil }
+        var tlv = Data()
+        tlv.append(0x01); tlv.append(UInt8(min(nk.count, 255))); tlv.append(nk.prefix(255))
+        tlv.append(0x02); tlv.append(UInt8(min(nonceA.count, 255))); tlv.append(nonceA.prefix(255))
+        tlv.append(0x03); tlv.append(UInt8(min(sig.count, 255))); tlv.append(sig.prefix(255))
+        return NoisePayload(type: .verifyResponse, data: tlv).encode()
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        self.map { String(format: "%02x", $0) }.joined()
+    }
+    init?(hexString: String) {
+        let len = hexString.count
+        guard len % 2 == 0 else { return nil }
+        var data = Data(capacity: len/2)
+        var i = hexString.startIndex
+        while i < hexString.endIndex {
+            let j = hexString.index(i, offsetBy: 2)
+            if let b = UInt8(hexString[i..<j], radix: 16) { data.append(b) } else { return nil }
+            i = j
+        }
+        self = data
+    }
+}
+

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -871,6 +871,9 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                                             category: SecureLogger.session, level: .warning)
                         }
                     }
+                case .verifyChallenge, .verifyResponse:
+                    // QR verification payloads over Nostr are not supported; ignore in geohash DMs
+                    break
                 }
             }
         } catch { }
@@ -3866,6 +3869,9 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                         objectWillChange.send()
                     }
                 }
+            case .verifyChallenge, .verifyResponse:
+                // Not yet handled over BLE; ignore
+                break
             }
         }
     }
@@ -4552,6 +4558,9 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                     privateChats[targetPeerID]?[idx].deliveryStatus = .read(by: peerName, at: Date())
                     objectWillChange.send()
                 }
+            case .verifyChallenge, .verifyResponse:
+                // Ignore verification payloads arriving via Nostr path for now
+                break
             }
             
         } catch {

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -412,6 +412,22 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     // Delivery tracking
     private var cancellables = Set<AnyCancellable>()
 
+    // MARK: - QR Verification (pending state)
+    private struct PendingVerification {
+        let noiseKeyHex: String
+        let signKeyHex: String
+        let nonceA: Data
+        let startedAt: Date
+        var sent: Bool
+    }
+    private var pendingQRVerifications: [String: PendingVerification] = [:] // peerID -> pending
+    // Last handled challenge nonce per peer to avoid duplicate responses
+    private var lastVerifyNonceByPeer: [String: Data] = [:]
+    // Track when we last received a verify challenge from a peer (fingerprint-keyed)
+    private var lastInboundVerifyChallengeAt: [String: Date] = [:] // key: fingerprint
+    // Throttle mutual verification toasts per fingerprint
+    private var lastMutualToastAt: [String: Date] = [:] // key: fingerprint
+
     // MARK: - Public message batching (UI perf)
     // Buffer incoming public messages and flush in small batches to reduce UI invalidations
     private var publicBuffer: [BitchatMessage] = []
@@ -450,6 +466,9 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             }
         }
     }
+
+    // Throttle verification response toasts per peer to avoid spam
+    private var lastVerifyToastAt: [String: Date] = [:]
     
     // Track processed Nostr ACKs to avoid duplicate processing
     private var processedNostrAcks: Set<String> = []  // "messageId:ackType:senderPubkey" format
@@ -3729,10 +3748,35 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         // Update encryption status after verification
         updateEncryptionStatus(for: peerID)
     }
+
+    @MainActor
+    func unverifyFingerprint(for peerID: String) {
+        guard let fingerprint = getFingerprint(for: peerID) else { return }
+        SecureIdentityStateManager.shared.setVerified(fingerprint: fingerprint, verified: false)
+        SecureIdentityStateManager.shared.forceSave()
+        verifiedFingerprints.remove(fingerprint)
+        updateEncryptionStatus(for: peerID)
+    }
     
+    @MainActor
     func loadVerifiedFingerprints() {
         // Load verified fingerprints directly from secure storage
         verifiedFingerprints = SecureIdentityStateManager.shared.getVerifiedFingerprints()
+        // Log snapshot for debugging persistence
+        let sample = Array(verifiedFingerprints.prefix(3)).map { $0.prefix(8) }.joined(separator: ", ")
+        SecureLogger.log("🔐 Verified loaded: \(verifiedFingerprints.count) [\(sample)]", category: SecureLogger.security, level: .info)
+        // Also log any offline favorites and whether we consider them verified
+        let offlineFavorites = unifiedPeerService.favorites.filter { !$0.isConnected }
+        for fav in offlineFavorites {
+            let fp = unifiedPeerService.getFingerprint(for: fav.id)
+            let isVer = fp.flatMap { verifiedFingerprints.contains($0) } ?? false
+            let fpShort = fp?.prefix(8) ?? "nil"
+            SecureLogger.log("⭐️ Favorite offline: \(fav.nickname) fp=\(fpShort) verified=\(isVer)", category: SecureLogger.security, level: .info)
+        }
+        // Invalidate cached encryption statuses so offline favorites can show verified badges immediately
+        invalidateEncryptionCache()
+        // Trigger UI refresh of peer list
+        objectWillChange.send()
     }
     
     private func setupNoiseCallbacks() {
@@ -3764,6 +3808,14 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                     self.shortIDToNoiseKey[peerID] = stable
                     SecureLogger.log("🗺️ Mapped short peerID to Noise key for header continuity: \(peerID) -> \(stable.prefix(8))…",
                                     category: SecureLogger.session, level: .debug)
+                }
+
+                // If a QR verification is pending but not sent yet, send it now that session is authenticated
+                if var pending = self.pendingQRVerifications[peerID], pending.sent == false {
+                    self.meshService.sendVerifyChallenge(to: peerID, noiseKeyHex: pending.noiseKeyHex, nonceA: pending.nonceA)
+                    pending.sent = true
+                    self.pendingQRVerifications[peerID] = pending
+                    SecureLogger.log("📤 Sent deferred verify challenge to \(peerID) after handshake", category: SecureLogger.security, level: .debug)
                 }
 
                 // Schedule UI update
@@ -3869,9 +3921,72 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
                         objectWillChange.send()
                     }
                 }
-            case .verifyChallenge, .verifyResponse:
-                // Not yet handled over BLE; ignore
-                break
+            case .verifyChallenge:
+                // Parse and respond
+                guard let tlv = VerificationService.shared.parseVerifyChallenge(payload) else { return }
+                // Ensure intended for our noise key
+                let myNoiseHex = meshService.getNoiseService().getStaticPublicKeyData().hexEncodedString().lowercased()
+                guard tlv.noiseKeyHex.lowercased() == myNoiseHex else { return }
+                // Deduplicate: ignore if we've already responded to this nonce for this peer
+                if let last = lastVerifyNonceByPeer[peerID], last == tlv.nonceA { return }
+                lastVerifyNonceByPeer[peerID] = tlv.nonceA
+                // Record inbound challenge time keyed by stable fingerprint if available
+                if let fp = getFingerprint(for: peerID) {
+                    lastInboundVerifyChallengeAt[fp] = Date()
+                    // If we've already verified this fingerprint locally, treat this as mutual and toast immediately (responder side)
+                    if verifiedFingerprints.contains(fp) {
+                        let now = Date()
+                        let last = lastMutualToastAt[fp] ?? .distantPast
+                        if now.timeIntervalSince(last) > 60 { // 1-minute throttle
+                            lastMutualToastAt[fp] = now
+                            let name = unifiedPeerService.getPeer(by: peerID)?.nickname ?? resolveNickname(for: peerID)
+                            NotificationService.shared.sendLocalNotification(
+                                title: "Mutual verification",
+                                body: "You and \(name) verified each other",
+                                identifier: "verify-mutual-\(peerID)-\(UUID().uuidString)"
+                            )
+                        }
+                    }
+                }
+                meshService.sendVerifyResponse(to: peerID, noiseKeyHex: tlv.noiseKeyHex, nonceA: tlv.nonceA)
+                // Silent response: no toast needed on responder
+            case .verifyResponse:
+                guard let resp = VerificationService.shared.parseVerifyResponse(payload) else { return }
+                // Check pending for this peer
+                guard let pending = pendingQRVerifications[peerID] else { return }
+                guard resp.noiseKeyHex.lowercased() == pending.noiseKeyHex.lowercased(), resp.nonceA == pending.nonceA else { return }
+                // Verify signature with expected sign key
+                let ok = VerificationService.shared.verifyResponseSignature(noiseKeyHex: resp.noiseKeyHex, nonceA: resp.nonceA, signature: resp.signature, signerPublicKeyHex: pending.signKeyHex)
+                if ok {
+                    pendingQRVerifications.removeValue(forKey: peerID)
+                    if let fp = getFingerprint(for: peerID) {
+                        let short = fp.prefix(8)
+                        SecureLogger.log("🔐 Marking verified fingerprint: \(short)", category: SecureLogger.security, level: .info)
+                        SecureIdentityStateManager.shared.setVerified(fingerprint: fp, verified: true)
+                        SecureIdentityStateManager.shared.forceSave()
+                        verifiedFingerprints.insert(fp)
+                        let name = unifiedPeerService.getPeer(by: peerID)?.nickname ?? resolveNickname(for: peerID)
+                        NotificationService.shared.sendLocalNotification(
+                            title: "Verified",
+                            body: "You verified \(name)",
+                            identifier: "verify-success-\(peerID)-\(UUID().uuidString)"
+                        )
+                        // If we also recently responded to their challenge, flag mutual and toast (initiator side)
+                        if let t = lastInboundVerifyChallengeAt[fp], Date().timeIntervalSince(t) < 600 {
+                            let now = Date()
+                            let lastToast = lastMutualToastAt[fp] ?? .distantPast
+                            if now.timeIntervalSince(lastToast) > 60 {
+                                lastMutualToastAt[fp] = now
+                                NotificationService.shared.sendLocalNotification(
+                                    title: "Mutual verification",
+                                    body: "You and \(name) verified each other",
+                                    identifier: "verify-mutual-\(peerID)-\(UUID().uuidString)"
+                                )
+                            }
+                        }
+                        updateEncryptionStatus(for: peerID)
+                    }
+                }
             }
         }
     }
@@ -3895,6 +4010,36 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             checkForMentions(msg)
             sendHapticFeedback(for: msg)
         }
+    }
+
+    // MARK: - QR Verification API
+    @MainActor
+    func beginQRVerification(with qr: VerificationService.VerificationQR) -> Bool {
+        // Find a matching peer by Noise key
+        let targetNoise = qr.noiseKeyHex.lowercased()
+        guard let peer = unifiedPeerService.peers.first(where: { $0.noisePublicKey.hexEncodedString().lowercased() == targetNoise }) else {
+            return false
+        }
+        let peerID = peer.id
+        // If we already have a pending verification with this peer, don't send another
+        if pendingQRVerifications[peerID] != nil {
+            return true
+        }
+        // Generate nonceA
+        var nonce = Data(count: 16)
+        _ = nonce.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, 16, $0.baseAddress!) }
+        var pending = PendingVerification(noiseKeyHex: qr.noiseKeyHex, signKeyHex: qr.signKeyHex, nonceA: nonce, startedAt: Date(), sent: false)
+        pendingQRVerifications[peerID] = pending
+        // If Noise session is established, send immediately; otherwise trigger handshake and send on auth
+        let noise = meshService.getNoiseService()
+        if noise.hasEstablishedSession(with: peerID) {
+            meshService.sendVerifyChallenge(to: peerID, noiseKeyHex: qr.noiseKeyHex, nonceA: nonce)
+            pending.sent = true
+            pendingQRVerifications[peerID] = pending
+        } else {
+            meshService.triggerHandshake(with: peerID)
+        }
+        return true
     }
 
     // Mention parsing moved from BLE – use the existing non-optional helper below
@@ -4913,10 +5058,12 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     // MARK: - Geohash Nickname Resolution (for /block in geohash)
     @MainActor
     func nostrPubkeyForDisplayName(_ name: String) -> String? {
-        // Look up current visible geohash participants for an exact displayName match
+        // Look up current visible geohash participants for an exact displayName match (iOS only)
+        #if os(iOS)
         for p in visibleGeohashPeople() {
             if p.displayName == name { return p.id }
         }
+        #endif
         return nil
     }
     

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -58,6 +58,8 @@ struct ContentView: View {
     @State private var scrollThrottleTimer: Timer?
     @State private var autocompleteDebounceTimer: Timer?
     @State private var showLocationChannelsSheet = false
+    @State private var showMyQRSheet = false
+    @State private var showScanQRSheet = false
     @State private var expandedMessageIDs: Set<String> = []
     // Window sizes for rendering (infinite scroll up)
     @State private var windowCountPublic: Int = 300
@@ -1224,12 +1226,35 @@ struct ContentView: View {
                         .accessibilityHidden(true)
                 }
                 .foregroundColor(headerCountColor)
+
+                // QR actions
+                Button(action: { showMyQRSheet = true }) {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help("Show my verification QR")
+
+                Button(action: { showScanQRSheet = true }) {
+                    Image(systemName: "qrcode.viewfinder")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help("Scan a friend's QR to verify")
             }
             .onTapGesture {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     showSidebar.toggle()
                     sidebarDragOffset = 0
                 }
+            }
+            .sheet(isPresented: $showMyQRSheet) {
+                let npub = try? NostrIdentityBridge.getCurrentNostrIdentity()?.npub
+                let qr = VerificationService.shared.buildMyQRString(nickname: viewModel.nickname, npub: npub)
+                MyQRView(qrString: qr ?? "")
+            }
+            .sheet(isPresented: $showScanQRSheet) {
+                QRScanView()
             }
         }
         .frame(height: 44)

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -32,8 +32,9 @@ struct FingerprintView: View {
                 
                 Spacer()
                 
-                Button("DONE") {
-                    dismiss()
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
                 }
                 .foregroundColor(textColor)
             }
@@ -162,6 +163,20 @@ struct FingerprintView: View {
                                     .padding(.horizontal, 20)
                                     .padding(.vertical, 10)
                                     .background(Color.green)
+                                    .cornerRadius(8)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                        } else {
+                            Button(action: {
+                                viewModel.unverifyFingerprint(for: peerID)
+                                dismiss()
+                            }) {
+                                Text("REMOVE VERIFICATION")
+                                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                                    .foregroundColor(.white)
+                                    .padding(.horizontal, 20)
+                                    .padding(.vertical, 10)
+                                    .background(Color.red)
                                     .cornerRadius(8)
                             }
                             .buttonStyle(PlainButtonStyle())

--- a/bitchat/Views/MeshPeerList.swift
+++ b/bitchat/Views/MeshPeerList.swift
@@ -85,10 +85,27 @@ struct MeshPeerList: View {
                                 .help("Blocked")
                         }
 
-                        if let icon = item.enc.icon, !isMe {
-                            Image(systemName: icon)
-                                .font(.system(size: 10))
-                                .foregroundColor(baseColor)
+                        if !isMe {
+                            if peer.isConnected {
+                                if let icon = item.enc.icon {
+                                    Image(systemName: icon)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(baseColor)
+                                }
+                            } else {
+                                // Offline: prefer showing verified badge from persisted fingerprints
+                                if let fp = viewModel.getFingerprint(for: peer.id),
+                                   viewModel.verifiedFingerprints.contains(fp) {
+                                    Image(systemName: "checkmark.seal.fill")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(baseColor)
+                                } else if let icon = item.enc.icon {
+                                    // Fallback to whatever status says (likely lock if we had a past session)
+                                    Image(systemName: icon)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(baseColor)
+                                }
+                            }
                         }
 
                         Spacer()

--- a/bitchat/Views/VerificationViews.swift
+++ b/bitchat/Views/VerificationViews.swift
@@ -10,36 +10,32 @@ import AppKit
 /// Placeholder view to display the user's verification QR payload as text.
 struct MyQRView: View {
     let qrString: String
+    @Environment(\.colorScheme) var colorScheme
+    private var boxColor: Color { Color.gray.opacity(0.1) }
 
     var body: some View {
         VStack(spacing: 12) {
-            Text("Scan to verify me")
+            Text("scan to verify me")
                 .font(.system(size: 16, weight: .bold, design: .monospaced))
 
-            QRCodeImage(data: qrString, size: 240)
-                .accessibilityLabel("verification QR code")
+            VStack(spacing: 10) {
+                QRCodeImage(data: qrString, size: 240)
+                    .accessibilityLabel("verification qr code")
 
-            HStack(spacing: 8) {
-                Button("Copy Link") {
-                    #if os(iOS)
-                    UIPasteboard.general.string = qrString
-                    #else
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(qrString, forType: .string)
-                    #endif
-                }
-                .buttonStyle(.bordered)
-            }
-
-            ScrollView {
+                // Non-scrolling, fully visible URL (wraps across lines)
                 Text(qrString)
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: 11, design: .monospaced))
                     .textSelection(.enabled)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(8)
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(6)
+                    .background(boxColor)
+                    .cornerRadius(8)
             }
-            .frame(maxHeight: 120)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(boxColor)
+            .cornerRadius(8)
         }
         .padding()
     }
@@ -63,7 +59,7 @@ struct QRCodeImage: View {
                     .stroke(Color.gray.opacity(0.5), lineWidth: 1)
                     .frame(width: size, height: size)
                     .overlay(
-                        Text("QR unavailable")
+                        Text("qr unavailable")
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundColor(.gray)
                     )
@@ -102,49 +98,42 @@ struct ImageWrapper: View {
 
 /// Placeholder scanner UI; real camera scanning will be added later.
 struct QRScanView: View {
+    @EnvironmentObject var viewModel: ChatViewModel
+    var isActive: Bool = true
     @State private var input = ""
-    @State private var result: String = ""
+    @State private var result: String = "" // not shown for iOS scanner
     @State private var lastValid: String = ""
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             #if os(iOS)
-            Text("Scan a friend's QR")
-                .font(.system(size: 14, weight: .medium, design: .monospaced))
-            CameraScannerView { code in
+            CameraScannerView(isActive: isActive) { code in
                 if let qr = VerificationService.shared.verifyScannedQR(code) {
-                    result = "Valid QR: \(qr.nickname)"
+                    let ok = viewModel.beginQRVerification(with: qr)
+                    if !ok { /* already pending; continue scanning */ }
                     lastValid = code
                 } else {
-                    result = "Invalid or expired QR"
+                    // ignore invalid reads; continue scanning
                 }
             }
             .frame(height: 260)
             .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3), lineWidth: 1))
             #else
-            Text("Paste QR content to validate:")
+            Text("paste qr content to validate:")
                 .font(.system(size: 14, weight: .medium, design: .monospaced))
             TextEditor(text: $input)
                 .frame(height: 100)
                 .border(Color.gray.opacity(0.4))
-            Button("Validate") {
-                if let _ = VerificationService.shared.verifyScannedQR(input) {
-                    result = "Valid QR payload"
+            Button("validate") {
+                if let qr = VerificationService.shared.verifyScannedQR(input) {
+                    let ok = viewModel.beginQRVerification(with: qr)
+                    result = ok ? "verification requested for \(qr.nickname)" : "could not find matching peer"
                 } else {
-                    result = "Invalid or expired QR payload"
+                    result = "invalid or expired qr payload"
                 }
             }
             .buttonStyle(.bordered)
             #endif
-            Text(result)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(result.contains("Valid") ? .green : .orange)
-            if !lastValid.isEmpty {
-                Text(lastValid)
-                    .font(.system(size: 10, design: .monospaced))
-                    .textSelection(.enabled)
-                    .foregroundColor(.secondary)
-            }
+            // No status text under camera per design
             Spacer()
         }
         .padding()
@@ -156,15 +145,19 @@ import AVFoundation
 
 struct CameraScannerView: UIViewRepresentable {
     typealias UIViewType = PreviewView
+    var isActive: Bool
     var onCode: (String) -> Void
 
     func makeUIView(context: Context) -> PreviewView {
         let view = PreviewView()
         context.coordinator.setup(sessionOwner: view, onCode: onCode)
+        context.coordinator.setActive(isActive)
         return view
     }
 
-    func updateUIView(_ uiView: PreviewView, context: Context) {}
+    func updateUIView(_ uiView: PreviewView, context: Context) {
+        context.coordinator.setActive(isActive)
+    }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -172,6 +165,9 @@ struct CameraScannerView: UIViewRepresentable {
         private var onCode: ((String) -> Void)?
         private weak var owner: PreviewView?
         private let session = AVCaptureSession()
+        private var isRunning = false
+        private var permissionGranted = false
+        private var desiredActive = false
 
         func setup(sessionOwner: PreviewView, onCode: @escaping (String) -> Void) {
             self.owner = sessionOwner
@@ -193,8 +189,25 @@ struct CameraScannerView: UIViewRepresentable {
             sessionOwner.videoPreviewLayer.session = session
             // Request permission and start
             AVCaptureDevice.requestAccess(for: .video) { granted in
-                DispatchQueue.main.async {
-                    if granted { self.session.startRunning() }
+                self.permissionGranted = granted
+                if granted && self.desiredActive && !self.isRunning {
+                    self.setActive(true)
+                }
+            }
+        }
+
+        func setActive(_ active: Bool) {
+            desiredActive = active
+            guard permissionGranted else { return }
+            if active && !isRunning {
+                isRunning = true
+                DispatchQueue.global(qos: .userInitiated).async {
+                    if !self.session.isRunning { self.session.startRunning() }
+                }
+            } else if !active && isRunning {
+                isRunning = false
+                DispatchQueue.global(qos: .userInitiated).async {
+                    if self.session.isRunning { self.session.stopRunning() }
                 }
             }
         }
@@ -220,3 +233,115 @@ struct CameraScannerView: UIViewRepresentable {
     }
 }
 #endif
+
+// Combined sheet: shows my QR by default with a button to scan instead
+struct VerificationSheetView: View {
+    @EnvironmentObject var viewModel: ChatViewModel
+    @Binding var isPresented: Bool
+    @State private var showingScanner = false
+    @Environment(\.colorScheme) var colorScheme
+
+    private var backgroundColor: Color { colorScheme == .dark ? Color.black : Color.white }
+    private var accentColor: Color { colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0) }
+    private var boxColor: Color { Color.gray.opacity(0.1) }
+
+    private func myQRString() -> String {
+        let npub = try? NostrIdentityBridge.getCurrentNostrIdentity()?.npub
+        return VerificationService.shared.buildMyQRString(nickname: viewModel.nickname, npub: npub) ?? ""
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top header (always at top)
+            HStack {
+                Text("VERIFY")
+                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                    .foregroundColor(accentColor)
+                Spacer()
+                Button(action: {
+                    showingScanner = false
+                    isPresented = false
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(accentColor)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // Content area
+            Group {
+                if showingScanner {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("scan a friend's qr")
+                            .font(.system(size: 16, weight: .bold, design: .monospaced))
+                            .frame(maxWidth: .infinity)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(accentColor)
+                        #if os(iOS)
+                        QRScanView(isActive: showingScanner)
+                            .environmentObject(viewModel)
+                            .frame(height: 280)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                        #else
+                        QRScanView()
+                            .environmentObject(viewModel)
+                        #endif
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(boxColor)
+                    .cornerRadius(8)
+                } else {
+                    let qr = myQRString()
+                    MyQRView(qrString: qr)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
+            // Centered controls moved up
+            VStack(spacing: 10) {
+                if showingScanner {
+                    Button(action: { showingScanner = false }) {
+                        Label("show my qr", systemImage: "qrcode")
+                            .font(.system(size: 13, design: .monospaced))
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Button(action: { showingScanner = true }) {
+                        Label("scan someone else's qr", systemImage: "camera.viewfinder")
+                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.gray)
+                }
+
+                // Optional: Remove verification for selected peer (if verified)
+                if let pid = viewModel.selectedPrivateChatPeer,
+                   let fp = viewModel.getFingerprint(for: pid),
+                   viewModel.verifiedFingerprints.contains(fp) {
+                    Button(action: { viewModel.unverifyFingerprint(for: pid) }) {
+                        Label("remove verification", systemImage: "minus.circle")
+                            .font(.system(size: 12, design: .monospaced))
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.gray)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+        }
+        .background(backgroundColor)
+        #if os(iOS)
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+        #endif
+        .onDisappear { showingScanner = false }
+    }
+}

--- a/bitchat/Views/VerificationViews.swift
+++ b/bitchat/Views/VerificationViews.swift
@@ -57,8 +57,6 @@ struct QRCodeImage: View {
         Group {
             if let image = generateImage() {
                 ImageWrapper(image: image)
-                    .interpolation(.none)
-                    .resizable()
                     .frame(width: size, height: size)
             } else {
                 RoundedRectangle(cornerRadius: 8)
@@ -91,9 +89,13 @@ struct ImageWrapper: View {
         #if os(iOS)
         let ui = UIImage(cgImage: image)
         return Image(uiImage: ui)
+            .interpolation(.none)
+            .resizable()
         #else
         let ns = NSImage(cgImage: image, size: .zero)
         return Image(nsImage: ns)
+            .interpolation(.none)
+            .resizable()
         #endif
     }
 }

--- a/bitchat/Views/VerificationViews.swift
+++ b/bitchat/Views/VerificationViews.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Placeholder view to display the user's verification QR payload as text.
+struct MyQRView: View {
+    let qrString: String
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Scan to verify me")
+                .font(.system(size: 16, weight: .bold, design: .monospaced))
+            // Placeholder box where a future QR image will go
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                .frame(width: 220, height: 220)
+                .overlay(Text("QR PREVIEW\ncoming soon").font(.system(size: 12, design: .monospaced)).multilineTextAlignment(.center).foregroundColor(.gray))
+            ScrollView {
+                Text(qrString)
+                    .font(.system(size: 10, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(6)
+            }.frame(maxHeight: 120)
+        }
+        .padding()
+    }
+}
+
+/// Placeholder scanner UI; real camera scanning will be added later.
+struct QRScanView: View {
+    @State private var input = ""
+    @State private var result: String = ""
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Paste QR content to simulate scan:")
+                .font(.system(size: 14, weight: .medium, design: .monospaced))
+            TextEditor(text: $input)
+                .frame(height: 100)
+                .border(Color.gray.opacity(0.4))
+            Button("Validate") {
+                if let _ = VerificationService.shared.verifyScannedQR(input) {
+                    result = "Valid QR payload"
+                } else {
+                    result = "Invalid or expired QR payload"
+                }
+            }
+            .buttonStyle(.bordered)
+            Text(result)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(result.contains("Valid") ? .green : .orange)
+            Spacer()
+        }
+        .padding()
+    }
+}
+


### PR DESCRIPTION
# QR Verification: Live Proof over Noise + Persistence, Offline Badges, and UX/Perf Polish

## Summary
This PR implements a secure, QR-based verification flow that binds a mesh peer’s cryptographic identity to the human you meet in person. It uses a signed QR plus a live challenge/response exchange over the existing Noise channel. The work also adds immediate persistence for verified status, shows verified badges for offline favorites, polishes the VERIFY sheet, and speeds up first-open performance.

## Why
- Strongly ties the person you meet to the device’s Noise identity (no nickname spoofing).
- Live possession proof prevents copying someone else’s QR or replaying old codes.
- Improves UX (no manual fingerprint compare) while maintaining privacy.
- Optional Nostr linkage (via npub) for future cross-transport features.

## Flow
1. Generate QR (on Device A):
   - Fields: `v`, `noiseKeyHex`, `signKeyHex` (ed25519), optional `npub`, `nickname`, `ts`, `nonceB64`, `sigHex`.
   - Signature: Ed25519 over canonical bytes with context `bitchat-verify-v1`.
2. Scan + validate (on Device B):
   - Validate signature and freshness locally.
   - Find live peer by `noiseKeyHex`.
3. Send challenge (B ➜ A):
   - Noise payload type `verifyChallenge` (0x10).
   - TLV: `[0x01 noiseKeyHex][0x02 nonceA]`.
   - If no Noise session, we trigger handshake and defer send until authenticated.
4. Respond (A ➜ B):
   - Validate intended `noiseKeyHex`.
   - Sign context `bitchat-verify-resp-v1 | noiseKeyHex | nonceA` with Ed25519 signing key.
   - Noise payload type `verifyResponse` (0x11) with TLV: `[0x01 noiseKeyHex][0x02 nonceA][0x03 signature]`.
5. Verify and persist (B):
   - Verify signature using QR’s `signKeyHex`.
   - Mark peer fingerprint verified, force-save immediately.
   - Toast: “Verified <name>”.
6. Mutual verification:
   - If both sides complete the flow (either order), both devices show one “Mutual verification” toast.

## Security Properties
- Live possession proof: responder must sign a fresh nonce over the established Noise channel.
- Replay resistance: QR includes timestamp + random nonce; challenge uses a new nonce per attempt.
- Privacy: QR contains only public keys and metadata; no secrets; proofs are Noise-encrypted.
- Robustness: dedup nonce handling prevents repeated responses; toasts are throttled.

## Persistence & Offline Badges
- Standardize fingerprint to SHA‑256(Noise pubkey) across BLE/Noise/UI.
- On verify/unverify, call `forceSave()` so the verified set lands in Keychain immediately.
- At startup, load verified set, invalidate encryption-status cache, and refresh UI.
- Peer list: if a favorite is offline and verified is persisted, show the verified badge even without a live session.
- Diagnostics: logs for loaded verified set and per-offline-favorite verification state.

## UX Changes
- VERIFY sheet matches peer sheet:
  - Header: `VERIFY` + `X` (top), monospaced, accent color.
  - Content uses gray rounded boxes (QR + URL; scanner area).
  - Lowercase labels for consistency; centered “scan a friend’s qr”.
  - Buttons centered; scanner shows no “verification requested” text.
- Camera stays active until verification completes; no intermediate “response sent” toast.
- Added “Remove verification” (red) on the peer sheet when already verified.
- Single QR entry point in PEOPLE header (mesh peer list only).

## Performance Improvements
- Inject live Noise service into `VerificationService` (no new BLE instance construction).
- Prewarm Nostr identity (optional) and build QR on app start; 60s QR cache.
- Core Image path initialized ahead of first sheet use.

## Protocol / Wiring
- New Noise payloads: `verifyChallenge` (0x10), `verifyResponse` (0x11).
- TLV encoding as described above.
- BLE forwards verify payloads to `ChatViewModel.didReceiveNoisePayload`.
- `ChatViewModel` handles challenge/response logic, persistence, toasts, and mutual detection.

## Logging
- On startup: `Verified loaded: N [prefixes]` and `Favorite offline: <name> fp=<prefix> verified=<true/false>`.
- On success: `Marking verified fingerprint: <prefix>`.

## Compatibility
- QR includes optional `npub` for future interop; current flow does not require Nostr path.
- Verify payloads ignored on Nostr transport for now (future: add fallback when BLE unavailable).

## Testing / Validation
- Manual testing with two devices (mutual verification both orders, offline badges, and restarts).
- Verified cache invalidation displays offline badges immediately on cold start.
- Scanner dedup prevents re-challenges while QR is in view.

## Migration / Risk
- No breaking storage changes; verified set is stored in existing secure cache.
- Icon logic prefers persisted verification for offline peers; connected peers show live lock/verified.

## Screenshots
- Omitted here; UI mirrors peer sheet visuals.

Please review copy, placements (PEOPLE header), and the logs during startup to confirm persistence on your devices. 
