### PR TITLE
[WIP] Add missing info.plist’s to tor’s xcframework

### DIFF
--- a/Frameworks/tor-nolzma.xcframework/ios-arm64-simulator/tor-nolzma.framework/Info.plist
+++ b/Frameworks/tor-nolzma.xcframework/ios-arm64-simulator/tor-nolzma.framework/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>org.torproject.tor-nolzma.iossim</string>
+    <key>CFBundleExecutable</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleName</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>

--- a/Frameworks/tor-nolzma.xcframework/ios-arm64/tor-nolzma.framework/Info.plist
+++ b/Frameworks/tor-nolzma.xcframework/ios-arm64/tor-nolzma.framework/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>org.torproject.tor-nolzma.ios</string>
+    <key>CFBundleExecutable</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleName</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>

--- a/Frameworks/tor-nolzma.xcframework/macos-arm64/tor-nolzma.framework/Info.plist
+++ b/Frameworks/tor-nolzma.xcframework/macos-arm64/tor-nolzma.framework/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>org.torproject.tor-nolzma.macos</string>
+    <key>CFBundleExecutable</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleName</key>
+    <string>tor-nolzma</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>


### PR DESCRIPTION
only after adding these I was able to run on a device (iOS 17.7.2)