### PR TITLE
Improve mesh relaying, presence, and DM robustness; signed public msgs; reachability UI; quicker announces; store-and-forward

### DIFF
--- a/bitchat/Identity/IdentityModels.swift
+++ b/bitchat/Identity/IdentityModels.swift
@@ -106,6 +106,8 @@ enum HandshakeState {
 struct CryptographicIdentity: Codable {
     let fingerprint: String     // SHA256 of public key
     let publicKey: Data         // Noise static public key
+    // Optional Ed25519 signing public key (used to authenticate public messages)
+    var signingPublicKey: Data? = nil
     let firstSeen: Date
     let lastHandshake: Date?
 }

--- a/bitchat/Models/BitchatPeer.swift
+++ b/bitchat/Models/BitchatPeer.swift
@@ -8,6 +8,7 @@ struct BitchatPeer: Identifiable, Equatable {
     let nickname: String
     let lastSeen: Date
     let isConnected: Bool
+    let isReachable: Bool
     
     // Favorite-related properties
     var favoriteStatus: FavoritesPersistenceService.FavoriteRelationship?
@@ -18,6 +19,7 @@ struct BitchatPeer: Identifiable, Equatable {
     // Connection state
     enum ConnectionState {
         case bluetoothConnected
+        case meshReachable      // Seen via mesh recently, not directly connected
         case nostrAvailable     // Mutual favorite, reachable via Nostr
         case offline            // Not connected via any transport
     }
@@ -25,6 +27,8 @@ struct BitchatPeer: Identifiable, Equatable {
     var connectionState: ConnectionState {
         if isConnected {
             return .bluetoothConnected
+        } else if isReachable {
+            return .meshReachable
         } else if favoriteStatus?.isMutual == true {
             // Mutual favorites can communicate via Nostr when offline
             return .nostrAvailable
@@ -54,6 +58,8 @@ struct BitchatPeer: Identifiable, Equatable {
         switch connectionState {
         case .bluetoothConnected:
             return "📻" // Radio icon for mesh connection
+        case .meshReachable:
+            return "📡" // Antenna for mesh reachable
         case .nostrAvailable:
             return "🌐" // Purple globe for Nostr
         case .offline:
@@ -71,13 +77,15 @@ struct BitchatPeer: Identifiable, Equatable {
         noisePublicKey: Data,
         nickname: String,
         lastSeen: Date = Date(),
-        isConnected: Bool = false
+        isConnected: Bool = false,
+        isReachable: Bool = false
     ) {
         self.id = id
         self.noisePublicKey = noisePublicKey
         self.nickname = nickname
         self.lastSeen = lastSeen
         self.isConnected = isConnected
+        self.isReachable = isReachable
         
         // Load favorite status - will be set later by the manager
         self.favoriteStatus = nil

--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -2041,6 +2041,8 @@ final class BLEService: NSObject {
                 for peerID in disconnectedPeers {
                     self.delegate?.didDisconnectFromPeer(peerID)
                 }
+                // Publish snapshots so UnifiedPeerService updates connection/reachability icons
+                self.publishFullPeerData()
                 self.delegate?.didUpdatePeerList(currentPeerIDs)
             }
         }

--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -212,8 +212,6 @@ final class BLEService: NSObject {
                 self.collectionsQueue.async(flags: .barrier) {
                     self.pendingPeripheralWrites[uuid, default: []].append(data)
                 }
-            } else {
-                SecureLogger.log("📡 Reachable via mesh (relayed announce): \(announcement.nickname) ttl=\(packet.ttl)", category: SecureLogger.session, level: .debug)
             }
         }
     }

--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -1118,14 +1118,13 @@ final class BLEService: NSObject {
             var out: [(String, BitchatPacket)] = []
             let now = Date()
             for (recipient, dict) in pendingDirectedRelays {
-                var remaining: [String: (packet: BitchatPacket, enqueuedAt: Date)] = [:]
-                for (msgID, entry) in dict {
+                for (_, entry) in dict {
                     if now.timeIntervalSince(entry.enqueuedAt) <= TransportConfig.bleDirectedSpoolWindowSeconds {
                         out.append((recipient, entry.packet))
                     }
                 }
-                // Clear recipient bucket; will be re-spooled if still no links
-                pendingDirectedRelays[recipient] = remaining
+                // Clear recipient bucket; items will be re-spooled if still no links
+                pendingDirectedRelays.removeValue(forKey: recipient)
             }
             return out
         }

--- a/bitchat/Services/NostrTransport.swift
+++ b/bitchat/Services/NostrTransport.swift
@@ -31,6 +31,7 @@ final class NostrTransport: Transport {
     func emergencyDisconnectAll() { /* no-op */ }
 
     func isPeerConnected(_ peerID: String) -> Bool { false }
+    func isPeerReachable(_ peerID: String) -> Bool { false }
     func peerNickname(peerID: String) -> String? { nil }
     func getPeerNicknames() -> [String : String] { [:] }
 

--- a/bitchat/Services/RelayController.swift
+++ b/bitchat/Services/RelayController.swift
@@ -15,6 +15,7 @@ struct RelayController {
                        isDirectedEncrypted: Bool,
                        isDirectedFragment: Bool,
                        isHandshake: Bool,
+                       isAnnounce: Bool,
                        degree: Int,
                        highDegreeThreshold: Int) -> RelayDecision {
         // Suppress obvious non-relays
@@ -46,7 +47,11 @@ struct RelayController {
         // TTL clamping for broadcast
         // - Dense graphs: keep very low to avoid floods
         // - Sparse graphs: allow slightly longer reach for multi-hop discovery
-        let ttlCap: UInt8 = degree >= highDegreeThreshold ? 3 : 6
+        // - Announces in sparse graphs get a bit more headroom
+        let ttlCap: UInt8 = {
+            if degree >= highDegreeThreshold { return 3 }
+            return isAnnounce ? 7 : 6
+        }()
         let clamped = max(1, min(ttl, ttlCap))
         let newTTL = clamped &- 1
 

--- a/bitchat/Services/RelayController.swift
+++ b/bitchat/Services/RelayController.swift
@@ -48,9 +48,10 @@ struct RelayController {
         let newTTL = clamped &- 1
 
         // Wider jitter window to allow duplicate suppression to win more often
+        // For sparse graphs (<=2), relay quickly to avoid cancellation races
         let delayMs: Int
         switch degree {
-        case 0...2: delayMs = Int.random(in: 40...100)
+        case 0...2: delayMs = Int.random(in: 10...40)
         case 3...5: delayMs = Int.random(in: 60...150)
         case 6...9: delayMs = Int.random(in: 80...180)
         default:    delayMs = Int.random(in: 100...220)

--- a/bitchat/Services/Transport.swift
+++ b/bitchat/Services/Transport.swift
@@ -29,6 +29,7 @@ protocol Transport: AnyObject {
 
     // Connectivity and peers
     func isPeerConnected(_ peerID: String) -> Bool
+    func isPeerReachable(_ peerID: String) -> Bool
     func peerNickname(peerID: String) -> String?
     func getPeerNicknames() -> [String: String]
 

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -85,7 +85,9 @@ enum TransportConfig {
     static let bleThreadSleepWriteShortDelaySeconds: TimeInterval = 0.05
     static let bleExpectedWritePerFragmentMs: Int = 8
     static let bleExpectedWriteMaxMs: Int = 2000
-    static let bleFragmentSpacingMs: Int = 6
+    // Faster fragment pacing; use slightly tighter spacing for directed trains
+    static let bleFragmentSpacingMs: Int = 5
+    static let bleFragmentSpacingDirectedMs: Int = 4
     static let bleAnnounceIntervalSeconds: TimeInterval = 4.0
     static let bleDutyOnDurationDense: TimeInterval = 3.0
     static let bleDutyOffDurationDense: TimeInterval = 15.0

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -62,7 +62,7 @@ enum TransportConfig {
     static let uiRecentCutoffFiveMinutesSeconds: TimeInterval = 5 * 60
 
     // BLE maintenance & thresholds
-    static let bleMaintenanceInterval: TimeInterval = 10.0
+    static let bleMaintenanceInterval: TimeInterval = 5.0
     static let bleMaintenanceLeewaySeconds: Int = 1
     static let bleIsolationRelaxThresholdSeconds: TimeInterval = 60
     static let bleRecentTimeoutWindowSeconds: TimeInterval = 60
@@ -84,13 +84,13 @@ enum TransportConfig {
     static let bleExpectedWritePerFragmentMs: Int = 8
     static let bleExpectedWriteMaxMs: Int = 2000
     static let bleFragmentSpacingMs: Int = 6
-    static let bleAnnounceIntervalSeconds: TimeInterval = 10.0
+    static let bleAnnounceIntervalSeconds: TimeInterval = 4.0
     static let bleDutyOnDurationDense: TimeInterval = 3.0
     static let bleDutyOffDurationDense: TimeInterval = 15.0
-    static let bleConnectedAnnounceBaseSecondsDense: TimeInterval = 90.0
-    static let bleConnectedAnnounceBaseSecondsSparse: TimeInterval = 45.0
-    static let bleConnectedAnnounceJitterDense: TimeInterval = 20.0
-    static let bleConnectedAnnounceJitterSparse: TimeInterval = 7.5
+    static let bleConnectedAnnounceBaseSecondsDense: TimeInterval = 30.0
+    static let bleConnectedAnnounceBaseSecondsSparse: TimeInterval = 15.0
+    static let bleConnectedAnnounceJitterDense: TimeInterval = 8.0
+    static let bleConnectedAnnounceJitterSparse: TimeInterval = 4.0
 
     // Location
     static let locationDistanceFilterMeters: Double = 1000
@@ -129,12 +129,12 @@ enum TransportConfig {
     static let geoRelayFetchIntervalSeconds: TimeInterval = 60 * 60 * 24
 
     // BLE operational delays
-    static let bleInitialAnnounceDelaySeconds: TimeInterval = 2.0
+    static let bleInitialAnnounceDelaySeconds: TimeInterval = 0.6
     static let bleConnectTimeoutSeconds: TimeInterval = 8.0
     static let bleRestartScanDelaySeconds: TimeInterval = 0.1
-    static let blePostSubscribeAnnounceDelaySeconds: TimeInterval = 0.1
+    static let blePostSubscribeAnnounceDelaySeconds: TimeInterval = 0.05
     static let blePostAnnounceDelaySeconds: TimeInterval = 0.4
-    static let bleForceAnnounceMinIntervalSeconds: TimeInterval = 0.2
+    static let bleForceAnnounceMinIntervalSeconds: TimeInterval = 0.15
 
     // Content hashing / formatting
     static let contentKeyPrefixLength: Int = 256

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -72,6 +72,9 @@ enum TransportConfig {
     static let bleRSSIConnectedThreshold: Int = -85
     static let bleRSSIHighTimeoutThreshold: Int = -80
     static let blePeerInactivityTimeoutSeconds: TimeInterval = 20.0
+    // How long to retain a peer as "reachable" (not directly connected) since lastSeen
+    static let bleReachabilityRetentionVerifiedSeconds: TimeInterval = 600.0   // 10 minutes for verified/favorites
+    static let bleReachabilityRetentionUnverifiedSeconds: TimeInterval = 120.0 // 2 minutes for unknown/unverified
     static let bleFragmentLifetimeSeconds: TimeInterval = 30.0
     static let bleIngressRecordLifetimeSeconds: TimeInterval = 3.0
     static let bleConnectTimeoutBackoffWindowSeconds: TimeInterval = 120.0

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -80,6 +80,8 @@ enum TransportConfig {
     static let bleConnectTimeoutBackoffWindowSeconds: TimeInterval = 120.0
     static let bleRecentPacketWindowSeconds: TimeInterval = 30.0
     static let bleRecentPacketWindowMaxCount: Int = 100
+    // Keep scanning fully ON when we saw traffic very recently
+    static let bleRecentTrafficForceScanSeconds: TimeInterval = 10.0
     static let bleThreadSleepWriteShortDelaySeconds: TimeInterval = 0.05
     static let bleExpectedWritePerFragmentMs: Int = 8
     static let bleExpectedWriteMaxMs: Int = 2000
@@ -135,6 +137,9 @@ enum TransportConfig {
     static let blePostSubscribeAnnounceDelaySeconds: TimeInterval = 0.05
     static let blePostAnnounceDelaySeconds: TimeInterval = 0.4
     static let bleForceAnnounceMinIntervalSeconds: TimeInterval = 0.15
+
+    // Store-and-forward for directed packets at relays
+    static let bleDirectedSpoolWindowSeconds: TimeInterval = 15.0
 
     // Content hashing / formatting
     static let contentKeyPrefixLength: Int = 256

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -73,8 +73,8 @@ enum TransportConfig {
     static let bleRSSIHighTimeoutThreshold: Int = -80
     static let blePeerInactivityTimeoutSeconds: TimeInterval = 20.0
     // How long to retain a peer as "reachable" (not directly connected) since lastSeen
-    static let bleReachabilityRetentionVerifiedSeconds: TimeInterval = 600.0   // 10 minutes for verified/favorites
-    static let bleReachabilityRetentionUnverifiedSeconds: TimeInterval = 120.0 // 2 minutes for unknown/unverified
+    static let bleReachabilityRetentionVerifiedSeconds: TimeInterval = 21.0    // 21s for verified/favorites
+    static let bleReachabilityRetentionUnverifiedSeconds: TimeInterval = 21.0  // 21s for unknown/unverified
     static let bleFragmentLifetimeSeconds: TimeInterval = 30.0
     static let bleIngressRecordLifetimeSeconds: TimeInterval = 3.0
     static let bleConnectTimeoutBackoffWindowSeconds: TimeInterval = 120.0

--- a/bitchat/Services/UnifiedPeerService.swift
+++ b/bitchat/Services/UnifiedPeerService.swift
@@ -143,8 +143,11 @@ class UnifiedPeerService: ObservableObject, TransportPeerEventsDelegate {
             }
         }
         
-        // Phase 5: Update published properties
-        self.peers = enrichedPeers
+        // Phase 5: Filter out offline non-mutual peers and update published properties
+        let filtered = enrichedPeers.filter { p in
+            p.isConnected || p.isReachable || p.isMutualFavorite
+        }
+        self.peers = filtered
         self.connectedPeerIDs = connected
         self.favorites = favoritesList
         self.mutualFavorites = mutualsList

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -935,6 +935,13 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             if unreadPrivateMessages.contains(noiseKeyHex) {
                 return true
             }
+            // Also check for geohash (Nostr) DM conv key if this peer has a known Nostr pubkey
+            if let nostrHex = peer.nostrPublicKey {
+                let convKey = "nostr_" + String(nostrHex.prefix(TransportConfig.nostrConvKeyPrefixLength))
+                if unreadPrivateMessages.contains(convKey) {
+                    return true
+                }
+            }
         }
         
         // Get the peer's nickname to check for temporary Nostr peer IDs

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1874,6 +1874,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         // Determine routing method and recipient nickname
         guard let noiseKey = Data(hexString: peerID) else { return }
         let isConnected = meshService.isPeerConnected(peerID)
+        let isReachable = meshService.isPeerReachable(peerID)
         let favoriteStatus = FavoritesPersistenceService.shared.getFavoriteStatus(for: noiseKey)
         let isMutualFavorite = favoriteStatus?.isMutual ?? false
         let hasNostrKey = favoriteStatus?.peerNostrPublicKey != nil
@@ -1913,8 +1914,8 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         // Trigger UI update for sent message
         objectWillChange.send()
         
-        // Send via appropriate transport (BLE if connected, else Nostr when possible)
-        if isConnected || (isMutualFavorite && hasNostrKey) {
+        // Send via appropriate transport (BLE if connected/reachable, else Nostr when possible)
+        if isConnected || isReachable || (isMutualFavorite && hasNostrKey) {
             messageRouter.sendPrivate(content, to: peerID, recipientNickname: recipientNickname ?? "user", messageID: messageID)
             // Optimistically mark as sent for both transports; delivery/read will update subsequently
             if let idx = privateChats[peerID]?.firstIndex(where: { $0.id == messageID }) {
@@ -2542,16 +2543,12 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
             }
         }
         
-        // If we know the original transport, use it for the read receipt
+        // If this originated over Nostr, skip (handled by Nostr code paths)
         if originalTransport == "nostr" {
-            // Skip read receipts for Nostr messages - unnecessary complexity
-            // The radical simplification plan says to accept occasional loss
-        } else if meshService.peerNickname(peerID: actualPeerID) != nil {
-            // Use mesh for connected peers (default behavior)
-            messageRouter.sendReadReceipt(receipt, to: actualPeerID)
-        } else {
-            // Skip read receipts for offline peers - fire and forget principle
+            return
         }
+        // Use router to decide (mesh if reachable, else Nostr if available)
+        messageRouter.sendReadReceipt(receipt, to: actualPeerID)
     }
     
     @MainActor

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1247,8 +1247,8 @@ struct ContentView: View {
                                         .foregroundColor(textColor)
                                         .accessibilityLabel("Connected via mesh")
                                 case .meshReachable:
-                                    // point.3 icon for reachable via mesh (not directly connected)
-                                    Image(systemName: "point.3.connected.trianglepath.dotted")
+                                    // point.3 filled icon for reachable via mesh (not directly connected)
+                                    Image(systemName: "point.3.filled.connected.trianglepath.dotted")
                                         .font(.system(size: 14))
                                         .foregroundColor(textColor)
                                         .accessibilityLabel("Reachable via mesh")

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1036,9 +1036,8 @@ struct ContentView: View {
         case .mesh:
             let counts = viewModel.allPeers.reduce(into: (others: 0, mesh: 0)) { counts, peer in
                 guard peer.id != viewModel.meshService.myPeerID else { return }
-                let isMeshConnected = peer.isConnected
-                if isMeshConnected { counts.mesh += 1; counts.others += 1 }
-                else if peer.isMutualFavorite { counts.others += 1 }
+                if peer.isConnected { counts.mesh += 1; counts.others += 1 }
+                else if peer.isReachable { counts.others += 1 }
             }
             let meshBlue = Color(hue: 0.60, saturation: 0.85, brightness: 0.82)
             let color: Color = counts.mesh > 0 ? meshBlue : Color.secondary
@@ -1248,8 +1247,8 @@ struct ContentView: View {
                                         .foregroundColor(textColor)
                                         .accessibilityLabel("Connected via mesh")
                                 case .meshReachable:
-                                    // Antenna icon for reachable via mesh (not directly connected)
-                                    Image(systemName: "antenna.radiowaves.left.and.right")
+                                    // point.3 icon for reachable via mesh (not directly connected)
+                                    Image(systemName: "point.3.connected.trianglepath.dotted")
                                         .font(.system(size: 14))
                                         .foregroundColor(textColor)
                                         .accessibilityLabel("Reachable via mesh")

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1247,6 +1247,12 @@ struct ContentView: View {
                                         .font(.system(size: 14))
                                         .foregroundColor(textColor)
                                         .accessibilityLabel("Connected via mesh")
+                                case .meshReachable:
+                                    // Antenna icon for reachable via mesh (not directly connected)
+                                    Image(systemName: "antenna.radiowaves.left.and.right")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(textColor)
+                                        .accessibilityLabel("Reachable via mesh")
                                 case .nostrAvailable:
                                     // Purple globe for Nostr
                                     Image(systemName: "globe")

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1180,20 +1180,11 @@ struct ContentView: View {
     
     @ViewBuilder
     private func privateHeaderContent(for privatePeerID: String) -> some View {
-        // Prefer short (mesh) ID when mesh-connected (radio). Only use full Noise key when not connected (globe).
+        // Prefer short (mesh) ID whenever available for encryption/session status; keep stable key for display resolution only.
         let headerPeerID: String = {
-            if privatePeerID.count == 16 {
-                let isMeshConnected = viewModel.meshService.isPeerConnected(privatePeerID) || viewModel.connectedPeers.contains(privatePeerID)
-                if !isMeshConnected, let stable = viewModel.getNoiseKeyForShortID(privatePeerID) {
-                    return stable
-                }
-            } else if privatePeerID.count == 64 {
-                // If we have a full Noise key and a corresponding short ID is currently mesh-connected, prefer short ID
-                if let short = viewModel.getShortIDForNoiseKey(privatePeerID) {
-                    if viewModel.meshService.isPeerConnected(short) || viewModel.connectedPeers.contains(short) {
-                        return short
-                    }
-                }
+            if privatePeerID.count == 64 {
+                // Map stable Noise key to short ID if we know it (even if not directly connected)
+                if let short = viewModel.getShortIDForNoiseKey(privatePeerID) { return short }
             }
             return privatePeerID
         }()
@@ -1208,10 +1199,29 @@ struct ContentView: View {
                     return "#\(ch.geohash)/@\(disp)"
                 }
             }
-            return peer?.displayName ?? 
-                   viewModel.meshService.peerNickname(peerID: headerPeerID) ??
-                   FavoritesPersistenceService.shared.getFavoriteStatus(for: Data(hexString: headerPeerID) ?? Data())?.peerNickname ?? 
-                   "Unknown"
+            // Try mesh/unified peer display
+            if let name = peer?.displayName { return name }
+            // Try direct mesh nickname (connected-only)
+            if let name = viewModel.meshService.peerNickname(peerID: headerPeerID) { return name }
+            // Try favorite nickname by stable Noise key
+            if let fav = FavoritesPersistenceService.shared.getFavoriteStatus(for: Data(hexString: headerPeerID) ?? Data()),
+               !fav.peerNickname.isEmpty { return fav.peerNickname }
+            // Fallback: resolve from persisted social identity via fingerprint mapping
+            if headerPeerID.count == 16 {
+                let candidates = SecureIdentityStateManager.shared.getCryptoIdentitiesByPeerIDPrefix(headerPeerID)
+                if let id = candidates.first,
+                   let social = SecureIdentityStateManager.shared.getSocialIdentity(for: id.fingerprint) {
+                    if let pet = social.localPetname, !pet.isEmpty { return pet }
+                    if !social.claimedNickname.isEmpty { return social.claimedNickname }
+                }
+            } else if headerPeerID.count == 64, let keyData = Data(hexString: headerPeerID) {
+                let fp = keyData.sha256Fingerprint()
+                if let social = SecureIdentityStateManager.shared.getSocialIdentity(for: fp) {
+                    if let pet = social.localPetname, !pet.isEmpty { return pet }
+                    if !social.claimedNickname.isEmpty { return social.claimedNickname }
+                }
+            }
+            return "Unknown"
         }()
         let isNostrAvailable: Bool = {
             guard let connectionState = peer?.connectionState else { 
@@ -1262,6 +1272,12 @@ struct ContentView: View {
                                     // Should not happen for PM header, but handle gracefully
                                     EmptyView()
                                 }
+                            } else if viewModel.meshService.isPeerReachable(headerPeerID) {
+                                // Fallback: reachable via mesh but not in current peer list
+                                Image(systemName: "point.3.filled.connected.trianglepath.dotted")
+                                    .font(.system(size: 14))
+                                    .foregroundColor(textColor)
+                                    .accessibilityLabel("Reachable via mesh")
                             } else if isNostrAvailable {
                                 // Fallback to Nostr if peer not in list but is mutual favorite
                                 Image(systemName: "globe")
@@ -1280,7 +1296,14 @@ struct ContentView: View {
                                 .font(.system(size: 16, weight: .medium, design: .monospaced))
                                 .foregroundColor(textColor)                            // Dynamic encryption status icon (hide for geohash DMs)
                             if !privatePeerID.hasPrefix("nostr_") {
-                                let encryptionStatus = viewModel.getEncryptionStatus(for: headerPeerID)
+                                // Use short peer ID if available for encryption status (sessions keyed by short ID)
+                                let statusPeerID: String = {
+                                    if privatePeerID.count == 64, let short = viewModel.getShortIDForNoiseKey(privatePeerID) {
+                                        return short
+                                    }
+                                    return headerPeerID
+                                }()
+                                let encryptionStatus = viewModel.getEncryptionStatus(for: statusPeerID)
                                 if let icon = encryptionStatus.icon {
                                     Image(systemName: icon)
                                         .font(.system(size: 14))

--- a/bitchat/Views/MeshPeerList.swift
+++ b/bitchat/Views/MeshPeerList.swift
@@ -115,6 +115,14 @@ struct MeshPeerList: View {
 
                         Spacer()
 
+                        // Unread message indicator for this peer
+                        if !isMe, item.hasUnread {
+                            Image(systemName: "envelope.fill")
+                                .font(.system(size: 10))
+                                .foregroundColor(.yellow)
+                                .help("New messages")
+                        }
+
                         if !isMe {
                             Button(action: { onToggleFavorite(peer.id) }) {
                                 Image(systemName: (peer.favoriteStatus?.isFavorite ?? false) ? "star.fill" : "star")

--- a/bitchat/Views/MeshPeerList.swift
+++ b/bitchat/Views/MeshPeerList.swift
@@ -54,7 +54,7 @@ struct MeshPeerList: View {
                                 .foregroundColor(baseColor)
                         } else if peer.isReachable {
                             // Mesh-reachable (relayed): point.3 icon
-                            Image(systemName: "point.3.connected.trianglepath.dotted")
+                            Image(systemName: "point.3.filled.connected.trianglepath.dotted")
                                 .font(.system(size: 10))
                                 .foregroundColor(baseColor)
                         } else if peer.isMutualFavorite {

--- a/bitchat/Views/MeshPeerList.swift
+++ b/bitchat/Views/MeshPeerList.swift
@@ -52,6 +52,11 @@ struct MeshPeerList: View {
                             Image(systemName: "antenna.radiowaves.left.and.right")
                                 .font(.system(size: 10))
                                 .foregroundColor(baseColor)
+                        } else if peer.isReachable {
+                            // Mesh-reachable (relayed): point.3 icon
+                            Image(systemName: "point.3.connected.trianglepath.dotted")
+                                .font(.system(size: 10))
+                                .foregroundColor(baseColor)
                         } else if peer.isMutualFavorite {
                             // Mutual favorite reachable via Nostr: globe icon (purple)
                             Image(systemName: "globe")

--- a/bitchat/Views/MeshPeerList.swift
+++ b/bitchat/Views/MeshPeerList.swift
@@ -119,7 +119,7 @@ struct MeshPeerList: View {
                         if !isMe, item.hasUnread {
                             Image(systemName: "envelope.fill")
                                 .font(.system(size: 10))
-                                .foregroundColor(.yellow)
+                                .foregroundColor(.orange)
                                 .help("New messages")
                         }
 


### PR DESCRIPTION
This PR significantly improves mesh reliability, reachability, and user experience for small-to-medium networks while preserving battery in dense graphs. It also introduces authenticated presence and better direct-vs-mesh semantics.

Summary
- Robust multi-hop DM relays and handshakes with lower latency.
- Signed public messages and signed announces; verify relayed messages.
- Clear presence model: connected vs mesh-reachable, with UI iconography.
- Faster, adaptive announces and proactive nudges (handshake and recent-traffic).
- Directed store-and-forward: short-lifetime spooling at relays.
- Range improvements: announce TTL=7 in sparse meshes; no fanout subsetting for announces.
- UI/UX: DM header icons; fix “Unknown” name; unread envelope in peer list (orange).
- Logging, backoff improvements; reduce connect thrash/flapping.

Key Transport/Relay Changes
- RelayController
  - Broadcast TTL caps: sparse=6 (public), dense=3; announces in sparse meshes get TTL=7.
  - Tighter jitter for critical traffic:
    - Handshake: 10–35 ms (was 20–60 ms)
    - Directed encrypted/fragment: 20–60 ms (was 40–120 ms)
- BLEService
  - Directed spooling: queue handshake/DM/acks up to 15s if no link; flush on new links and periodically.
  - Announce special-case: no K-of-N fanout subsetting; always send across all links.
  - “Afterglow” re-announce 300–600 ms after first-seen peers for quicker presence spread.
  - Neighbor change rebroadcast: resend last 2–3 unique announces (staggered) when a new link forms.
  - Faster fragments: 5 ms spacing globally; 4 ms for directed trains.
  - Adaptive scanning: force ON when ≤2 neighbors or any traffic in the last 10s.
  - Proactive announces: on handshake completion and when recent traffic with cooldown.
  - Connectivity checks now publish snapshots so peer icons refresh in real time.

Public Message Signing + Verification
- All outbound public `.message` packets are Ed25519-signed (Noise service signing key).
- Announce packets are signed; handleAnnounce requires verified signature and key consistency.
- Persist cryptographic identity + signing key via SecureIdentityStateManager.
- On receive (public message): accept if sender is known/verified, else verify via persisted signing key by fingerprint prefix.

Routing/Reachability/DMs
- New API: `Transport.isPeerReachable(_:)` exposes “reachable via mesh” state (recently seen, not directly connected).
- MessageRouter and ChatViewModel now route DMs (and READ/DELIVERED acks) when peer is reachable (not only directly connected). BLE initiates handshakes and queues until established.

Presence Model + UI
- UnifiedPeerService: list shows connected + reachable + mutual favorites only (hides offline non-mutuals).
- BitchatPeer connection states: bluetoothConnected, meshReachable, nostrAvailable.
- MeshPeerList icons:
  - Connected: antenna.radiowaves
  - Reachable (mesh): point.3.filled.connected.trianglepath.dotted
  - Nostr: globe
  - Self: person.fill
- DM header
  - Shows transport icon + lock/checkmark based on session.
  - Fix mapping: when only full Noise key is known, map to short mesh ID for encryption status so it doesn’t display “not encrypted/handshake”.
- Unread indicator: orange envelope next to peers with unread DMs; checks stable Noise key and Nostr conv key where known.

Announce Cadence (TransportConfig)
- Discovery (0 peers): 4s (was 10s).
- Connected sparse (1–5): 15s ± 4s (was 45s ± 7.5s).
- Connected dense (≥6): 30s ± 8s (was 90s ± 20s).
- Initial announce: 0.6s (was 2.0s).
- Post-subscribe announce: 50 ms (was 100 ms).
- Force-send minimum spacing: 150 ms (was 200 ms).
- Maintenance interval: 5s (was 10s).

Config Knobs (new/changed)
- `messageTTLDefault = 7` (unchanged default; clamp logic in RelayController)
- `bleFragmentSpacingMs = 5`, `bleFragmentSpacingDirectedMs = 4`
- `bleDirectedSpoolWindowSeconds = 15.0`
- `bleRecentTrafficForceScanSeconds = 10.0`
- Announce TTL caps now: sparse announces=7; other broadcasts sparse=6; dense=3.

Compatibility + Interop
- Signed announces required: unverified announces are ignored (prevents spoofing). Legacy clients that don’t sign announces will not appear.
- Public message verification is lenient for known peers (accepts known/verified senders even if unsigned) but verifies whenever signing key is known for relayed paths.

Testing/Verification Steps
1) 3-node mesh (sol ↔ mac ↔ jack)
   - jack sees sol as mesh-reachable; DMs jack↔sol work via mac.
   - Disconnect a link intermittently: directed spooling replays messages after links reappear.
2) 4-node chain (rick → calle → sol → mac → jack)
   - jack learns rick via multi-hop announces (TTL 7 for sparse announces).
   - jack can DM rick; handshake and DMs propagate with tightened jitter; fragments pace at 4 ms.
3) UI checks
   - Mesh list icons update promptly when connection flips.
   - DM header shows correct transport + encryption states.
   - Unread envelope (orange) shows for unread peers; geohash DMs contribute to unread when peer has known Nostr key.

Risk/Tradeoffs
- Slightly higher announce traffic in sparse graphs; mitigated by fanout only for announces and jitter.
- Store-and-forward caches small directed payloads for 15s; bounded key space and periodic cleanup.
- Strict signed-announce requirement partitions from legacy nodes that don’t sign; acceptable per current security model.

Follow-ups (optional)
- Capability bits in announces (“supports signed public msgs”, “requires signed announces”) for smoother legacy interop.
- Last-hop memory for directed routing (prefer known good next hop, then fanout).
- Very small TTL bump for public broadcasts in ultra-sparse scenarios if needed.

