### PR TITLE
Debug: AppInfoView shows live logs (copy/clear) in DEBUG

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		0481A3472E6D869F00FC845E /* TorURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3442E6D869F00FC845E /* TorURLSession.swift */; };
 		0481A3482E6D869F00FC845E /* TorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3432E6D869F00FC845E /* TorManager.swift */; };
 		0481A3492E6D869F00FC845E /* TorURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3442E6D869F00FC845E /* TorURLSession.swift */; };
-
 		0481A35B2E6D9BEF00FC845E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A35A2E6D9BEF00FC845E /* libz.tbd */; };
 		0481A35D2E6DA18600FC845E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A35C2E6DA18600FC845E /* libz.tbd */; };
 		0481A3902E734CAE00FC845E /* CommandProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A38F2E734CAE00FC845E /* CommandProcessorTests.swift */; };
@@ -383,7 +382,6 @@
 				0481A39F2E744D6300FC845E /* tor-nolzma.xcframework */,
 				0481A35A2E6D9BEF00FC845E /* libz.tbd */,
 				0481A35C2E6DA18600FC845E /* libz.tbd */,
-
 			);
 			path = Frameworks;
 			sourceTree = "<group>";
@@ -815,7 +813,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+<<<<<<< Updated upstream
 
+=======
+>>>>>>> Stashed changes
 				7DD72D928FF9DD3CA81B46B0 /* Assets.xcassets in Resources */,
 				E0A1B2C3D4E5F6012345678D /* relays/online_relays_gps.csv in Resources */,
 			);

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -199,9 +199,8 @@ struct AppInfoView: View {
             #if DEBUG
             // Debug section (visible only in Debug builds)
             DebugLogsSection(textColor: textColor, secondaryTextColor: secondaryTextColor)
+                .padding(.top)
             #endif
-            
-            .padding(.top)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- Add a DEBUG-only debug panel to  that shows current sanitized logs with live refresh.
- Provide actions to Copy Logs and Clear Logs.

## Details
- SecureLogger:
  - DEBUG builds now keep a small in-memory, sanitized ring buffer (default cap: 2000 lines).
  - All SecureLogger entrypoints append sanitized lines to this buffer in DEBUG.
  - Expose  and  for UI.
- UI (AppInfoView):
  - Adds a  section (only compiled in DEBUG) with:
    - Buttons: , [3J[H[2J (monospaced style consistent with view).
    - Scrollable, selectable text view with the current logs.
    - Lightweight 1s refresh timer to keep output current.
  - Uses  (iOS) /  (macOS) for copy.

## Rationale
- Quick, in-app visibility into what the app is doing reduces context switching to Console.
- Sanitization mirrors existing SecureLogger behavior; the buffer contains filtered lines.
- Only present in DEBUG to avoid any runtime cost or data exposure in release builds.

## Testing
- Build a DEBUG configuration and open App Info (ℹ️):
  - Observe  section with logs updating in place.
  - Tap  and paste to verify contents.
  - Tap [3J[H[2J to reset the buffer and confirm UI updates.

## Notes
- No changes to release behavior. In RELEASE, there is no in-memory buffer and no debug panel.
- If desired, we can add a filter or level selector in a follow-up.
