### PR TITLE
Regenerate info.plist by adding the missing keys

### DIFF
--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -35,10 +35,10 @@
 	<string>bitchat uses Bluetooth to create a secure mesh network for chatting with nearby users.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>bitchat uses Bluetooth to discover and connect with other bitchat users nearby.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>bitchat uses the camera to scan QR codes to verify peers.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,8 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSBluetoothAlwaysUsageDescription: bitchat uses Bluetooth to create a secure mesh network for chatting with nearby users.
         NSBluetoothPeripheralUsageDescription: bitchat uses Bluetooth to discover and connect with other bitchat users nearby.
+        NSCameraUsageDescription: bitchat uses the camera to scan QR codes to verify peers.
+        NSLocationWhenInUseUsageDescription: bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.
         UIBackgroundModes:
           - bluetooth-central
           - bluetooth-peripheral
@@ -85,6 +87,8 @@ targets:
         LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
         NSBluetoothAlwaysUsageDescription: bitchat uses Bluetooth to create a secure mesh network for chatting with nearby users.
         NSBluetoothPeripheralUsageDescription: bitchat uses Bluetooth to discover and connect with other bitchat users nearby.
+        NSCameraUsageDescription: bitchat uses the camera to scan QR codes to verify peers.
+        NSLocationWhenInUseUsageDescription: bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - bitchat


### PR DESCRIPTION
`xcodegen` probably uses alphabetical sorting so had to commit the info.plist to avoid discrepancies