### PR TITLE
Geohash Bookmarks + Rising‑Edge Notifications + Friendly Names

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		048A4BE72E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE82E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE92E5CCCC300162C4B /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
+		048A4C282E5FCD6600162C4A /* GeohashBookmarksStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */; };
+		048A4C292E5FCD6600162C4A /* GeohashBookmarksStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */; };
+		048A4C2B2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */; };
+		048A4C2C2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */; };
 		049BD3902E4EC4F0001A566B /* PrivateChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049BD38F2E4EC4F0001A566B /* PrivateChatManager.swift */; };
 		049BD3912E4EC4F0001A566B /* AutocompleteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049BD38C2E4EC4F0001A566B /* AutocompleteService.swift */; };
 		049BD3922E4EC4F0001A566B /* CommandProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049BD38D2E4EC4F0001A566B /* CommandProcessor.swift */; };
@@ -205,6 +209,8 @@
 		047502B32E55FED60083520F /* MeshPeerList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshPeerList.swift; sourceTree = "<group>"; };
 		047502B82E560F690083520F /* RelayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayController.swift; sourceTree = "<group>"; };
 		048A4BE62E5CCCC300162C4A /* TransportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConfig.swift; sourceTree = "<group>"; };
+		048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStore.swift; sourceTree = "<group>"; };
+		048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStoreTests.swift; sourceTree = "<group>"; };
 		049BD38C2E4EC4F0001A566B /* AutocompleteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteService.swift; sourceTree = "<group>"; };
 		049BD38D2E4EC4F0001A566B /* CommandProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandProcessor.swift; sourceTree = "<group>"; };
 		049BD38F2E4EC4F0001A566B /* PrivateChatManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateChatManager.swift; sourceTree = "<group>"; };
@@ -483,6 +489,7 @@
 		C3D98EB3E1B455E321F519F4 /* bitchatTests */ = {
 			isa = PBXGroup;
 			children = (
+				048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */,
 				D69A18D27F9A565FD6041E12 /* Info.plist */,
 				047502912E547ACC0083520F /* LocationChannelsTests.swift */,
 				C272F137CE00FC5A96E0CC06 /* NostrProtocolTests.swift */,
@@ -519,6 +526,7 @@
 		D98A3186D7E4C72E35BDF7FE /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */,
 				048A4BE62E5CCCC300162C4A /* TransportConfig.swift */,
 				AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */,
 				047502B82E560F690083520F /* RelayController.swift */,
@@ -771,6 +779,7 @@
 				0475028C2E54171C0083520F /* LocationChannelManager.swift in Sources */,
 				AFF33EF44626EF0579D17EB1 /* NoiseHandshakeCoordinator.swift in Sources */,
 				8C1AB0F2D48207E0755DA91A /* NoiseProtocol.swift in Sources */,
+				048A4C282E5FCD6600162C4A /* GeohashBookmarksStore.swift in Sources */,
 				049BD3AC2E51E38E001A566B /* PeerIDResolver.swift in Sources */,
 				D691938B4029A04CC905FDC8 /* NoiseSecurityConsiderations.swift in Sources */,
 				8A14ADADF5CD7A79919CB655 /* NoiseSession.swift in Sources */,
@@ -830,6 +839,7 @@
 				0475028D2E54171C0083520F /* LocationChannelManager.swift in Sources */,
 				6D0D4A0B1D8B659DCBAE7C9C /* NoiseHandshakeCoordinator.swift in Sources */,
 				A7187D48B07C6857DE01D0ED /* NoiseProtocol.swift in Sources */,
+				048A4C292E5FCD6600162C4A /* GeohashBookmarksStore.swift in Sources */,
 				049BD3AB2E51E38E001A566B /* PeerIDResolver.swift in Sources */,
 				9CCF09F7527EC681A13FC246 /* NoiseSecurityConsiderations.swift in Sources */,
 				92D1CF17DF88EA298F6E5E8E /* NoiseSession.swift in Sources */,
@@ -866,6 +876,7 @@
 				047502B12E55E8450083520F /* InputValidatorTests.swift in Sources */,
 				D727EA273CB214FC32612469 /* MockBluetoothMeshService.swift in Sources */,
 				047502932E547ACC0083520F /* LocationChannelsTests.swift in Sources */,
+				048A4C2B2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift in Sources */,
 				6C803BF930E7E19BE6E99EAA /* MockBLEService.swift in Sources */,
 				765254F56997F01054699AC0 /* NoiseProtocolTests.swift in Sources */,
 				968181D255CA7A804340B4DA /* NostrProtocolTests.swift in Sources */,
@@ -888,6 +899,7 @@
 				047502B02E55E8450083520F /* InputValidatorTests.swift in Sources */,
 				8851F08D88C5B1DE7B9F55C6 /* MockBluetoothMeshService.swift in Sources */,
 				047502922E547ACC0083520F /* LocationChannelsTests.swift in Sources */,
+				048A4C2C2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift in Sources */,
 				3849CA6D99B2D536636DF4A6 /* MockBLEService.swift in Sources */,
 				BC4DC75F4FB823FF40569676 /* NoiseProtocolTests.swift in Sources */,
 				EE8C3ECADAB3083A2687D50B /* NostrProtocolTests.swift in Sources */,

--- a/bitchat/Protocols/Geohash.swift
+++ b/bitchat/Protocols/Geohash.swift
@@ -87,4 +87,28 @@ enum Geohash {
         let lon = (lonInterval.0 + lonInterval.1) / 2
         return (lat, lon)
     }
+
+    /// Decodes a geohash into its latitude and longitude bounds.
+    /// - Parameter geohash: Base32 geohash string.
+    /// - Returns: (latMin, latMax, lonMin, lonMax)
+    static func decodeBounds(_ geohash: String) -> (latMin: Double, latMax: Double, lonMin: Double, lonMax: Double) {
+        var latInterval: (Double, Double) = (-90.0, 90.0)
+        var lonInterval: (Double, Double) = (-180.0, 180.0)
+
+        var isEven = true
+        for ch in geohash.lowercased() {
+            guard let cd = base32Map[ch] else { continue }
+            for mask in [16, 8, 4, 2, 1] {
+                if isEven {
+                    let mid = (lonInterval.0 + lonInterval.1) / 2
+                    if (cd & mask) != 0 { lonInterval.0 = mid } else { lonInterval.1 = mid }
+                } else {
+                    let mid = (latInterval.0 + latInterval.1) / 2
+                    if (cd & mask) != 0 { latInterval.0 = mid } else { latInterval.1 = mid }
+                }
+                isEven.toggle()
+            }
+        }
+        return (latInterval.0, latInterval.1, lonInterval.0, lonInterval.1)
+    }
 }

--- a/bitchat/Services/GeohashBookmarksStore.swift
+++ b/bitchat/Services/GeohashBookmarksStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Combine
+
+/// Stores a user-maintained list of bookmarked geohash channels.
+/// - Persistence: UserDefaults (JSON string array)
+/// - Semantics: geohashes are normalized to lowercase base32 and de-duplicated
+final class GeohashBookmarksStore: ObservableObject {
+    static let shared = GeohashBookmarksStore()
+
+    @Published private(set) var bookmarks: [String] = []
+
+    private let storeKey = "locationChannel.bookmarks"
+    private var membership: Set<String> = []
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Public API
+    func isBookmarked(_ geohash: String) -> Bool {
+        return membership.contains(Self.normalize(geohash))
+    }
+
+    func toggle(_ geohash: String) {
+        let gh = Self.normalize(geohash)
+        if membership.contains(gh) {
+            remove(gh)
+        } else {
+            add(gh)
+        }
+    }
+
+    func add(_ geohash: String) {
+        let gh = Self.normalize(geohash)
+        guard !gh.isEmpty else { return }
+        guard !membership.contains(gh) else { return }
+        bookmarks.insert(gh, at: 0)
+        membership.insert(gh)
+        persist()
+    }
+
+    func remove(_ geohash: String) {
+        let gh = Self.normalize(geohash)
+        guard membership.contains(gh) else { return }
+        if let idx = bookmarks.firstIndex(of: gh) { bookmarks.remove(at: idx) }
+        membership.remove(gh)
+        persist()
+    }
+
+    // MARK: - Persistence
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: storeKey) else { return }
+        if let arr = try? JSONDecoder().decode([String].self, from: data) {
+            // Sanitize, normalize, dedupe while preserving order (first occurrence wins)
+            var seen = Set<String>()
+            var list: [String] = []
+            for raw in arr {
+                let gh = Self.normalize(raw)
+                guard !gh.isEmpty else { continue }
+                if !seen.contains(gh) {
+                    seen.insert(gh)
+                    list.append(gh)
+                }
+            }
+            bookmarks = list
+            membership = seen
+        }
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(bookmarks) {
+            UserDefaults.standard.set(data, forKey: storeKey)
+        }
+    }
+
+    // MARK: - Helpers
+    private static func normalize(_ s: String) -> String {
+        let allowed = Set("0123456789bcdefghjkmnpqrstuvwxyz")
+        return s
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "#", with: "")
+            .filter { allowed.contains($0) }
+    }
+
+    #if DEBUG
+    /// Testing-only reset helper
+    func _resetForTesting() {
+        bookmarks.removeAll()
+        membership.removeAll()
+        persist()
+    }
+    #endif
+}

--- a/bitchat/Services/GeohashBookmarksStore.swift
+++ b/bitchat/Services/GeohashBookmarksStore.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Combine
+#if os(iOS) || os(macOS)
+import CoreLocation
+#endif
 
 /// Stores a user-maintained list of bookmarked geohash channels.
 /// - Persistence: UserDefaults (JSON string array)
@@ -8,9 +11,15 @@ final class GeohashBookmarksStore: ObservableObject {
     static let shared = GeohashBookmarksStore()
 
     @Published private(set) var bookmarks: [String] = []
+    @Published private(set) var bookmarkNames: [String: String] = [:] // geohash -> friendly name
 
     private let storeKey = "locationChannel.bookmarks"
+    private let namesStoreKey = "locationChannel.bookmarkNames"
     private var membership: Set<String> = []
+    #if os(iOS) || os(macOS)
+    private let geocoder = CLGeocoder()
+    private var resolving: Set<String> = []
+    #endif
 
     private init() {
         load()
@@ -37,6 +46,8 @@ final class GeohashBookmarksStore: ObservableObject {
         bookmarks.insert(gh, at: 0)
         membership.insert(gh)
         persist()
+        // Resolve and persist a friendly name once when added
+        resolveNameIfNeeded(for: gh)
     }
 
     func remove(_ geohash: String) {
@@ -44,6 +55,10 @@ final class GeohashBookmarksStore: ObservableObject {
         guard membership.contains(gh) else { return }
         if let idx = bookmarks.firstIndex(of: gh) { bookmarks.remove(at: idx) }
         membership.remove(gh)
+        // Clean up stored name to avoid stale cache growth
+        if bookmarkNames.removeValue(forKey: gh) != nil {
+            persistNames()
+        }
         persist()
     }
 
@@ -65,11 +80,22 @@ final class GeohashBookmarksStore: ObservableObject {
             bookmarks = list
             membership = seen
         }
+        // Load any saved names
+        if let namesData = UserDefaults.standard.data(forKey: namesStoreKey),
+           let dict = try? JSONDecoder().decode([String: String].self, from: namesData) {
+            bookmarkNames = dict
+        }
     }
 
     private func persist() {
         if let data = try? JSONEncoder().encode(bookmarks) {
             UserDefaults.standard.set(data, forKey: storeKey)
+        }
+    }
+
+    private func persistNames() {
+        if let data = try? JSONEncoder().encode(bookmarkNames) {
+            UserDefaults.standard.set(data, forKey: namesStoreKey)
         }
     }
 
@@ -83,12 +109,119 @@ final class GeohashBookmarksStore: ObservableObject {
             .filter { allowed.contains($0) }
     }
 
+    // MARK: - Name Resolution
+    /// Attempt to resolve and persist a friendly place name for a bookmarked geohash.
+    func resolveNameIfNeeded(for geohash: String) {
+        let gh = Self.normalize(geohash)
+        guard !gh.isEmpty else { return }
+        if bookmarkNames[gh] != nil { return }
+        #if os(iOS) || os(macOS)
+        if resolving.contains(gh) { return }
+        resolving.insert(gh)
+        // For very coarse geohashes, sample multiple points to capture multiple admin areas
+        if gh.count <= 2 {
+            let b = Geohash.decodeBounds(gh)
+            let pts: [CLLocation] = [
+                CLLocation(latitude: (b.latMin + b.latMax) / 2, longitude: (b.lonMin + b.lonMax) / 2), // center
+                CLLocation(latitude: b.latMin, longitude: b.lonMin),
+                CLLocation(latitude: b.latMin, longitude: b.lonMax),
+                CLLocation(latitude: b.latMax, longitude: b.lonMin),
+                CLLocation(latitude: b.latMax, longitude: b.lonMax)
+            ]
+            resolveCompositeAdminName(geohash: gh, points: pts)
+        } else {
+            let center = Geohash.decodeCenter(gh)
+            let loc = CLLocation(latitude: center.lat, longitude: center.lon)
+            geocoder.reverseGeocodeLocation(loc) { [weak self] placemarks, _ in
+                guard let self = self else { return }
+                defer { self.resolving.remove(gh) }
+                if let pm = placemarks?.first {
+                    let name = Self.nameForGeohashLength(gh.count, from: pm)
+                    if let name = name, !name.isEmpty {
+                        DispatchQueue.main.async {
+                            self.bookmarkNames[gh] = name
+                            self.persistNames()
+                        }
+                    }
+                }
+            }
+        }
+        #endif
+    }
+
+    #if os(iOS) || os(macOS)
+    private func resolveCompositeAdminName(geohash gh: String, points: [CLLocation]) {
+        var uniqueAdmins = OrderedSet<String>()
+        var idx = 0
+        func step() {
+            if idx >= points.count {
+                // Compose up to 2 names joined by ' and '
+                let finalName: String? = {
+                    let names = uniqueAdmins.array
+                    if names.count >= 2 { return names[0] + " and " + names[1] }
+                    return names.first
+                }()
+                if let finalName = finalName, !finalName.isEmpty {
+                    DispatchQueue.main.async {
+                        self.bookmarkNames[gh] = finalName
+                        self.persistNames()
+                    }
+                }
+                self.resolving.remove(gh)
+                return
+            }
+            let loc = points[idx]
+            idx += 1
+            geocoder.reverseGeocodeLocation(loc) { [weak self] placemarks, _ in
+                guard self != nil else { return }
+                if let pm = placemarks?.first {
+                    if let admin = pm.administrativeArea, !admin.isEmpty {
+                        uniqueAdmins.insert(admin)
+                    } else if let country = pm.country, !country.isEmpty {
+                        uniqueAdmins.insert(country)
+                    }
+                }
+                // Proceed to next point
+                step()
+            }
+        }
+        step()
+    }
+
+    // Minimal ordered-set for stable joining
+    private struct OrderedSet<Element: Hashable> {
+        private var set: Set<Element> = []
+        private(set) var array: [Element] = []
+        mutating func insert(_ element: Element) {
+            if set.insert(element).inserted { array.append(element) }
+        }
+    }
+
+    private static func nameForGeohashLength(_ len: Int, from pm: CLPlacemark) -> String? {
+        switch len {
+        case 0...2:
+            // Prefer administrative area if available at this coarse level
+            return pm.administrativeArea ?? pm.country
+        case 3...4:
+            return pm.administrativeArea ?? pm.subAdministrativeArea ?? pm.country
+        case 5:
+            return pm.locality ?? pm.subAdministrativeArea ?? pm.administrativeArea
+        case 6...7:
+            return pm.subLocality ?? pm.locality ?? pm.administrativeArea
+        default:
+            return pm.subLocality ?? pm.locality ?? pm.administrativeArea ?? pm.country
+        }
+    }
+    #endif
+
     #if DEBUG
     /// Testing-only reset helper
     func _resetForTesting() {
         bookmarks.removeAll()
         membership.removeAll()
+        bookmarkNames.removeAll()
         persist()
+        persistNames()
     }
     #endif
 }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     
     @EnvironmentObject var viewModel: ChatViewModel
     @ObservedObject private var locationManager = LocationChannelManager.shared
+    @ObservedObject private var bookmarks = GeohashBookmarksStore.shared
     @State private var messageText = ""
     @State private var textFieldSelection: NSRange? = nil
     @FocusState private var isTextFieldFocused: Bool
@@ -1111,6 +1112,15 @@ struct ContentView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Open unread private chat")
+                }
+                // Bookmark toggle for current geohash (not shown for mesh)
+                if case .location(let ch) = locationManager.selectedChannel {
+                    Button(action: { GeohashBookmarksStore.shared.toggle(ch.geohash) }) {
+                        Image(systemName: GeohashBookmarksStore.shared.isBookmarked(ch.geohash) ? "bookmark.fill" : "bookmark")
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Toggle bookmark for #\(ch.geohash)")
                 }
                 // Location channels button '#'
                 Button(action: { showLocationChannelsSheet = true }) {

--- a/bitchatTests/GeohashBookmarksStoreTests.swift
+++ b/bitchatTests/GeohashBookmarksStoreTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import bitchat
+
+final class GeohashBookmarksStoreTests: XCTestCase {
+    let storeKey = "locationChannel.bookmarks"
+
+    override func setUp() {
+        super.setUp()
+        // Clear persisted state before each test
+        UserDefaults.standard.removeObject(forKey: storeKey)
+        GeohashBookmarksStore.shared._resetForTesting()
+    }
+
+    override func tearDown() {
+        // Clean after each test
+        UserDefaults.standard.removeObject(forKey: storeKey)
+        GeohashBookmarksStore.shared._resetForTesting()
+        super.tearDown()
+    }
+
+    func testToggleAndNormalize() {
+        let store = GeohashBookmarksStore.shared
+        // Start clean
+        XCTAssertTrue(store.bookmarks.isEmpty)
+
+        // Add with mixed case and hash prefix
+        store.toggle("#U4PRUY")
+        XCTAssertTrue(store.isBookmarked("u4pruy"))
+        XCTAssertEqual(store.bookmarks.first, "u4pruy")
+
+        // Toggling again removes
+        store.toggle("u4pruy")
+        XCTAssertFalse(store.isBookmarked("u4pruy"))
+        XCTAssertTrue(store.bookmarks.isEmpty)
+    }
+
+    func testPersistenceWritten() throws {
+        let store = GeohashBookmarksStore.shared
+        store.toggle("ezs42")
+        store.toggle("u4pruy")
+
+        // Verify persisted JSON contains both (order not enforced here)
+        guard let data = UserDefaults.standard.data(forKey: storeKey) else {
+            XCTFail("No persisted data found")
+            return
+        }
+        let arr = try JSONDecoder().decode([String].self, from: data)
+        XCTAssertTrue(arr.contains("ezs42"))
+        XCTAssertTrue(arr.contains("u4pruy"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add bookmarking for geohash channels with persistence and UI.
- Subscribe to activity for nearby + bookmarked geohashes.
- Send geohash notifications only on rising-edge (0 → alive) with freshness/cooldown guards.
- Pre-populate timelines so notification-triggering messages appear when opened.
- Resolve and persist friendly names for bookmarks.

## Changes

### Services
- `GeohashBookmarksStore` (new):
  - `@Published bookmarks: [String]`, `bookmarkNames: [String: String]` (UserDefaults)
  - APIs: `isBookmarked(_:)`, `toggle(_:)`, `add(_:)`, `remove(_:)`, `resolveNameIfNeeded(for:)`
  - Normalizes geohashes (lowercase base32; strips `#`), MRU on add; dedupes
  - Reverse geocoding of friendly names at bookmark time
    - For very coarse geohashes (length ≤ 2), sample multiple corners and compose a combined label (e.g., “California and Nevada”)
    - Persist names; clean up on unbookmark
  - DEBUG reset helper for tests
- `ChatViewModel`:
  - Sampling = union of nearby (`LocationChannelManager`) + bookmarks; updates on changes and relay reconnect
  - Geohash notifications (public chats): rising-edge only (5‑min window was 0 → activity), freshness gate (30s), suppress when viewing same geohash in foreground, respect blocks/self, per-gh cooldown
  - Pre-populate `geoTimelines[gh]` with triggering message (and UI dedup by message ID) so tapping a notification shows it
  - Remove generic background “new chats!” nudge
  - Mesh “bitchatters nearby!” now strictly 0 → alive, resets immediately when mesh goes empty
- `NotificationService`: unchanged API for geohash; includes deep link `bitchat://geohash/<gh>`
- `Geohash`: add `decodeBounds(_:)` to support composite names

### UI
- `ContentView`: toolbar bookmark button next to `#geohash` badge (hidden on mesh)
- `LocationChannelsSheet`:
  - Nearby: title = level label (block/neighborhood/city/province/region) + people count; subtitle shows `#geohash • coverage` + location name when available (trimmed)
  - Bookmarked: title = `#geohash` + people count; subtitle shows coverage + saved friendly name (trimmed)
  - Bookmark icon at far right; row checkmark remains just to its left; icon toggles without selecting the row

### Tests
- `GeohashBookmarksStoreTests` covering normalization/toggle and persistence sanity.

## Rationale
- Bookmarks give quick access and background awareness for chosen geohashes, beyond current region.
- Rising-edge notifications reduce noise: clear “it’s alive” signals without spamming.
- Pre-hydrating ensures the notified chat is visible immediately (ephemeral events may not replay reliably).
- Friendly names add context without needing geocoding on every render.

## Validation
- Build (macOS): `xcodebuild -project bitchat.xcodeproj -scheme "bitchat (macOS)" -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- iOS tests: run in Xcode (scheme name differs from docs on some setups); happy to align CI target names if needed.
- Manual:
  - Toggle bookmark in toolbar and sheet; persistence across launches
  - Bookmarked section renders with `#geohash` title and saved place subtitle
  - Notifications for geohashes only on 0 → alive; tapping shows the message (pre-populated)
  - Mesh “bitchatters nearby!” triggers only on zero→alive and resets when mesh goes empty

## Notes
- No protocol changes; no signing updates required.
- Dedup safeguards on both per-gh timeline and UI messages prevent duplicates.
