### PR TITLE
feat: weekly update bundled georelays

### DIFF
--- a/.github/workflows/fetch_georelays.yml
+++ b/.github/workflows/fetch_georelays.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add app/src/main/assets/nostr_relays.csv
+          git add relays/online_relays_gps.csv
           git commit -m "Automated update of relay data - $(date -u)"
           git push
         env:


### PR DESCRIPTION
## Description

A github workflow that pulls the `online_relays_gps.csv` from the georelays repository once per week. Bundled relays are used as a back-up in case can't reach the georelays repo live from the app.