### PR TITLE
feat: added swift-tor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-
+.idea
 ## Gcc Patch
 /*.gcno
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     ],
     dependencies:[
         .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.21.1"),
+        .package(url: "https://github.com/FlorianHubl/SwiftTor.git", branch: "main")
     ],
     targets: [
         .executableTarget(

--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		5BC5AB43F4A8FB62C935CD74 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		5F8043995007F0D84438EDD9 /* NostrIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrIdentity.swift; sourceTree = "<group>"; };
 		61F92EBA29C47C0FCC482F1F /* bitchatShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = bitchatShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F192E4A2E65018A00B0A130 /* bitchatShareExtensionDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = bitchatShareExtensionDebug.entitlements; sourceTree = "<group>"; };
 		6F94D3B42E64F61B002948FD /* TorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorService.swift; sourceTree = "<group>"; };
 		763E0DBA9492A654FC0CDCB9 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		78595178957244CBDF7E79B6 /* NostrRelayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrRelayManager.swift; sourceTree = "<group>"; };
@@ -683,6 +684,7 @@
 						ProvisioningStyle = Automatic;
 					};
 					57CA17A36A2532A6CFF367BB = {
+						DevelopmentTeam = L3N5LHJD5Y;
 						ProvisioningStyle = Automatic;
 					};
 					6CB97DF2EA57234CB3E563B8 = {
@@ -690,6 +692,7 @@
 						ProvisioningStyle = Automatic;
 					};
 					AF077EA0474EDEDE2C72716C = {
+						DevelopmentTeam = L3N5LHJD5Y;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1046,7 +1049,6 @@
 				CODE_SIGN_ENTITLEMENTS = bitchat/bitchat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = V68H23597R;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = bitchat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
@@ -1057,7 +1059,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.3;
-				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.sss;
+				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1317,7 +1319,6 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = bitchatShareExtension/bitchatShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = V68H23597R;
 				INFOPLIST_FILE = bitchatShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -1327,7 +1328,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.3.3;
-				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.sss.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -86,6 +86,9 @@
 		6D0D4A0B1D8B659DCBAE7C9C /* NoiseHandshakeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D6A89B36A3D31E590B94E5 /* NoiseHandshakeCoordinator.swift */; };
 		6DE056E1EE9850E9FBF50157 /* BitchatProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F17B68CFF7AB1BC91C847 /* BitchatProtocol.swift */; };
 		6E7761E21C99F28AE2F9BE5F /* BitchatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF625BB3AD919322C01A46B2 /* BitchatApp.swift */; };
+		6F94D3B32E64F51F002948FD /* SwiftTor in Frameworks */ = {isa = PBXBuildFile; productRef = 6F94D3B22E64F51F002948FD /* SwiftTor */; };
+		6F94D3B52E64F61B002948FD /* TorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F94D3B42E64F61B002948FD /* TorService.swift */; };
+		6F94D3B62E64F61B002948FD /* TorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F94D3B42E64F61B002948FD /* TorService.swift */; };
 		7241FFD6CFFB875B864FA223 /* InputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CB7A5CD1D1A521CD31F380 /* InputValidator.swift */; };
 		749D8CF8A362B6CD0786782D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448F84BF86A42A3CC4A9379 /* NotificationService.swift */; };
 		7576A357B278E5733E9D9F33 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8F7B7D55092C2540A7996 /* ChatViewModel.swift */; };
@@ -245,6 +248,7 @@
 		5BC5AB43F4A8FB62C935CD74 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		5F8043995007F0D84438EDD9 /* NostrIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrIdentity.swift; sourceTree = "<group>"; };
 		61F92EBA29C47C0FCC482F1F /* bitchatShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = bitchatShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F94D3B42E64F61B002948FD /* TorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorService.swift; sourceTree = "<group>"; };
 		763E0DBA9492A654FC0CDCB9 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		78595178957244CBDF7E79B6 /* NostrRelayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrRelayManager.swift; sourceTree = "<group>"; };
 		8A262EDDC04B7D7B5E31F321 /* PrivateChatE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateChatE2ETests.swift; sourceTree = "<group>"; };
@@ -295,6 +299,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F94D3B32E64F51F002948FD /* SwiftTor in Frameworks */,
 				885BBED78092484A5B069461 /* P256K in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -526,6 +531,7 @@
 		D98A3186D7E4C72E35BDF7FE /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				6F94D3B42E64F61B002948FD /* TorService.swift */,
 				048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */,
 				048A4BE62E5CCCC300162C4A /* TransportConfig.swift */,
 				AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */,
@@ -653,6 +659,7 @@
 			name = bitchat_iOS;
 			packageProductDependencies = (
 				4EB6BA1B8464F1EA38F4E286 /* P256K */,
+				6F94D3B22E64F51F002948FD /* SwiftTor */,
 			);
 			productName = bitchat_iOS;
 			productReference = 96D0D41CA19EE5A772AA8434 /* bitchat.app */;
@@ -676,7 +683,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					57CA17A36A2532A6CFF367BB = {
-						DevelopmentTeam = L3N5LHJD5Y;
 						ProvisioningStyle = Automatic;
 					};
 					6CB97DF2EA57234CB3E563B8 = {
@@ -684,7 +690,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					AF077EA0474EDEDE2C72716C = {
-						DevelopmentTeam = L3N5LHJD5Y;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -701,6 +706,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				B8C407587481BBB190741C93 /* XCRemoteSwiftPackageReference "swift-secp256k1" */,
+				6F94D3B12E64F51F002948FD /* XCRemoteSwiftPackageReference "SwiftTor" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -787,6 +793,7 @@
 				049BD3992E506A12001A566B /* UnifiedPeerService.swift in Sources */,
 				C3B1226CD30C87501EF6F12F /* NostrIdentity.swift in Sources */,
 				FBC409E105493C491531B59A /* NostrProtocol.swift in Sources */,
+				6F94D3B62E64F61B002948FD /* TorService.swift in Sources */,
 				049BD3A62E51DC0E001A566B /* MessageDeduplicator.swift in Sources */,
 				6A85FC357ACD85DBD9020845 /* NostrRelayManager.swift in Sources */,
 				749D8CF8A362B6CD0786782D /* NotificationService.swift in Sources */,
@@ -847,6 +854,7 @@
 				049BD39A2E506A12001A566B /* UnifiedPeerService.swift in Sources */,
 				D782AB596DDB5C846554F7C3 /* NostrIdentity.swift in Sources */,
 				F06732B1719EE13C5D09CE77 /* NostrProtocol.swift in Sources */,
+				6F94D3B52E64F61B002948FD /* TorService.swift in Sources */,
 				049BD3A52E51DC0E001A566B /* MessageDeduplicator.swift in Sources */,
 				BCD0EBACD82AF5E55C2CB2B9 /* NostrRelayManager.swift in Sources */,
 				61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */,
@@ -1038,6 +1046,7 @@
 				CODE_SIGN_ENTITLEMENTS = bitchat/bitchat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = V68H23597R;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = bitchat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
@@ -1048,7 +1057,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.3;
-				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
+				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.sss;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1308,6 +1317,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = bitchatShareExtension/bitchatShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = V68H23597R;
 				INFOPLIST_FILE = bitchatShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bitchat;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -1317,7 +1327,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.3.3;
-				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.sss.ShareExtension;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1388,6 +1398,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6F94D3B12E64F51F002948FD /* XCRemoteSwiftPackageReference "SwiftTor" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FlorianHubl/SwiftTor";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		B8C407587481BBB190741C93 /* XCRemoteSwiftPackageReference "swift-secp256k1" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/21-DOT-DEV/swift-secp256k1";
@@ -1403,6 +1421,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B8C407587481BBB190741C93 /* XCRemoteSwiftPackageReference "swift-secp256k1" */;
 			productName = P256K;
+		};
+		6F94D3B22E64F51F002948FD /* SwiftTor */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6F94D3B12E64F51F002948FD /* XCRemoteSwiftPackageReference "SwiftTor" */;
+			productName = SwiftTor;
 		};
 		B1D9136AA0083366353BFA2F /* P256K */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -44,6 +44,12 @@
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 	</array>
+	<!-- Allow Tor connections; consider tightening with specific exceptions in production -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiresFullScreen</key>

--- a/bitchat/Nostr/GeoRelayDirectory.swift
+++ b/bitchat/Nostr/GeoRelayDirectory.swift
@@ -50,7 +50,8 @@ final class GeoRelayDirectory {
 
     private func fetchRemote() {
         let req = URLRequest(url: remoteURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 15)
-        let task = URLSession.shared.dataTask(with: req) { [weak self] data, _, error in
+        // Fetch via Tor if enabled
+        let task = URLSession.torEnabledSession().dataTask(with: req) { [weak self] data, _, error in
             guard let self = self else { return }
             if let data = data, error == nil, let text = String(data: data, encoding: .utf8) {
                 let parsed = GeoRelayDirectory.parseCSV(text)

--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -200,6 +200,15 @@ class NostrRelayManager: ObservableObject {
             return 
         }
         
+        // If Tor is enabled but not connected yet, defer connecting to avoid clearnet leaks.
+        if TorService.shared.isEnabled && !TorService.shared.isConnected {
+            SecureLogger.log("⏳ Deferring relay connect until Tor is connected: \(urlString)", category: SecureLogger.session, level: .info)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.connectToRelay(urlString)
+            }
+            return
+        }
+        
         // Skip if we already have a connection object
         if connections[urlString] != nil {
             return
@@ -207,7 +216,8 @@ class NostrRelayManager: ObservableObject {
         
         // Attempting to connect to Nostr relay
         
-        let session = URLSession(configuration: .default)
+        // Use Tor-enabled session if Tor is enabled
+        let session = URLSession.torEnabledSession()
         let task = session.webSocketTask(with: url)
         
         connections[urlString] = task

--- a/bitchat/Services/TorService.swift
+++ b/bitchat/Services/TorService.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Combine
+import SwiftUI
+import SwiftTor
+
+@MainActor
+final class TorService: ObservableObject {
+    static let shared = TorService()
+    
+    @Published var isEnabled: Bool = UserDefaults.standard.bool(forKey: "torEnabled") {
+        didSet { UserDefaults.standard.set(isEnabled, forKey: "torEnabled") }
+    }
+    
+    @Published private(set) var isConnected: Bool = false
+    @Published private(set) var isConnecting: Bool = false
+    
+    // Underlying SwiftTor instance (manages Tor process and URLSession)
+    private var tor: SwiftTor?
+    private var cancellables = Set<AnyCancellable>()
+    
+    // Restart/stop coordination to avoid multiple TORThread instances
+    private var isStopping = false
+    private var restartWorkItem: DispatchWorkItem?
+    
+    private init() {}
+    
+    func startIfEnabled() {
+        guard isEnabled, !isStopping else { return }
+        if tor == nil { startTor() } else { updateConnectionFlags(from: tor?.state ?? .none) }
+    }
+    
+    func toggle() {
+        isEnabled.toggle()
+        if isEnabled {
+            startTor()
+        } else {
+            // Cleanly stop Tor thread and reconnect without Tor
+            stopTor()
+            NostrRelayManager.shared.resetAllConnections()
+        }
+    }
+    
+    func startTor() {
+        guard tor == nil, !isStopping else { return }
+        isConnecting = true
+        isConnected = false
+        
+        let instance = SwiftTor(start: true)
+        self.tor = instance
+        
+        // Observe Tor state changes
+        instance.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self = self else { return }
+                self.updateConnectionFlags(from: state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    /// Safely restart Tor avoiding multiple TORThread instances.
+    func restartTor() {
+        guard let tor = tor else { startTor(); return }
+        guard !isStopping else { return }
+        isStopping = true
+        isConnecting = true
+        isConnected = false
+        
+        // Stop current Tor thread
+        tor.tor.resign()
+        tor.started = false
+        
+        // Coalesce restarts and wait briefly for TORThread to fully teardown
+        restartWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            // Reinitialize the underlying TorHelper and start
+            if let st = self.tor {
+                st.tor = TorHelper()
+                st.start()
+            } else {
+                self.tor = SwiftTor(start: true)
+            }
+            self.isStopping = false
+        }
+        restartWorkItem = work
+        // Give TORThread time to fully cancel before starting a new one
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+    }
+    
+    func stopTor() {
+        // Clean stop of Tor thread and clear observers
+        restartWorkItem?.cancel()
+        cancellables.removeAll()
+        if let st = tor {
+            st.tor.resign()
+            st.started = false
+        }
+        tor = nil
+        isConnecting = false
+        isConnected = false
+        isStopping = false
+    }
+    
+    private func updateConnectionFlags(from state: TorState) {
+        switch state {
+        case .connected:
+            let wasConnected = isConnected
+            isConnected = true
+            isConnecting = false
+            if !wasConnected {
+                // Reconnect Nostr websockets through Tor
+                NostrRelayManager.shared.resetAllConnections()
+            }
+        case .started:
+            isConnecting = true
+            isConnected = false
+        case .stopped, .none, .refreshing:
+            isConnected = false
+        }
+    }
+    
+    /// Returns the URLSession to use for network/WebSocket traffic respecting Tor setting.
+    func networkSession() -> URLSession {
+        if isEnabled {
+            var port = 19050
+            #if targetEnvironment(simulator)
+            port = 19052
+            #endif
+            let config = URLSessionConfiguration.default
+            config.connectionProxyDictionary = [
+                kCFProxyTypeKey: kCFProxyTypeSOCKS,
+                kCFStreamPropertySOCKSVersion: kCFStreamSocketSOCKSVersion5,
+                kCFStreamPropertySOCKSProxyHost: "127.0.0.1",
+                kCFStreamPropertySOCKSProxyPort: port
+            ] as [AnyHashable: Any]
+            return URLSession(configuration: config)
+        }
+        return URLSession(configuration: .default)
+    }
+    
+    // MARK: - Health probe
+    private func probeTorConnectivity(timeout: TimeInterval = 8, completion: @escaping (Bool) -> Void) {
+        // Use Tor-enabled session regardless of state, to test proxy path
+        let session = networkSession()
+        guard let url = URL(string: "https://check.torproject.org/api/ip") else { completion(false); return }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeout
+        let task = session.dataTask(with: request) { data, response, error in
+            let ok = (error == nil) && (response as? HTTPURLResponse)?.statusCode == 200 && (data?.isEmpty == false)
+            completion(ok)
+        }
+        task.resume()
+        // Fallback timeout guard (non-cancelling, returns false if not completed earlier)
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout + 2) {
+            completion(false)
+        }
+    }
+    
+    /// Call when app resumes from background to ensure Tor is actually routing.
+    func verifyTorOnResume() {
+        guard isEnabled else { return }
+        guard !isStopping else { return }
+        probeTorConnectivity { [weak self] ok in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                if ok {
+                    if !NostrRelayManager.shared.isConnected {
+                        NostrRelayManager.shared.resetAllConnections()
+                    }
+                } else {
+                    self.restartTor()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        NostrRelayManager.shared.resetAllConnections()
+                    }
+                }
+            }
+        }
+    }
+    
+    /// Optional one-shot health check shortly after resume
+    func scheduleActiveHealthCheck() {
+        guard isEnabled else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            self.verifyTorOnResume()
+        }
+    }
+}
+
+extension URLSession {
+    /// Convenience to get a Tor-enabled session if available
+    @MainActor static func torEnabledSession() -> URLSession {
+        return TorService.shared.networkSession()
+    }
+}

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -4,6 +4,36 @@ struct AppInfoView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
     
+
+private struct TorToggleView: View {
+    @ObservedObject var tor = TorService.shared
+    @Environment(\.colorScheme) var colorScheme
+
+    private var textColor: Color {
+        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("tor")
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .foregroundColor(textColor)
+                Spacer()
+                Text(tor.isConnected ? "connected" : (tor.isEnabled ? "connecting…" : "off"))
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(tor.isConnected ? .green : .secondary)
+            }
+            Toggle(isOn: Binding(get: { tor.isEnabled }, set: { _ in tor.toggle() })) {
+                Text("route nostr via tor")
+                    .font(.system(size: 12, design: .monospaced))
+            }
+            .toggleStyle(SwitchToggleStyle(tint: .green))
+        }
+        .padding(.vertical, 8)
+    }
+}
+
     private var backgroundColor: Color {
         colorScheme == .dark ? Color.black : Color.white
     }
@@ -115,6 +145,8 @@ struct AppInfoView: View {
             // Features
             VStack(alignment: .leading, spacing: 16) {
                 SectionHeader(Strings.Features.title)
+                
+                TorToggleView()
                 
                 FeatureRow(icon: Strings.Features.offlineComm.0, 
                           title: Strings.Features.offlineComm.1,

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -25,6 +25,8 @@ struct ContentView: View {
     @EnvironmentObject var viewModel: ChatViewModel
     @ObservedObject private var locationManager = LocationChannelManager.shared
     @ObservedObject private var bookmarks = GeohashBookmarksStore.shared
+    @ObservedObject private var tor = TorService.shared
+
     @State private var messageText = ""
     @State private var textFieldSelection: NSRange? = nil
     @FocusState private var isTextFieldFocused: Bool
@@ -1123,6 +1125,15 @@ struct ContentView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Open unread private chat")
                 }
+                // Tor toggle button
+                Button(action: { tor.toggle() }) {
+                    Image(systemName: tor.isEnabled ? (tor.isConnected ? "lock.shield.fill" : "lock.shield") : "lock.slash")
+                        .font(.system(size: 12))
+                        .foregroundColor(tor.isEnabled ? (tor.isConnected ? Color.green : Color.orange) : Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(tor.isEnabled ? (tor.isConnected ? "Tor is enabled and connected" : "Tor is enabled (connecting)") : "Tor is disabled")
+                .accessibilityLabel(tor.isEnabled ? (tor.isConnected ? "Tor on" : "Tor connecting") : "Tor off")
                 // Bookmark toggle for current geohash (not shown for mesh)
                 if case .location(let ch) = locationManager.selectedChannel {
                     Button(action: { GeohashBookmarksStore.shared.toggle(ch.geohash) }) {


### PR DESCRIPTION
Hi, 

This PR adds Tor with Swift Package Manager support, improved stability, and reduces app size by ~20 MB.

I am uncertain whether the adjustment in ATS is necessary.

Closing #552.

Summary
- Integrates Tor via SwiftTor and adds a TorService to manage a single Tor instance across the app.
- Adds a user-facing toggle to enable/disable Tor and surfaces connection status in the UI.
- Routes all Nostr HTTP/WebSocket traffic through a SOCKS5 proxy when Tor is enabled.
- Defers relay connections until Tor is connected to avoid clearnet leaks.
- Adds resume-time health probe to verify Tor path; guarded restart if proxy path is stale.
- Wires app lifecycle hooks to start/verify Tor on launch and when app becomes active.
- Fixes ATS placement to allow Tor connectivity.
- Adds Swift Package dependency for Tor.

Motivation
- Provide optional privacy routing for Nostr traffic without impacting mesh functionality.
- Ensure robust lifecycle handling of Tor to avoid multiple Tor threads, race conditions, and stale proxy paths.

Key Changes
- New service encapsulates Tor state, exposes enable/connected flags, and provides a Tor-configured URLSession for all networking when enabled.
- Guarded start/stop/restart flow to prevent concurrent Tor threads; delayed restart to allow clean teardown.
- Health probe on resume hits a Tor-check endpoint to confirm routing, with automatic reconnect/restart logic.
- Relay manager defers connects while Tor is coming up, then reconnects once Tor is ready.
- UI: toggle control and status indicator for Tor.
- Project: adds SwiftTor dependency; updates ATS to permit Tor routing.
