### PR TITLE
UI: diversify peer colors; smarter geo notifications; 21m live location

### DIFF
--- a/bitchat/Services/NotificationService.swift
+++ b/bitchat/Services/NotificationService.swift
@@ -90,6 +90,15 @@ class NotificationService {
         }
     }
     
+    // Geohash public chat notification with deep link to a specific geohash
+    func sendGeohashActivityNotification(geohash: String, titlePrefix: String = "#", bodyPreview: String) {
+        let title = "\(titlePrefix)\(geohash)"
+        let identifier = "geo-activity-\(geohash)-\(Date().timeIntervalSince1970)"
+        let deeplink = "bitchat://geohash/\(geohash)"
+        let userInfo: [String: Any] = ["deeplink": deeplink]
+        sendLocalNotification(title: title, body: bodyPreview, identifier: identifier, userInfo: userInfo)
+    }
+
     func sendNetworkAvailableNotification(peerCount: Int) {
         let title = "👥 bitchatters nearby!"
         let body = peerCount == 1 ? "1 person around" : "\(peerCount) people around"

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -100,7 +100,13 @@ enum TransportConfig {
 
     // Location
     static let locationDistanceFilterMeters: Double = 1000
+    // Live (channel sheet open) distance threshold for meaningful updates
+    static let locationDistanceFilterLiveMeters: Double = 21.0
     static let locationLiveRefreshInterval: TimeInterval = 5.0
+
+    // Notifications (geohash)
+    static let uiGeoNotifyCooldownSeconds: TimeInterval = 60.0
+    static let uiGeoNotifySnippetMaxLen: Int = 80
 
     // Nostr geohash
     static let nostrGeohashInitialLookbackSeconds: TimeInterval = 3600
@@ -169,6 +175,10 @@ enum TransportConfig {
     // UI color tuning
     static let uiColorHueAvoidanceDelta: Double = 0.05
     static let uiColorHueOffset: Double = 0.12
+    // Peer list palette
+    static let uiPeerPaletteSlots: Int = 36
+    static let uiPeerPaletteRingBrightnessDeltaLight: Double = 0.07
+    static let uiPeerPaletteRingBrightnessDeltaDark: Double = -0.07
 
     // UI windowing (infinite scroll)
     static let uiWindowInitialCountPublic: Int = 300


### PR DESCRIPTION
- Use minimal-distance hue palette for mesh and geohash lists; align chat sender colors with list palette.
- Add foreground geo notifications for different channels; deep-link to bitchat://geohash/<gh>; per-geohash 60s cooldown; respect self/blocks.
- Global geohash sampling runs outside the sheet; delegate handles deeplinks and suppresses when already in-channel.
- Switch location channel sheet to continuous CoreLocation with 21m distance filter; add config knob.
- Only link geohash hashtags when standalone (no @name#abcd or word#abcd).
- Include mesh-reachable peers in mesh counts and in "bitchatters nearby" notification.
- Add TransportConfig knobs for palette and geo notifications.