### PR TITLE
Update README to explain hybrid messaging architecture, nostr integration, and channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,59 +2,108 @@
 
 ## bitchat
 
-A decentralized peer-to-peer messaging app that works over Bluetooth mesh networks. No internet required, no servers, no phone numbers. It's the side-groupchat. 
+A decentralized peer-to-peer messaging app with dual transport architecture: local Bluetooth mesh networks for offline communication and internet-based Nostr protocol for global reach. No accounts, no phone numbers, no central servers. It's the side-groupchat.
 
 [bitchat.free](http://bitchat.free)
 
 📲 [App Store](https://apps.apple.com/us/app/bitchat-mesh/id6748219622)
 
 > [!WARNING]
-> Private messages have not received external security review and may contain vulnerabilities. Do not use for sensitive use cases, and do not rely on its security until it has been reviewed. Now uses the [Noise Protocol](http://www.noiseprotocol.org) for identity and encryption. Public local chat (the main feature) has no security concerns. 
-
+> Private messages have not received external security review and may contain vulnerabilities. Do not use for sensitive use cases, and do not rely on its security until it has been reviewed. Now uses the [Noise Protocol](http://www.noiseprotocol.org) for identity and encryption. Public local chat (the main feature) has no security concerns.
 
 ## License
 
 This project is released into the public domain. See the [LICENSE](LICENSE) file for details.
 
-
 ## Features
 
+- **Dual Transport Architecture**: Bluetooth mesh for offline + Nostr protocol for internet-based messaging
+- **Location-Based Channels**: Geographic chat rooms using geohash coordinates over global Nostr relays
+- **Intelligent Message Routing**: Automatically chooses best transport (Bluetooth → Nostr fallback)
 - **Decentralized Mesh Network**: Automatic peer discovery and multi-hop message relay over Bluetooth LE
 - **Privacy First**: No accounts, no phone numbers, no persistent identifiers
-- **Private Message End-to-End Encryption**: [Noise Protocol](http://noiseprotocol.org)
+- **Private Message End-to-End Encryption**: [Noise Protocol](http://noiseprotocol.org) for mesh, NIP-17 for Nostr
 - **IRC-Style Commands**: Familiar `/slap`, `/msg`, `/who` style interface
 - **Universal App**: Native support for iOS and macOS
 - **Emergency Wipe**: Triple-tap to instantly clear all data
 - **Performance Optimizations**: LZ4 message compression, adaptive battery modes, and optimized networking
 
-
 ## [Technical Architecture](https://deepwiki.com/permissionlesstech/bitchat)
 
-### Binary Protocol
-bitchat uses an efficient binary protocol optimized for Bluetooth LE:
-- Compact packet format with 1-byte type field
-- TTL-based message routing (max 7 hops)
-- Automatic fragmentation for large messages
-- Message deduplication via unique IDs
+BitChat uses a **hybrid messaging architecture** with two complementary transport layers:
 
-### Mesh Networking
-- Each device acts as both client and peripheral
-- Automatic peer discovery and connection management
-- Adaptive duty cycling for battery optimization
+### Bluetooth Mesh Network (Offline)
+
+- **Local Communication**: Direct peer-to-peer within Bluetooth range
+- **Multi-hop Relay**: Messages route through nearby devices (max 7 hops)
+- **No Internet Required**: Works completely offline in disaster scenarios
+- **Noise Protocol Encryption**: End-to-end encryption with forward secrecy
+- **Binary Protocol**: Compact packet format optimized for Bluetooth LE constraints
+- **Automatic Discovery**: Peer discovery and connection management
+- **Adaptive Power**: Battery-optimized duty cycling
+
+### Nostr Protocol (Internet)
+
+- **Global Reach**: Connect with users worldwide via internet relays
+- **Location Channels**: Geographic chat rooms using geohash coordinates
+- **290+ Relay Network**: Distributed across the globe for reliability
+- **NIP-17 Encryption**: Gift-wrapped private messages for internet privacy
+- **Ephemeral Keys**: Fresh cryptographic identity per geohash area
+
+### Channel Types
+
+#### `mesh #bluetooth`
+
+- **Transport**: Bluetooth Low Energy mesh network
+- **Scope**: Local devices within multi-hop range
+- **Internet**: Not required
+- **Use Case**: Offline communication, protests, disasters, remote areas
+
+#### Location Channels (`block #dr5rsj7`, `neighborhood #dr5rs`, `country #dr`)
+
+- **Transport**: Nostr protocol over internet
+- **Scope**: Geographic areas defined by geohash precision
+  - `block` (7 chars): City block level
+  - `neighborhood` (6 chars): District/neighborhood
+  - `city` (5 chars): City level
+  - `province` (4 chars): State/province
+  - `region` (2 chars): Country/large region
+- **Internet**: Required (connects to Nostr relays)
+- **Use Case**: Location-based community chat, local events, regional discussions
+
+### Direct Message Routing
+
+Private messages use **intelligent transport selection**:
+
+1. **Bluetooth First** (preferred when available)
+
+   - Direct connection with established Noise session
+   - Fastest and most private option
+
+2. **Nostr Fallback** (when Bluetooth unavailable)
+
+   - Uses recipient's Nostr public key
+   - NIP-17 gift-wrapping for privacy
+   - Routes through global relay network
+
+3. **Smart Queuing** (when neither available)
+   - Messages queued until transport becomes available
+   - Automatic delivery when connection established
 
 For detailed protocol documentation, see the [Technical Whitepaper](WHITEPAPER.md).
-
 
 ## Setup
 
 ### Option 1: Using XcodeGen (Recommended)
 
 1. Install XcodeGen if you haven't already:
+
    ```bash
    brew install xcodegen
    ```
 
 2. Generate the Xcode project:
+
    ```bash
    cd bitchat
    xcodegen generate
@@ -68,6 +117,7 @@ For detailed protocol documentation, see the [Technical Whitepaper](WHITEPAPER.m
 ### Option 2: Using Swift Package Manager
 
 1. Open the project in Xcode:
+
    ```bash
    cd bitchat
    open Package.swift
@@ -84,5 +134,5 @@ For detailed protocol documentation, see the [Technical Whitepaper](WHITEPAPER.m
 
 ### Option 4: just
 
-Want to try this on macos: `just run` will set it up and run from source. 
+Want to try this on macos: `just run` will set it up and run from source.
 Run `just clean` afterwards to restore things to original state for mobile app building and development.


### PR DESCRIPTION
### Purpose
BitChat's hybrid architecture (Bluetooth mesh + Nostr internet protocol) wasn't documented, causing confusion about how location channels work across large geographic areas despite Bluetooth's limited range, and when internet is required vs. optional.

### Changes
- Updated project description to clarify dual transport architecture
- Added Technical Architecture section explaining:
  - Bluetooth mesh (offline, local, multi-hop)
  - Nostr protocol (internet-based, global relays)
  - Channel types and routing logic
- Clarified geohash precision levels for location channels