### PR TITLE
Fix critical routing + buffer issues (outbox, Nostr queue, BLE cap, fallback)

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -492,6 +492,8 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
         self.messageRouter = MessageRouter(mesh: meshService, nostr: nostrTransport)
         // Route receipts from PrivateChatManager through MessageRouter
         self.privateChatManager.messageRouter = self.messageRouter
+        // Allow UnifiedPeerService to route favorite notifications via mesh/Nostr
+        self.unifiedPeerService.messageRouter = self.messageRouter
         self.autocompleteService = AutocompleteService()
         
         // Wire up dependencies


### PR DESCRIPTION
Fix critical routing + buffer issues (outbox, Nostr queue, BLE cap, fallback)

Summary
- Prevent data loss: preserve unsent items in MessageRouter outbox when neither mesh nor Nostr delivery is possible.
- Bound and drain Nostr send queue: queue only for relays not yet connected, flush on connect.
- Protect memory under BLE backpressure: cap per‑peripheral pending write buffers.
- Enable Nostr fallback for short peer IDs (16‑hex) when favorites have an npub mapping.
- Route favorite notifications via MessageRouter (mesh if connected, Nostr fallback if mapped).

Details
1) MessageRouter outbox
   - Before: `flushOutbox` always cleared the outbox, even if items could not be sent yet.
   - After: only remove items actually sent; keep remaining queued.
   - File: `bitchat/Services/MessageRouter.swift`

2) NostrRelayManager send queue
   - Before: `messageQueue` appended every send and never removed, risking unbounded growth.
   - After: queue stores only relays that lacked a connection at send time; items are flushed when that relay connects and are removed when fully sent.
   - Files: `bitchat/Nostr/NostrRelayManager.swift`

3) BLE pending write buffer cap
   - Before: `pendingPeripheralWrites` had no byte cap when `canSendWriteWithoutResponse` is false.
   - After: enforce per‑peripheral byte cap (reuses `TransportConfig.blePendingWriteBufferCapBytes`), trimming oldest entries; drop single oversized chunks with a warning.
   - File: `bitchat/Services/BLEService.swift`

4) Nostr fallback for short IDs
   - Before: fallback checked only 64‑hex Noise keys; 16‑hex short IDs missed valid favorites mapping.
   - After: detect 16‑hex peerIDs via `FavoritesPersistenceService.getFavoriteStatus(forPeerID:)`.
   - File: `bitchat/Services/MessageRouter.swift`

5) Favorite notifications via router
   - Before: `UnifiedPeerService.toggleFavorite` sent via mesh directly, losing notifications when peer not connected.
   - After: route through `MessageRouter` (mesh if connected, else Nostr when mapped); fallback to mesh only if router isn’t wired yet.
   - Files: `bitchat/Services/UnifiedPeerService.swift`, injection in `bitchat/ViewModels/ChatViewModel.swift`

Rationale
- Fixes a data‑loss edge (outbox cleared prematurely).
- Prevents unbounded memory growth in Nostr relay manager.
- Avoids BLE backpressure OOM from unbounded write queues.
- Ensures PM/ACKs can use Nostr fallback even when UI passes short peer IDs.
- Makes favorite mutuality and npub exchange more reliable across transports.

Risk/compatibility
- Message ordering unchanged; only persistence of unsent outbox items differs (safer).
- Nostr queue behavior is more conservative (flush on connect). No protocol changes.
- BLE cap trims oldest unsent fragments when severely backpressured; better than runaway growth. Logs include sizes.
- Router change is additive; keeps mesh direct path when available.

Validation
- Build (macOS):
  xcodebuild -project bitchat.xcodeproj -scheme "bitchat (macOS)" -configuration Debug CODE_SIGNING_ALLOWED=NO build
- Tests (sim):
  xcodebuild -project bitchat.xcodeproj -scheme bitchat -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' test
- Manual smoke (suggested):
  - Toggle network/relays to see Nostr queued then flushed on connect.
  - Force peripheral write backpressure; confirm logs show trimming and app remains responsive.
  - Favorite a peer when disconnected; confirm notification routes over Nostr when mapped.
  - Send PMs using short peerID to offline favorite; confirm Nostr fallback.

Follow‑ups (separate PRs)
- Consider transitional handling for unverified announces (mark as unverified instead of drop‑all) to ease mixed‑version meshes.
