### PR TITLE
Location Notes (kind 1) at Building Precision + Live Updates

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1143,7 +1143,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
@@ -1198,7 +1198,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				SDKROOT = iphoneos;
@@ -1230,7 +1230,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				REGISTER_APP_GROUPS = YES;
@@ -1319,7 +1319,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat;
 				PRODUCT_NAME = bitchat;
 				REGISTER_APP_GROUPS = YES;
@@ -1412,7 +1412,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.bitchat.ShareExtension;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		0481A3AA2E74D28800FC845E /* LocationNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3A82E74D28800FC845E /* LocationNotesView.swift */; };
 		0481A3AC2E74D29400FC845E /* LocationNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */; };
 		0481A3AD2E74D29400FC845E /* LocationNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */; };
+		0481A3AF2E74E06300FC845E /* LocationNotesCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AE2E74E06300FC845E /* LocationNotesCounter.swift */; };
+		0481A3B02E74E06300FC845E /* LocationNotesCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AE2E74E06300FC845E /* LocationNotesCounter.swift */; };
 		048A4BE72E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE82E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE92E5CCCC300162C4B /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
@@ -240,6 +242,7 @@
 		0481A38F2E734CAE00FC845E /* CommandProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandProcessorTests.swift; sourceTree = "<group>"; };
 		0481A3A82E74D28800FC845E /* LocationNotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNotesView.swift; sourceTree = "<group>"; };
 		0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNotesManager.swift; sourceTree = "<group>"; };
+		0481A3AE2E74E06300FC845E /* LocationNotesCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNotesCounter.swift; sourceTree = "<group>"; };
 		048A4BE62E5CCCC300162C4A /* TransportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConfig.swift; sourceTree = "<group>"; };
 		048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStore.swift; sourceTree = "<group>"; };
 		048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStoreTests.swift; sourceTree = "<group>"; };
@@ -594,8 +597,9 @@
 		D98A3186D7E4C72E35BDF7FE /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */,
 				0481A3452E6D869F00FC845E /* Tor */,
+				0481A3AE2E74E06300FC845E /* LocationNotesCounter.swift */,
+				0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */,
 				048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */,
 				048A4BE62E5CCCC300162C4A /* TransportConfig.swift */,
 				AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */,
@@ -836,6 +840,7 @@
 				047502B92E560F690083520F /* RelayController.swift in Sources */,
 				6E7761E21C99F28AE2F9BE5F /* BitchatApp.swift in Sources */,
 				84E3F9B64FB7FB4A140BD0A8 /* BitchatPeer.swift in Sources */,
+				0481A3B02E74E06300FC845E /* LocationNotesCounter.swift in Sources */,
 				923027D6F2F417AFA2488127 /* BitchatProtocol.swift in Sources */,
 				D450CF41F207BDE1A1AAA56E /* ChatViewModel.swift in Sources */,
 				B0CA7796B2B2AC2B33F84548 /* CompressionUtil.swift in Sources */,
@@ -903,6 +908,7 @@
 				047502BA2E560F690083520F /* RelayController.swift in Sources */,
 				10E68BB889356219189E38EC /* BitchatApp.swift in Sources */,
 				84D13329AB7EE1D65A37438A /* BitchatPeer.swift in Sources */,
+				0481A3AF2E74E06300FC845E /* LocationNotesCounter.swift in Sources */,
 				6DE056E1EE9850E9FBF50157 /* BitchatProtocol.swift in Sources */,
 				7576A357B278E5733E9D9F33 /* ChatViewModel.swift in Sources */,
 				7DCA0DBCB8884E3B31C7BCE3 /* CompressionUtil.swift in Sources */,

--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -33,14 +33,16 @@
 		0481A3472E6D869F00FC845E /* TorURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3442E6D869F00FC845E /* TorURLSession.swift */; };
 		0481A3482E6D869F00FC845E /* TorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3432E6D869F00FC845E /* TorManager.swift */; };
 		0481A3492E6D869F00FC845E /* TorURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3442E6D869F00FC845E /* TorURLSession.swift */; };
-		0481A3552E6D877600FC845E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0481A3532E6D877600FC845E /* README.md */; };
-		0481A3562E6D877600FC845E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0481A3532E6D877600FC845E /* README.md */; };
 		0481A3582E6D929E00FC845E /* tor-nolzma.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A3572E6D929E00FC845E /* tor-nolzma.xcframework */; };
 		0481A3592E6D929E00FC845E /* tor-nolzma.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A3572E6D929E00FC845E /* tor-nolzma.xcframework */; };
 		0481A35B2E6D9BEF00FC845E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A35A2E6D9BEF00FC845E /* libz.tbd */; };
 		0481A35D2E6DA18600FC845E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0481A35C2E6DA18600FC845E /* libz.tbd */; };
 		0481A3902E734CAE00FC845E /* CommandProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A38F2E734CAE00FC845E /* CommandProcessorTests.swift */; };
 		0481A3912E734CAE00FC845E /* CommandProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A38F2E734CAE00FC845E /* CommandProcessorTests.swift */; };
+		0481A3A92E74D28800FC845E /* LocationNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3A82E74D28800FC845E /* LocationNotesView.swift */; };
+		0481A3AA2E74D28800FC845E /* LocationNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3A82E74D28800FC845E /* LocationNotesView.swift */; };
+		0481A3AC2E74D29400FC845E /* LocationNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */; };
+		0481A3AD2E74D29400FC845E /* LocationNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */; };
 		048A4BE72E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE82E5CCCC300162C4A /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
 		048A4BE92E5CCCC300162C4B /* TransportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048A4BE62E5CCCC300162C4A /* TransportConfig.swift */; };
@@ -128,6 +130,10 @@
 		9CCF09F7527EC681A13FC246 /* NoiseSecurityConsiderations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4548DAFC9F7AA8873DA53 /* NoiseSecurityConsiderations.swift */; };
 		A0A1C26EFBFDD5B8EFEEDE57 /* PublicChatE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22BF09A49010947CEFE45E2 /* PublicChatE2ETests.swift */; };
 		A1B2C3D44E5F60718293A4B5 /* XChaCha20Poly1305Compat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */; };
+		A1B2C3D4E5F60123456789BA /* MockKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AA /* MockKeychain.swift */; };
+		A1B2C3D4E5F60123456789BB /* MockKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AA /* MockKeychain.swift */; };
+		A1B2C3D4E5F60123456789BC /* MockIdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */; };
+		A1B2C3D4E5F60123456789BD /* MockIdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */; };
 		A1B2C3D54E5F60718293A4B6 /* XChaCha20Poly1305Compat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */; };
 		A2977428C1D9EF9944C4BFAF /* BLEServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980B109CBA72BC996455C62B /* BLEServiceTests.swift */; };
 		A7187D48B07C6857DE01D0ED /* NoiseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43613045E63D21D429396805 /* NoiseProtocol.swift */; };
@@ -173,10 +179,6 @@
 		F455F011B3B648ADA233F998 /* BinaryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */; };
 		FB8819B4C84FAFEF5C36B216 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136696FC4436A02D98CE6A77 /* KeychainManager.swift */; };
 		FBC409E105493C491531B59A /* NostrProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5A9FF4AEA8A923317ED26A /* NostrProtocol.swift */; };
- 		A1B2C3D4E5F60123456789BA /* MockKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AA /* MockKeychain.swift */; };
- 		A1B2C3D4E5F60123456789BB /* MockKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AA /* MockKeychain.swift */; };
- 		A1B2C3D4E5F60123456789BC /* MockIdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */; };
- 		A1B2C3D4E5F60123456789BD /* MockIdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -232,11 +234,12 @@
 		047502B82E560F690083520F /* RelayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayController.swift; sourceTree = "<group>"; };
 		0481A3432E6D869F00FC845E /* TorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorManager.swift; sourceTree = "<group>"; };
 		0481A3442E6D869F00FC845E /* TorURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorURLSession.swift; sourceTree = "<group>"; };
-		0481A3532E6D877600FC845E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		0481A3572E6D929E00FC845E /* tor-nolzma.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "tor-nolzma.xcframework"; sourceTree = "<group>"; };
 		0481A35A2E6D9BEF00FC845E /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		0481A35C2E6DA18600FC845E /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		0481A38F2E734CAE00FC845E /* CommandProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandProcessorTests.swift; sourceTree = "<group>"; };
+		0481A3A82E74D28800FC845E /* LocationNotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNotesView.swift; sourceTree = "<group>"; };
+		0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationNotesManager.swift; sourceTree = "<group>"; };
 		048A4BE62E5CCCC300162C4A /* TransportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConfig.swift; sourceTree = "<group>"; };
 		048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStore.swift; sourceTree = "<group>"; };
 		048A4C2A2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashBookmarksStoreTests.swift; sourceTree = "<group>"; };
@@ -289,6 +292,8 @@
 		9AB6BE4ABD7F5088E9865E56 /* NoiseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoiseSession.swift; sourceTree = "<group>"; };
 		A08E03AA0C63E97C91749AEC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A1B2C3D44E5F60718293A4B4 /* XChaCha20Poly1305Compat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XChaCha20Poly1305Compat.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60123456789AA /* MockKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKeychain.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentityManager.swift; sourceTree = "<group>"; };
 		A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryProtocol.swift; sourceTree = "<group>"; };
 		AA11BB22CC33DD44EE55FF68 /* MessageTextHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTextHelpers.swift; sourceTree = "<group>"; };
 		AA77BB10CC22DD33EE44FF55 /* VerificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationService.swift; sourceTree = "<group>"; };
@@ -311,8 +316,6 @@
 		FC75901A0F0073B5BB8356E7 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		FDC18D910D6FF2E8B1B6C885 /* SecureIdentityStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureIdentityStateManager.swift; sourceTree = "<group>"; };
 		FE7CCF2BD78A3F3DAE6DA145 /* MockBLEService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBLEService.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60123456789AA /* MockKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKeychain.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60123456789AB /* MockIdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentityManager.swift; sourceTree = "<group>"; };
 		FF7AF93D874001FBD94C8306 /* bitchat-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "bitchat-macOS.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -372,7 +375,6 @@
 			children = (
 				0481A35A2E6D9BEF00FC845E /* libz.tbd */,
 				0481A35C2E6DA18600FC845E /* libz.tbd */,
-				0481A3532E6D877600FC845E /* README.md */,
 				0481A3572E6D929E00FC845E /* tor-nolzma.xcframework */,
 			);
 			path = Frameworks;
@@ -515,6 +517,7 @@
 		A55126E93155456CAA8D6656 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0481A3A82E74D28800FC845E /* LocationNotesView.swift */,
 				AA77BB13CC22DD33EE44FF57 /* VerificationViews.swift */,
 				047502B22E55FED60083520F /* GeohashPeopleList.swift */,
 				047502B32E55FED60083520F /* MeshPeerList.swift */,
@@ -591,6 +594,7 @@
 		D98A3186D7E4C72E35BDF7FE /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				0481A3AB2E74D29400FC845E /* LocationNotesManager.swift */,
 				0481A3452E6D869F00FC845E /* Tor */,
 				048A4C272E5FCD6600162C4A /* GeohashBookmarksStore.swift */,
 				048A4BE62E5CCCC300162C4A /* TransportConfig.swift */,
@@ -785,7 +789,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0481A3552E6D877600FC845E /* README.md in Resources */,
 				7DD72D928FF9DD3CA81B46B0 /* Assets.xcassets in Resources */,
 				E0A1B2C3D4E5F6012345678D /* relays/online_relays_gps.csv in Resources */,
 			);
@@ -797,7 +800,6 @@
 			files = (
 				BCCFEDC1EBE59323C3C470BF /* Assets.xcassets in Resources */,
 				E65BBB6544FE0159F3C6C3A8 /* LaunchScreen.storyboard in Resources */,
-				0481A3562E6D877600FC845E /* README.md in Resources */,
 				E0A1B2C3D4E5F6012345678E /* relays/online_relays_gps.csv in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -864,6 +866,8 @@
 				049BD3AF2E51ED60001A566B /* Transport.swift in Sources */,
 				E2DCF7817344F1CCDB8B7B2F /* SecureIdentityStateManager.swift in Sources */,
 				049BD3A02E51DBF4001A566B /* Packets.swift in Sources */,
+				0481A3AD2E74D29400FC845E /* LocationNotesManager.swift in Sources */,
+				0481A3AA2E74D28800FC845E /* LocationNotesView.swift in Sources */,
 				047502892E5416250083520F /* Geohash.swift in Sources */,
 				0475028A2E5416250083520F /* LocationChannel.swift in Sources */,
 				049BD3A12E51DBF4001A566B /* PeerID.swift in Sources */,
@@ -929,6 +933,8 @@
 				049BD3AE2E51ED60001A566B /* Transport.swift in Sources */,
 				68C4BE564735F6E7915274A2 /* SecureIdentityStateManager.swift in Sources */,
 				049BD3A22E51DBF4001A566B /* Packets.swift in Sources */,
+				0481A3AC2E74D29400FC845E /* LocationNotesManager.swift in Sources */,
+				0481A3A92E74D28800FC845E /* LocationNotesView.swift in Sources */,
 				047502872E5416250083520F /* Geohash.swift in Sources */,
 				047502882E5416250083520F /* LocationChannel.swift in Sources */,
 				049BD3A32E51DBF4001A566B /* PeerID.swift in Sources */,
@@ -984,7 +990,6 @@
 				048A4C2C2E5FCE0300162C4A /* GeohashBookmarksStoreTests.swift in Sources */,
 				3849CA6D99B2D536636DF4A6 /* MockBLEService.swift in Sources */,
 				A1B2C3D4E5F60123456789BA /* MockKeychain.swift in Sources */,
-
 				A1B2C3D4E5F60123456789BC /* MockIdentityManager.swift in Sources */,
 				BC4DC75F4FB823FF40569676 /* NoiseProtocolTests.swift in Sources */,
 				EE8C3ECADAB3083A2687D50B /* NostrProtocolTests.swift in Sources */,

--- a/bitchat/Nostr/NostrProtocol.swift
+++ b/bitchat/Nostr/NostrProtocol.swift
@@ -129,15 +129,11 @@ struct NostrProtocol {
         content: String,
         geohash: String,
         senderIdentity: NostrIdentity,
-        nickname: String? = nil,
-        teleported: Bool = false
+        nickname: String? = nil
     ) throws -> NostrEvent {
         var tags = [["g", geohash]]
         if let nickname = nickname?.trimmingCharacters(in: .whitespacesAndNewlines), !nickname.isEmpty {
             tags.append(["n", nickname])
-        }
-        if teleported {
-            tags.append(["t", "teleport"])
         }
         let event = NostrEvent(
             pubkey: senderIdentity.publicKeyHex,

--- a/bitchat/Nostr/NostrProtocol.swift
+++ b/bitchat/Nostr/NostrProtocol.swift
@@ -123,6 +123,32 @@ struct NostrProtocol {
         let schnorrKey = try senderIdentity.schnorrSigningKey()
         return try event.sign(with: schnorrKey)
     }
+
+    /// Create a persistent location note (kind 1: text note) tagged to a street-level geohash.
+    static func createGeohashTextNote(
+        content: String,
+        geohash: String,
+        senderIdentity: NostrIdentity,
+        nickname: String? = nil,
+        teleported: Bool = false
+    ) throws -> NostrEvent {
+        var tags = [["g", geohash]]
+        if let nickname = nickname?.trimmingCharacters(in: .whitespacesAndNewlines), !nickname.isEmpty {
+            tags.append(["n", nickname])
+        }
+        if teleported {
+            tags.append(["t", "teleport"])
+        }
+        let event = NostrEvent(
+            pubkey: senderIdentity.publicKeyHex,
+            createdAt: Date(),
+            kind: .textNote,
+            tags: tags,
+            content: content
+        )
+        let schnorrKey = try senderIdentity.schnorrSigningKey()
+        return try event.sign(with: schnorrKey)
+    }
     
     // MARK: - Private Methods
     

--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -264,11 +264,13 @@ final class NostrRelayManager: ObservableObject {
                 var tracker = EOSETracker(pendingRelays: Set(urls), callback: onEOSE, timer: nil)
                 // Fallback timeout to avoid hanging if a relay never sends EOSE
                 tracker.timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
-                    guard let self = self else { return }
-                    if let t = self.eoseTrackers[id] {
-                        t.timer?.invalidate()
-                        self.eoseTrackers.removeValue(forKey: id)
-                        onEOSE()
+                    Task { @MainActor in
+                        guard let self = self else { return }
+                        if let t = self.eoseTrackers[id] {
+                            t.timer?.invalidate()
+                            self.eoseTrackers.removeValue(forKey: id)
+                            onEOSE()
+                        }
                     }
                 }
                 eoseTrackers[id] = tracker

--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -755,6 +755,16 @@ struct NostrFilter: Encodable {
         filter.limit = limit
         return filter
     }
+
+    // For location notes: persistent text notes (kind 1) tagged with geohash
+    static func geohashNotes(_ geohash: String, since: Date? = nil, limit: Int = 200) -> NostrFilter {
+        var filter = NostrFilter()
+        filter.kinds = [1]
+        filter.since = since?.timeIntervalSince1970.toInt()
+        filter.tagFilters = ["g": [geohash]]
+        filter.limit = limit
+        return filter
+    }
 }
 
 // Dynamic coding key for tag filters

--- a/bitchat/Protocols/LocationChannel.swift
+++ b/bitchat/Protocols/LocationChannel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Levels of location channels mapped to geohash precisions.
 enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
+    case building
     case block
     case neighborhood
     case city
@@ -11,6 +12,7 @@ enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
     /// Geohash length used for this level.
     var precision: Int {
         switch self {
+        case .building: return 8
         case .block: return 7
         case .neighborhood: return 6
         case .city: return 5
@@ -21,6 +23,7 @@ enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
 
     var displayName: String {
         switch self {
+        case .building: return "Building"
         case .block: return "Block"
         case .neighborhood: return "Neighborhood"
         case .city: return "City"
@@ -35,6 +38,7 @@ extension GeohashChannelLevel {
         let container = try decoder.singleValueContainer()
         if let raw = try? container.decode(String.self) {
             switch raw {
+            case "building": self = .building
             case "block": self = .block
             case "neighborhood": self = .neighborhood
             case "city": self = .city
@@ -46,6 +50,7 @@ extension GeohashChannelLevel {
             }
         } else if let precision = try? container.decode(Int.self) {
             switch precision {
+            case 8: self = .building
             case 7: self = .block
             case 6: self = .neighborhood
             case 5: self = .city
@@ -61,6 +66,7 @@ extension GeohashChannelLevel {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .building: try container.encode("building")
         case .block: try container.encode("block")
         case .neighborhood: try container.encode("neighborhood")
         case .city: try container.encode("city")

--- a/bitchat/Protocols/LocationChannel.swift
+++ b/bitchat/Protocols/LocationChannel.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// Levels of location channels mapped to geohash precisions.
 enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
-    case building
     case block
     case neighborhood
     case city
@@ -12,7 +11,6 @@ enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
     /// Geohash length used for this level.
     var precision: Int {
         switch self {
-        case .building: return 8
         case .block: return 7
         case .neighborhood: return 6
         case .city: return 5
@@ -23,7 +21,6 @@ enum GeohashChannelLevel: CaseIterable, Codable, Equatable {
 
     var displayName: String {
         switch self {
-        case .building: return "Building"
         case .block: return "Block"
         case .neighborhood: return "Neighborhood"
         case .city: return "City"
@@ -38,7 +35,6 @@ extension GeohashChannelLevel {
         let container = try decoder.singleValueContainer()
         if let raw = try? container.decode(String.self) {
             switch raw {
-            case "building": self = .building
             case "block": self = .block
             case "neighborhood": self = .neighborhood
             case "city": self = .city
@@ -50,7 +46,6 @@ extension GeohashChannelLevel {
             }
         } else if let precision = try? container.decode(Int.self) {
             switch precision {
-            case 8: self = .building
             case 7: self = .block
             case 6: self = .neighborhood
             case 5: self = .city
@@ -66,7 +61,6 @@ extension GeohashChannelLevel {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
-        case .building: try container.encode("building")
         case .block: try container.encode("block")
         case .neighborhood: try container.encode("neighborhood")
         case .city: try container.encode("city")

--- a/bitchat/Services/LocationChannelManager.swift
+++ b/bitchat/Services/LocationChannelManager.swift
@@ -291,6 +291,12 @@ final class LocationChannelManager: NSObject, CLLocationManagerDelegate, Observa
         } else if let locality = pm.locality, !locality.isEmpty {
             dict[.block] = locality
         }
+        // Building: prefer place name/street/venue when available
+        if let name = pm.name, !name.isEmpty {
+            dict[.building] = name
+        } else if let thoroughfare = pm.thoroughfare, !thoroughfare.isEmpty {
+            dict[.building] = thoroughfare
+        }
         return dict
     }
 }

--- a/bitchat/Services/LocationChannelManager.swift
+++ b/bitchat/Services/LocationChannelManager.swift
@@ -291,12 +291,6 @@ final class LocationChannelManager: NSObject, CLLocationManagerDelegate, Observa
         } else if let locality = pm.locality, !locality.isEmpty {
             dict[.block] = locality
         }
-        // Building: prefer place name/street address without numbers where possible
-        if let name = pm.name, !name.isEmpty {
-            dict[.building] = name
-        } else if let thoroughfare = pm.thoroughfare, !thoroughfare.isEmpty {
-            dict[.building] = thoroughfare
-        }
         return dict
     }
 }

--- a/bitchat/Services/LocationChannelManager.swift
+++ b/bitchat/Services/LocationChannelManager.swift
@@ -285,11 +285,17 @@ final class LocationChannelManager: NSObject, CLLocationManagerDelegate, Observa
         } else if let locality = pm.locality, !locality.isEmpty {
             dict[.neighborhood] = locality
         }
-        // Block: reuse neighborhood/locality granularity without exposing street level
+        // Block: reuse neighborhood/locality granularity
         if let subLocality = pm.subLocality, !subLocality.isEmpty {
             dict[.block] = subLocality
         } else if let locality = pm.locality, !locality.isEmpty {
             dict[.block] = locality
+        }
+        // Building: prefer place name/street address without numbers where possible
+        if let name = pm.name, !name.isEmpty {
+            dict[.building] = name
+        } else if let thoroughfare = pm.thoroughfare, !thoroughfare.isEmpty {
+            dict[.building] = thoroughfare
         }
         return dict
     }

--- a/bitchat/Services/LocationNotesCounter.swift
+++ b/bitchat/Services/LocationNotesCounter.swift
@@ -28,7 +28,8 @@ final class LocationNotesCounter: ObservableObject {
         subscriptionID = subID
         let filter = NostrFilter.geohashNotes(norm, since: nil, limit: 500)
         let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: norm, count: TransportConfig.nostrGeoRelayCount)
-        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relays, handler: { [weak self] event in
+        let relayUrls: [String]? = relays.isEmpty ? nil : relays
+        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relayUrls, handler: { [weak self] event in
             guard let self = self else { return }
             guard event.kind == NostrProtocol.EventKind.textNote.rawValue else { return }
             guard event.tags.contains(where: { $0.count >= 2 && $0[0].lowercased() == "g" && $0[1].lowercased() == norm }) else { return }

--- a/bitchat/Services/LocationNotesCounter.swift
+++ b/bitchat/Services/LocationNotesCounter.swift
@@ -6,7 +6,7 @@ final class LocationNotesCounter: ObservableObject {
     static let shared = LocationNotesCounter()
 
     @Published private(set) var geohash: String? = nil
-    @Published private(set) var count: Int? = nil
+    @Published private(set) var count: Int? = 0
     @Published private(set) var initialLoadComplete: Bool = false
 
     private var subscriptionID: String? = nil
@@ -19,7 +19,7 @@ final class LocationNotesCounter: ObservableObject {
         if geohash == norm { return }
         cancel()
         geohash = norm
-        count = nil
+        count = 0
         noteIDs.removeAll()
         initialLoadComplete = false
 
@@ -46,7 +46,7 @@ final class LocationNotesCounter: ObservableObject {
         }
         subscriptionID = nil
         geohash = nil
-        count = nil
+        count = 0
         noteIDs.removeAll()
     }
 }

--- a/bitchat/Services/LocationNotesCounter.swift
+++ b/bitchat/Services/LocationNotesCounter.swift
@@ -9,7 +9,8 @@ final class LocationNotesCounter: ObservableObject {
     @Published private(set) var count: Int? = 0
     @Published private(set) var initialLoadComplete: Bool = false
 
-    private var subscriptionID: String? = nil
+    // Support multiple subscriptions (e.g., building + parent block fallback)
+    private var subscriptionIDs: Set<String> = []
     private var noteIDs = Set<String>()
 
     private init() {}
@@ -23,28 +24,40 @@ final class LocationNotesCounter: ObservableObject {
         noteIDs.removeAll()
         initialLoadComplete = false
 
-        let subID = "locnotes-count-\(norm)-\(UUID().uuidString.prefix(6))"
-        subscriptionID = subID
-        let filter = NostrFilter.geohashNotes(norm, since: nil, limit: 500)
-        let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: norm, count: TransportConfig.nostrGeoRelayCount)
-        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relays, handler: { [weak self] event in
-            guard let self = self else { return }
-            guard event.kind == NostrProtocol.EventKind.textNote.rawValue else { return }
-            guard event.tags.contains(where: { $0.count >= 2 && $0[0].lowercased() == "g" && $0[1].lowercased() == norm }) else { return }
-            if !self.noteIDs.contains(event.id) {
-                self.noteIDs.insert(event.id)
-                self.count = self.noteIDs.count
-            }
-        }, onEOSE: { [weak self] in
-            self?.initialLoadComplete = true
-        })
+        // Subscribe to both building and parent block to capture legacy notes
+        var targets: [String] = [norm]
+        if norm.count >= 8 {
+            let parent7 = String(norm.prefix(7))
+            if parent7 != norm { targets.append(parent7) }
+        }
+        var pendingEOSE = Set<String>()
+        for target in targets {
+            let subID = "locnotes-count-\(target)-\(UUID().uuidString.prefix(6))"
+            subscriptionIDs.insert(subID)
+            pendingEOSE.insert(subID)
+            let filter = NostrFilter.geohashNotes(target, since: nil, limit: 500)
+            let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: target, count: TransportConfig.nostrGeoRelayCount)
+            NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relays, handler: { [weak self] event in
+                guard let self = self else { return }
+                guard event.kind == NostrProtocol.EventKind.textNote.rawValue else { return }
+                // Ensure matching g-tag for either building or parent block
+                let matches = event.tags.contains(where: { $0.count >= 2 && $0[0].lowercased() == "g" && targets.contains($0[1].lowercased()) })
+                guard matches else { return }
+                if !self.noteIDs.contains(event.id) {
+                    self.noteIDs.insert(event.id)
+                    self.count = self.noteIDs.count
+                }
+            }, onEOSE: { [weak self] in
+                guard let self = self else { return }
+                pendingEOSE.remove(subID)
+                if pendingEOSE.isEmpty { self.initialLoadComplete = true }
+            })
+        }
     }
 
     func cancel() {
-        if let sub = subscriptionID {
-            NostrRelayManager.shared.unsubscribe(id: sub)
-        }
-        subscriptionID = nil
+        for sub in subscriptionIDs { NostrRelayManager.shared.unsubscribe(id: sub) }
+        subscriptionIDs.removeAll()
         geohash = nil
         count = 0
         noteIDs.removeAll()

--- a/bitchat/Services/LocationNotesCounter.swift
+++ b/bitchat/Services/LocationNotesCounter.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Lightweight background counter for location notes (kind 1) at block-level geohash.
+@MainActor
+final class LocationNotesCounter: ObservableObject {
+    static let shared = LocationNotesCounter()
+
+    @Published private(set) var geohash: String? = nil
+    @Published private(set) var count: Int? = nil
+
+    private var subscriptionID: String? = nil
+    private var noteIDs = Set<String>()
+
+    private init() {}
+
+    func subscribe(geohash gh: String) {
+        let norm = gh.lowercased()
+        if geohash == norm { return }
+        cancel()
+        geohash = norm
+        count = nil
+        noteIDs.removeAll()
+
+        let subID = "locnotes-count-\(norm)-\(UUID().uuidString.prefix(6))"
+        subscriptionID = subID
+        let filter = NostrFilter.geohashNotes(norm, since: nil, limit: 500)
+        let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: norm, count: TransportConfig.nostrGeoRelayCount)
+        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relays) { [weak self] event in
+            guard let self = self else { return }
+            guard event.kind == NostrProtocol.EventKind.textNote.rawValue else { return }
+            guard event.tags.contains(where: { $0.count >= 2 && $0[0].lowercased() == "g" && $0[1].lowercased() == norm }) else { return }
+            if !self.noteIDs.contains(event.id) {
+                self.noteIDs.insert(event.id)
+                self.count = self.noteIDs.count
+            }
+        }
+    }
+
+    func cancel() {
+        if let sub = subscriptionID {
+            NostrRelayManager.shared.unsubscribe(id: sub)
+        }
+        subscriptionID = nil
+        geohash = nil
+        count = nil
+        noteIDs.removeAll()
+    }
+}
+

--- a/bitchat/Services/LocationNotesManager.swift
+++ b/bitchat/Services/LocationNotesManager.swift
@@ -45,6 +45,8 @@ final class LocationNotesManager: ObservableObject {
     }
 
     private func subscribe() {
+        // Avoid double subscription for the same geohash while active
+        if subscriptionID != nil { return }
         // Begin loading: always display Matrix for a randomized 1–3 seconds
         isLoading = true
         loadingStartedAt = Date()

--- a/bitchat/Services/LocationNotesManager.swift
+++ b/bitchat/Services/LocationNotesManager.swift
@@ -48,8 +48,9 @@ final class LocationNotesManager: ObservableObject {
         // For persistent notes, allow relays to return recent history without an aggressive time cutoff
         let filter = NostrFilter.geohashNotes(geohash, since: nil, limit: 200)
         let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: geohash, count: TransportConfig.nostrGeoRelayCount)
+        let relayUrls: [String]? = relays.isEmpty ? nil : relays
         initialLoadComplete = false
-        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relays, handler: { [weak self] event in
+        NostrRelayManager.shared.subscribe(filter: filter, id: subID, relayUrls: relayUrls, handler: { [weak self] event in
             guard let self = self else { return }
             guard event.kind == NostrProtocol.EventKind.textNote.rawValue else { return }
             // Ensure matching tag

--- a/bitchat/Services/LocationNotesManager.swift
+++ b/bitchat/Services/LocationNotesManager.swift
@@ -71,8 +71,7 @@ final class LocationNotesManager: ObservableObject {
                 content: trimmed,
                 geohash: geohash,
                 senderIdentity: id,
-                nickname: nickname,
-                teleported: LocationChannelManager.shared.teleported
+                nickname: nickname
             )
             let relays = GeoRelayDirectory.shared.closestRelays(toGeohash: geohash, count: TransportConfig.nostrGeoRelayCount)
             NostrRelayManager.shared.sendEvent(event, to: relays)

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -103,7 +103,7 @@ enum TransportConfig {
     // Location
     static let locationDistanceFilterMeters: Double = 1000
     // Live (channel sheet open) distance threshold for meaningful updates
-    static let locationDistanceFilterLiveMeters: Double = 21.0
+    static let locationDistanceFilterLiveMeters: Double = 10.0
     static let locationLiveRefreshInterval: TimeInterval = 5.0
 
     // Notifications (geohash)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -858,7 +858,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
         Task { @MainActor in
             self.torRestartPending = true
             // Post only in geohash channels (queue if not active)
-            self.addGeohashOnlySystemMessage("tor restarting to recover connectivity…")
+            self.addGeohashOnlySystemMessage("tor restarting to recover connectivity...")
         }
     }
 

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -474,7 +474,8 @@ struct ContentView: View {
                     case 5: return .city
                     case 6: return .neighborhood
                     case 7: return .block
-                    default: return .block
+                    case 8: return .building
+                    default: return .building
                     }
                 }
                 let level = levelForLength(gh.count)
@@ -1180,7 +1181,7 @@ struct ContentView: View {
                         LocationChannelManager.shared.enableLocationChannels()
                         LocationChannelManager.shared.refreshChannels()
                         // If we already have a block geohash, pass it; otherwise wait in the sheet.
-                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
+                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash
                         showLocationNotes = true
                     }) {
                         HStack(spacing: 4) {
@@ -1231,7 +1232,7 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showLocationNotes) {
             Group {
-                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
+                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
                     LocationNotesView(geohash: gh)
                         .environmentObject(viewModel)
                 } else {
@@ -1265,8 +1266,8 @@ struct ContentView: View {
                     .background(backgroundColor)
                     .foregroundColor(textColor)
                     .onChange(of: locationManager.availableChannels) { channels in
-                        if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
-                            notesGeohash = block.geohash
+                        if notesGeohash == nil, let building = channels.first(where: { $0.level == .building }) {
+                            notesGeohash = building.geohash
                         }
                     }
                 }
@@ -1478,8 +1479,8 @@ extension ContentView {
     private func updateNotesCounterSubscription() {
         switch locationManager.selectedChannel {
         case .mesh:
-            if let block = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
-                LocationNotesCounter.shared.subscribe(geohash: block)
+            if let building = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
+                LocationNotesCounter.shared.subscribe(geohash: building)
             } else {
                 LocationNotesCounter.shared.cancel()
             }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1185,7 +1185,7 @@ struct ContentView: View {
                         showLocationNotes = true
                     }) {
                         HStack(spacing: 4) {
-                            Image(systemName: "note.text")
+                            Image(systemName: "long.text.page.and.pencil")
                                 .font(.system(size: 12))
                                 .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
                             if let c = notesCounter.count {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1235,41 +1235,35 @@ struct ContentView: View {
                     LocationNotesView(geohash: gh)
                         .environmentObject(viewModel)
                 } else {
-                    ZStack {
-                        VStack(spacing: 0) {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text("notes")
-                                        .font(.system(size: 16, weight: .bold, design: .monospaced))
-                                    Text("acquiring location…")
-                                        .font(.system(size: 12, design: .monospaced))
-                                        .foregroundColor(secondaryTextColor)
-                                }
-                                Spacer()
-                                Button(action: { showLocationNotes = false }) {
-                                    Image(systemName: "xmark")
-                                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                                        .foregroundColor(textColor)
-                                        .frame(width: 32, height: 32)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Close")
-                            }
-                            .frame(height: 44)
-                            .padding(.horizontal, 12)
-                            .background(backgroundColor.opacity(0.95))
+                    VStack(spacing: 12) {
+                        HStack {
+                            Text("notes")
+                                .font(.system(size: 16, weight: .bold, design: .monospaced))
                             Spacer()
+                            Button(action: { showLocationNotes = false }) {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                                    .foregroundColor(textColor)
+                                    .frame(width: 32, height: 32)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Close")
                         }
-                        // Simple system spinner while waiting for geohash
-                        ProgressView()
-                            .progressViewStyle(.circular)
+                        .frame(height: 44)
+                        .padding(.horizontal, 12)
+                        .background(backgroundColor.opacity(0.95))
+                        Text("location unavailable")
+                            .font(.system(size: 14, design: .monospaced))
+                            .foregroundColor(secondaryTextColor)
+                        Button("enable location") {
+                            LocationChannelManager.shared.enableLocationChannels()
+                            LocationChannelManager.shared.refreshChannels()
+                        }
+                        .buttonStyle(.bordered)
+                        Spacer()
                     }
                     .background(backgroundColor)
                     .foregroundColor(textColor)
-                    .onAppear {
-                        LocationChannelManager.shared.enableLocationChannels()
-                        LocationChannelManager.shared.refreshChannels()
-                    }
                     .onChange(of: locationManager.availableChannels) { channels in
                         if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
                             notesGeohash = block.geohash

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1185,15 +1185,11 @@ struct ContentView: View {
                         showLocationNotes = true
                     }) {
                         HStack(alignment: .center, spacing: 4) {
+                            let hasNotes = (notesCounter.count ?? 0) > 0
                             Image(systemName: "long.text.page.and.pencil")
                                 .font(.system(size: 12))
-                                .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
+                                .foregroundColor(hasNotes ? Color(hue: 0.60, saturation: 0.85, brightness: 0.82) : Color.gray)
                                 .padding(.top, 1)
-                            Text("\(notesCounter.count ?? 0)")
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
-                                .lineLimit(1)
-                                .fixedSize(horizontal: true, vertical: false)
                         }
                         .fixedSize(horizontal: true, vertical: false)
                     }
@@ -1286,30 +1282,10 @@ struct ContentView: View {
                 LocationChannelManager.shared.endLiveRefresh()
             }
         }
-        .onAppear {
-            updateNotesCounterSubscription()
-            // Keep live updates running while on mesh to follow building changes
-            if case .mesh = locationManager.selectedChannel, locationManager.permissionState == .authorized {
-                LocationChannelManager.shared.beginLiveRefresh()
-            }
-        }
-        .onChange(of: locationManager.selectedChannel) { _ in
-            updateNotesCounterSubscription()
-            if case .mesh = locationManager.selectedChannel, locationManager.permissionState == .authorized {
-                LocationChannelManager.shared.beginLiveRefresh()
-            } else {
-                LocationChannelManager.shared.endLiveRefresh()
-            }
-        }
+        .onAppear { updateNotesCounterSubscription() }
+        .onChange(of: locationManager.selectedChannel) { _ in updateNotesCounterSubscription() }
         .onChange(of: locationManager.availableChannels) { _ in updateNotesCounterSubscription() }
-        .onChange(of: locationManager.permissionState) { _ in
-            updateNotesCounterSubscription()
-            if case .mesh = locationManager.selectedChannel, locationManager.permissionState == .authorized {
-                LocationChannelManager.shared.beginLiveRefresh()
-            } else {
-                LocationChannelManager.shared.endLiveRefresh()
-            }
-        }
+        .onChange(of: locationManager.permissionState) { _ in updateNotesCounterSubscription() }
         .alert("heads up", isPresented: $viewModel.showScreenshotPrivacyWarning) {
             Button("ok", role: .cancel) {}
         } message: {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1266,11 +1266,7 @@ struct ContentView: View {
                     }
                     .background(backgroundColor)
                     .foregroundColor(textColor)
-                    .onChange(of: locationManager.availableChannels) { channels in
-                        if let building = channels.first(where: { $0.level == .building }) {
-                            if notesGeohash != building.geohash { notesGeohash = building.geohash }
-                        }
-                    }
+                    // per-sheet global onChange added below
                 }
             }
             .onAppear {
@@ -1280,6 +1276,18 @@ struct ContentView: View {
             }
             .onDisappear {
                 LocationChannelManager.shared.endLiveRefresh()
+            }
+            .onChange(of: locationManager.availableChannels) { channels in
+                if let current = channels.first(where: { $0.level == .building })?.geohash,
+                   notesGeohash != current {
+                    notesGeohash = current
+                    #if os(iOS)
+                    // Light taptic when geohash changes while the sheet is open
+                    let generator = UIImpactFeedbackGenerator(style: .light)
+                    generator.prepare()
+                    generator.impactOccurred()
+                    #endif
+                }
             }
         }
         .onAppear {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -469,15 +469,14 @@ struct ContentView: View {
                 guard (2...12).contains(gh.count), gh.allSatisfy({ allowed.contains($0) }) else { return }
                 func levelForLength(_ len: Int) -> GeohashChannelLevel {
                     switch len {
-                    case 0...2: return .region
-                    case 3...4: return .province
-                    case 5: return .city
-                    case 6: return .neighborhood
+                        case 0...2: return .region
+                        case 3...4: return .province
+                        case 5: return .city
+                        case 6: return .neighborhood
                     case 7: return .block
-                    case 8: return .building
-                    default: return .building
+                    default: return .block
+                        }
                     }
-                }
                 let level = levelForLength(gh.count)
                 let ch = GeohashChannel(level: level, geohash: gh)
                 // Do not mark teleported when opening a geohash that is in our regional set.
@@ -1181,7 +1180,7 @@ struct ContentView: View {
                         LocationChannelManager.shared.enableLocationChannels()
                         LocationChannelManager.shared.refreshChannels()
                         // If we already have a block geohash, pass it; otherwise wait in the sheet.
-                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash
+                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
                         showLocationNotes = true
                     }) {
                         HStack(spacing: 4) {
@@ -1232,7 +1231,7 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showLocationNotes) {
             Group {
-                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
+                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
                     LocationNotesView(geohash: gh)
                         .environmentObject(viewModel)
                 } else {
@@ -1266,8 +1265,8 @@ struct ContentView: View {
                     .background(backgroundColor)
                     .foregroundColor(textColor)
                     .onChange(of: locationManager.availableChannels) { channels in
-                        if notesGeohash == nil, let building = channels.first(where: { $0.level == .building }) {
-                            notesGeohash = building.geohash
+                        if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
+                            notesGeohash = block.geohash
                         }
                     }
                 }
@@ -1479,8 +1478,8 @@ extension ContentView {
     private func updateNotesCounterSubscription() {
         switch locationManager.selectedChannel {
         case .mesh:
-            if let building = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
-                LocationNotesCounter.shared.subscribe(geohash: building)
+            if let block = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
+                LocationNotesCounter.shared.subscribe(geohash: block)
             } else {
                 LocationNotesCounter.shared.cancel()
             }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1180,7 +1180,7 @@ struct ContentView: View {
                         LocationChannelManager.shared.enableLocationChannels()
                         LocationChannelManager.shared.refreshChannels()
                         // If we already have a block geohash, pass it; otherwise wait in the sheet.
-                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
+                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash
                         showLocationNotes = true
                     }) {
                         HStack(alignment: .center, spacing: 4) {
@@ -1193,6 +1193,7 @@ struct ContentView: View {
                                     .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
                                     .lineLimit(1)
                                     .fixedSize(horizontal: true, vertical: false)
+                                    .alignmentGuide(.firstTextBaseline) { d in d[.firstTextBaseline] }
                             }
                         }
                         .fixedSize(horizontal: true, vertical: false)
@@ -1234,7 +1235,7 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showLocationNotes) {
             Group {
-                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
+                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
                     LocationNotesView(geohash: gh)
                         .environmentObject(viewModel)
                 } else {
@@ -1268,8 +1269,8 @@ struct ContentView: View {
                     .background(backgroundColor)
                     .foregroundColor(textColor)
                     .onChange(of: locationManager.availableChannels) { channels in
-                        if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
-                            notesGeohash = block.geohash
+                        if notesGeohash == nil, let building = channels.first(where: { $0.level == .building }) {
+                            notesGeohash = building.geohash
                         }
                     }
                 }
@@ -1481,8 +1482,8 @@ extension ContentView {
     private func updateNotesCounterSubscription() {
         switch locationManager.selectedChannel {
         case .mesh:
-            if let block = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
-                LocationNotesCounter.shared.subscribe(geohash: block)
+            if let building = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
+                LocationNotesCounter.shared.subscribe(geohash: building)
             } else {
                 LocationNotesCounter.shared.cancel()
             }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1518,6 +1518,10 @@ extension ContentView {
     private func updateNotesCounterSubscription() {
         switch locationManager.selectedChannel {
         case .mesh:
+            // Ensure we have a fresh one-shot location fix so building geohash is current
+            if locationManager.permissionState == .authorized {
+                LocationChannelManager.shared.refreshChannels()
+            }
             if let building = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .building })?.geohash {
                 LocationNotesCounter.shared.subscribe(geohash: building)
             } else {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -50,6 +50,8 @@ struct ContentView: View {
     @State private var showVerifySheet = false
     @State private var expandedMessageIDs: Set<String> = []
     @State private var showLocationNotes = false
+    @State private var notesGeohash: String? = nil
+    @State private var showLocationNotes = false
     // Window sizes for rendering (infinite scroll up)
     @State private var windowCountPublic: Int = 300
     @State private var windowCountPrivate: [String: Int] = [:]
@@ -1147,7 +1149,15 @@ struct ContentView: View {
                 }
                 // Notes icon (mesh only), left of channel badge
                 if case .mesh = locationManager.selectedChannel {
-                    Button(action: { showLocationNotes = true }) {
+                    Button(action: {
+                        if let block = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
+                            notesGeohash = block
+                            showLocationNotes = true
+                        } else {
+                            notesGeohash = nil
+                            showLocationNotes = true
+                        }
+                    }) {
                         Image(systemName: "note.text")
                             .font(.system(size: 12))
                             .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
@@ -1213,9 +1223,8 @@ struct ContentView: View {
                 .onDisappear { viewModel.isLocationChannelsSheetPresented = false }
         }
         .sheet(isPresented: $showLocationNotes) {
-            // Determine current block-level geohash for this place
-            if let block = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
-                LocationNotesView(geohash: block)
+            if let gh = notesGeohash {
+                LocationNotesView(geohash: gh)
                     .environmentObject(viewModel)
             } else {
                 VStack(spacing: 12) {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1251,8 +1251,9 @@ struct ContentView: View {
                             .background(backgroundColor.opacity(0.95))
                             Spacer()
                         }
-                        MatrixRainView()
-                            .transition(.opacity)
+                        // Simple system spinner while waiting for geohash
+                        ProgressView()
+                            .progressViewStyle(.circular)
                     }
                     .background(backgroundColor)
                     .foregroundColor(textColor)

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1183,7 +1183,7 @@ struct ContentView: View {
                         notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
                         showLocationNotes = true
                     }) {
-                        HStack(spacing: 4) {
+                        HStack(alignment: .center, spacing: 4) {
                             Image(systemName: "long.text.page.and.pencil")
                                 .font(.system(size: 12))
                                 .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
@@ -1191,8 +1191,11 @@ struct ContentView: View {
                                 Text("\(c)")
                                     .font(.system(size: 11, design: .monospaced))
                                     .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
+                                    .lineLimit(1)
+                                    .fixedSize(horizontal: true, vertical: false)
                             }
                         }
+                        .fixedSize(horizontal: true, vertical: false)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Location notes for this place")

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -51,7 +51,6 @@ struct ContentView: View {
     @State private var expandedMessageIDs: Set<String> = []
     @State private var showLocationNotes = false
     @State private var notesGeohash: String? = nil
-    @State private var showLocationNotes = false
     // Window sizes for rendering (infinite scroll up)
     @State private var windowCountPublic: Int = 300
     @State private var windowCountPrivate: [String: Int] = [:]

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1221,8 +1221,52 @@ struct ContentView: View {
                 .onDisappear { viewModel.isLocationChannelsSheetPresented = false }
         }
         .sheet(isPresented: $showLocationNotes) {
-            LocationNotesSheet(notesGeohash: $notesGeohash)
-                .environmentObject(viewModel)
+            Group {
+                if let gh = notesGeohash ?? LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash {
+                    LocationNotesView(geohash: gh)
+                        .environmentObject(viewModel)
+                } else {
+                    ZStack {
+                        VStack(spacing: 0) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("notes")
+                                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                                    Text("acquiring location…")
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .foregroundColor(secondaryTextColor)
+                                }
+                                Spacer()
+                                Button(action: { showLocationNotes = false }) {
+                                    Image(systemName: "xmark")
+                                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                                        .foregroundColor(textColor)
+                                        .frame(width: 32, height: 32)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Close")
+                            }
+                            .frame(height: 44)
+                            .padding(.horizontal, 12)
+                            .background(backgroundColor.opacity(0.95))
+                            Spacer()
+                        }
+                        MatrixRainView()
+                            .transition(.opacity)
+                    }
+                    .background(backgroundColor)
+                    .foregroundColor(textColor)
+                    .onAppear {
+                        LocationChannelManager.shared.enableLocationChannels()
+                        LocationChannelManager.shared.refreshChannels()
+                    }
+                    .onChange(of: locationManager.availableChannels) { channels in
+                        if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
+                            notesGeohash = block.geohash
+                        }
+                    }
+                }
+            }
         }
         .alert("heads up", isPresented: $viewModel.showScreenshotPrivacyWarning) {
             Button("ok", role: .cancel) {}

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1147,30 +1147,6 @@ struct ContentView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Toggle bookmark for #\(ch.geohash)")
                 }
-                // Notes icon (mesh only), left of channel badge
-                if case .mesh = locationManager.selectedChannel {
-                    Button(action: {
-                        // Kick a one-shot refresh and show the sheet immediately.
-                        LocationChannelManager.shared.enableLocationChannels()
-                        LocationChannelManager.shared.refreshChannels()
-                        // If we already have a block geohash, pass it; otherwise wait in the sheet.
-                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
-                        showLocationNotes = true
-                    }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "note.text")
-                                .font(.system(size: 12))
-                                .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
-                            if let c = notesCounter.count {
-                                Text("\(c)")
-                                    .font(.system(size: 11, design: .monospaced))
-                                    .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
-                            }
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Location notes for this place")
-                }
                 // Location channels button '#'
                 Button(action: { showLocationChannelsSheet = true }) {
                     let badgeText: String = {
@@ -1196,6 +1172,31 @@ struct ContentView: View {
                         .accessibilityLabel("location channels")
                 }
                 .buttonStyle(.plain)
+
+                // Notes icon (mesh only), to the right of #mesh
+                if case .mesh = locationManager.selectedChannel {
+                    Button(action: {
+                        // Kick a one-shot refresh and show the sheet immediately.
+                        LocationChannelManager.shared.enableLocationChannels()
+                        LocationChannelManager.shared.refreshChannels()
+                        // If we already have a block geohash, pass it; otherwise wait in the sheet.
+                        notesGeohash = LocationChannelManager.shared.availableChannels.first(where: { $0.level == .block })?.geohash
+                        showLocationNotes = true
+                    }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "note.text")
+                                .font(.system(size: 12))
+                                .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
+                            if let c = notesCounter.count {
+                                Text("\(c)")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(Color(hue: 0.60, saturation: 0.85, brightness: 0.82))
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Location notes for this place")
+                }
 
                 HStack(spacing: 4) {
                     // People icon with count

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1282,10 +1282,31 @@ struct ContentView: View {
                 LocationChannelManager.shared.endLiveRefresh()
             }
         }
-        .onAppear { updateNotesCounterSubscription() }
-        .onChange(of: locationManager.selectedChannel) { _ in updateNotesCounterSubscription() }
+        .onAppear {
+            updateNotesCounterSubscription()
+            if case .mesh = locationManager.selectedChannel,
+               locationManager.permissionState == .authorized,
+               LocationChannelManager.shared.availableChannels.isEmpty {
+                LocationChannelManager.shared.refreshChannels()
+            }
+        }
+        .onChange(of: locationManager.selectedChannel) { _ in
+            updateNotesCounterSubscription()
+            if case .mesh = locationManager.selectedChannel,
+               locationManager.permissionState == .authorized,
+               LocationChannelManager.shared.availableChannels.isEmpty {
+                LocationChannelManager.shared.refreshChannels()
+            }
+        }
         .onChange(of: locationManager.availableChannels) { _ in updateNotesCounterSubscription() }
-        .onChange(of: locationManager.permissionState) { _ in updateNotesCounterSubscription() }
+        .onChange(of: locationManager.permissionState) { _ in
+            updateNotesCounterSubscription()
+            if case .mesh = locationManager.selectedChannel,
+               locationManager.permissionState == .authorized,
+               LocationChannelManager.shared.availableChannels.isEmpty {
+                LocationChannelManager.shared.refreshChannels()
+            }
+        }
         .alert("heads up", isPresented: $viewModel.showScreenshotPrivacyWarning) {
             Button("ok", role: .cancel) {}
         } message: {

--- a/bitchat/Views/LocationChannelsSheet.swift
+++ b/bitchat/Views/LocationChannelsSheet.swift
@@ -107,7 +107,7 @@ struct LocationChannelsSheet: View {
 
             // Nearby options
             if !manager.availableChannels.isEmpty {
-                ForEach(manager.availableChannels) { channel in
+                ForEach(manager.availableChannels.filter { $0.level != .building }) { channel in
                     let coverage = coverageString(forPrecision: channel.geohash.count)
                     let nameBase = locationName(for: channel.level)
                     let namePart = nameBase.map { formattedNamePrefix(for: channel.level) + $0 }
@@ -381,6 +381,7 @@ struct LocationChannelsSheet: View {
         case 5: return .city
         case 6: return .neighborhood
         case 7: return .block
+        case 8: return .building
         default: return .block
         }
     }

--- a/bitchat/Views/LocationChannelsSheet.swift
+++ b/bitchat/Views/LocationChannelsSheet.swift
@@ -381,8 +381,7 @@ struct LocationChannelsSheet: View {
         case 5: return .city
         case 6: return .neighborhood
         case 7: return .block
-        case 8: return .building
-        default: return .building
+        default: return .block
         }
     }
 }
@@ -462,8 +461,6 @@ extension LocationChannelsSheet {
     private func formattedNamePrefix(for level: GeohashChannelLevel) -> String {
         switch level {
         case .region:
-            return ""
-        case .building:
             return ""
         default:
             return "~"

--- a/bitchat/Views/LocationChannelsSheet.swift
+++ b/bitchat/Views/LocationChannelsSheet.swift
@@ -381,7 +381,8 @@ struct LocationChannelsSheet: View {
         case 5: return .city
         case 6: return .neighborhood
         case 7: return .block
-        default: return .block
+        case 8: return .building
+        default: return .building
         }
     }
 }
@@ -461,6 +462,8 @@ extension LocationChannelsSheet {
     private func formattedNamePrefix(for level: GeohashChannelLevel) -> String {
         switch level {
         case .region:
+            return ""
+        case .building:
             return ""
         default:
             return "~"

--- a/bitchat/Views/LocationNotesSheet.swift
+++ b/bitchat/Views/LocationNotesSheet.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct LocationNotesSheet: View {
+    @EnvironmentObject var viewModel: ChatViewModel
+    @ObservedObject private var locationManager = LocationChannelManager.shared
+    @Binding var notesGeohash: String?
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var backgroundColor: Color { colorScheme == .dark ? .black : .white }
+    private var textColor: Color { colorScheme == .dark ? .green : Color(red: 0, green: 0.5, blue: 0) }
+    private var secondaryTextColor: Color { textColor.opacity(0.8) }
+
+    var body: some View {
+        Group {
+            if let gh = notesGeohash ?? locationManager.availableChannels.first(where: { $0.level == .block })?.geohash {
+                // Found block geohash: show notes view
+                LocationNotesView(geohash: gh)
+                    .environmentObject(viewModel)
+            } else {
+                // Acquire location: keep a loading overlay (Matrix) until we either get a block geohash
+                ZStack {
+                    VStack(spacing: 0) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("notes")
+                                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                                Text("acquiring location…")
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .foregroundColor(secondaryTextColor)
+                            }
+                            Spacer()
+                            Button(action: { dismiss() }) {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                                    .foregroundColor(textColor)
+                                    .frame(width: 32, height: 32)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Close")
+                        }
+                        .frame(height: 44)
+                        .padding(.horizontal, 12)
+                        .background(backgroundColor.opacity(0.95))
+                        Spacer()
+                    }
+                    MatrixRainView()
+                        .transition(.opacity)
+                }
+                .background(backgroundColor)
+                .foregroundColor(textColor)
+                .onAppear {
+                    LocationChannelManager.shared.enableLocationChannels()
+                    // Nudge a fresh fix
+                    LocationChannelManager.shared.refreshChannels()
+                }
+                .onChange(of: locationManager.availableChannels) { channels in
+                    if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
+                        notesGeohash = block.geohash
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/bitchat/Views/LocationNotesSheet.swift
+++ b/bitchat/Views/LocationNotesSheet.swift
@@ -13,7 +13,7 @@ struct LocationNotesSheet: View {
 
     var body: some View {
         Group {
-            if let gh = notesGeohash ?? locationManager.availableChannels.first(where: { $0.level == .building })?.geohash {
+            if let gh = notesGeohash ?? locationManager.availableChannels.first(where: { $0.level == .block })?.geohash {
                 // Found block geohash: show notes view
                 LocationNotesView(geohash: gh)
                     .environmentObject(viewModel)
@@ -55,8 +55,8 @@ struct LocationNotesSheet: View {
                     LocationChannelManager.shared.refreshChannels()
                 }
                 .onChange(of: locationManager.availableChannels) { channels in
-                    if notesGeohash == nil, let building = channels.first(where: { $0.level == .building }) {
-                        notesGeohash = building.geohash
+                    if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
+                        notesGeohash = block.geohash
                     }
                 }
             }

--- a/bitchat/Views/LocationNotesSheet.swift
+++ b/bitchat/Views/LocationNotesSheet.swift
@@ -13,7 +13,7 @@ struct LocationNotesSheet: View {
 
     var body: some View {
         Group {
-            if let gh = notesGeohash ?? locationManager.availableChannels.first(where: { $0.level == .block })?.geohash {
+            if let gh = notesGeohash ?? locationManager.availableChannels.first(where: { $0.level == .building })?.geohash {
                 // Found block geohash: show notes view
                 LocationNotesView(geohash: gh)
                     .environmentObject(viewModel)
@@ -55,12 +55,11 @@ struct LocationNotesSheet: View {
                     LocationChannelManager.shared.refreshChannels()
                 }
                 .onChange(of: locationManager.availableChannels) { channels in
-                    if notesGeohash == nil, let block = channels.first(where: { $0.level == .block }) {
-                        notesGeohash = block.geohash
+                    if notesGeohash == nil, let building = channels.first(where: { $0.level == .building }) {
+                        notesGeohash = building.geohash
                     }
                 }
             }
         }
     }
 }
-

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -73,6 +73,7 @@ struct LocationNotesView: View {
                                 .foregroundColor(secondaryTextColor.opacity(0.8))
                         }
                         Text(note.content)
+                            .font(.system(size: 14, design: .monospaced))
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     .padding(.horizontal, 12)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -42,7 +42,7 @@ struct LocationNotesView: View {
     private var header: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("notes @ #\(geohash)")
+                Text("notes @ #\(geohash) (\(manager.notes.count))")
                     .font(.system(size: 16, weight: .bold, design: .monospaced))
                 if let buildingName = locationManager.locationNames[.building], !buildingName.isEmpty {
                     Text(buildingName)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+struct LocationNotesView: View {
+    @EnvironmentObject var viewModel: ChatViewModel
+    @ObservedObject var manager: LocationNotesManager
+    let geohash: String
+
+    @Environment(\.colorScheme) var colorScheme
+    @State private var draft: String = ""
+
+    init(geohash: String) {
+        self.geohash = geohash.lowercased()
+        self.manager = LocationNotesManager(geohash: self.geohash)
+    }
+
+    private var backgroundColor: Color {
+        colorScheme == .dark ? Color.black : Color.white
+    }
+    private var textColor: Color {
+        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
+    }
+    private var secondaryTextColor: Color {
+        colorScheme == .dark ? Color.green.opacity(0.8) : Color(red: 0, green: 0.5, blue: 0).opacity(0.8)
+    }
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                header
+                Divider()
+                list
+                Divider()
+                input
+            }
+            if manager.isLoading {
+                MatrixRainView()
+                    .transition(.opacity)
+            }
+        }
+        .background(backgroundColor)
+        .foregroundColor(textColor)
+        .onDisappear { manager.cancel() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("notes @ #\(geohash)")
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                Text("street-level notes")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(secondaryTextColor)
+            }
+            Spacer()
+        }
+        .frame(height: 44)
+        .padding(.horizontal, 12)
+        .background(backgroundColor.opacity(0.95))
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(manager.notes) { note in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(note.displayName)
+                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .foregroundColor(secondaryTextColor)
+                            Text(note.createdAt, style: .relative)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(secondaryTextColor.opacity(0.8))
+                        }
+                        Text(note.content)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.horizontal, 12)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .background(backgroundColor)
+    }
+
+    private var input: some View {
+        HStack(alignment: .center, spacing: 8) {
+            TextField("add a note for this place", text: $draft, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.system(size: 14, design: .monospaced))
+                .lineLimit(3, reservesSpace: true)
+                .padding(.horizontal, 12)
+
+            Button(action: send) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 20))
+                    .foregroundColor(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? Color.gray : textColor)
+            }
+            .buttonStyle(.plain)
+            .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .padding(.trailing, 12)
+        }
+        .frame(minHeight: 44)
+        .padding(.vertical, 8)
+        .background(backgroundColor.opacity(0.95))
+    }
+
+    private func send() {
+        let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty else { return }
+        manager.send(content: content, nickname: viewModel.nickname)
+        draft = ""
+    }
+}
+
+// MARK: - Matrix Rain Loader
+private struct MatrixRainView: View {
+    @Environment(\.colorScheme) var colorScheme
+    private var fg: Color { colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0) }
+    private let charset = Array("01abcdefghijklmnopqrstuvwxyzｱｲｳｴｵｶｷｸｹｺﾊﾋﾌﾍﾎ0123456789")
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = max(geo.size.width, 1)
+            let h = max(geo.size.height, 1)
+            let colWidth: CGFloat = 14
+            let cols = max(Int(w / colWidth), 6)
+            ZStack {
+                ForEach(0..<cols, id: \.self) { i in
+                    RainColumn(charset: charset,
+                               columnWidth: colWidth,
+                               height: h,
+                               speed: Double.random(in: 2.8...4.8),
+                               delay: Double.random(in: 0...1.2),
+                               color: fg)
+                    .frame(width: colWidth)
+                    .position(x: CGFloat(i) * colWidth + colWidth/2, y: h/2)
+                }
+            }
+            .background(Color.black.opacity(colorScheme == .dark ? 0.75 : 0.65))
+            .overlay(
+                VStack(spacing: 6) {
+                    Text("loading notes…")
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundColor(fg)
+                        .padding(.top, 12)
+                    Spacer()
+                }
+            )
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .allowsHitTesting(false)
+    }
+}
+
+private struct RainColumn: View {
+    let charset: [Character]
+    let columnWidth: CGFloat
+    let height: CGFloat
+    let speed: Double
+    let delay: Double
+    let color: Color
+    @State private var y: CGFloat = 0
+    @State private var glyphs: [String] = []
+    @State private var timer: Timer?
+
+    var body: some View {
+        let font = Font.system(size: 12, weight: .regular, design: .monospaced)
+        VStack(spacing: 0) {
+            ForEach(Array(glyphs.enumerated()), id: \.offset) { idx, ch in
+                Text(ch)
+                    .font(font)
+                    .foregroundColor(color.opacity(opacity(for: idx)))
+                    .frame(width: columnWidth, alignment: .center)
+            }
+        }
+        .offset(y: y)
+        .onAppear {
+            let count = max(Int(height / 14) + 12, 24)
+            glyphs = randomGlyphs(count)
+            startGlyphTimer()
+            y = -height
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                withAnimation(.linear(duration: speed).repeatForever(autoreverses: false)) {
+                    y = height * 2
+                }
+            }
+        }
+        .onDisappear { stopGlyphTimer() }
+    }
+
+    private func opacity(for idx: Int) -> Double {
+        let p = Double(idx) / Double(max(glyphs.count, 1))
+        return 0.15 + (1.0 - p) * 0.85
+    }
+
+    private func randomGlyphs(_ n: Int) -> [String] {
+        (0..<n).map { _ in String(charset.randomElement() ?? "0") }
+    }
+
+    private func startGlyphTimer() {
+        stopGlyphTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.20, repeats: true) { _ in
+            if glyphs.isEmpty { return }
+            let changes = Int.random(in: 1...3)
+            for _ in 0..<changes {
+                let idx = Int.random(in: 0..<glyphs.count)
+                glyphs[idx] = String(charset.randomElement() ?? "1")
+            }
+        }
+    }
+
+    private func stopGlyphTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -6,6 +6,7 @@ struct LocationNotesView: View {
     let geohash: String
 
     @Environment(\.colorScheme) var colorScheme
+    @ObservedObject private var locationManager = LocationChannelManager.shared
     @Environment(\.dismiss) private var dismiss
     @State private var draft: String = ""
 
@@ -43,9 +44,11 @@ struct LocationNotesView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("notes @ #\(geohash)")
                     .font(.system(size: 16, weight: .bold, design: .monospaced))
-                Text("street-level notes")
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(secondaryTextColor)
+                if let blockName = locationManager.locationNames[.block], !blockName.isEmpty {
+                    Text(blockName)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(secondaryTextColor)
+                }
             }
             Spacer()
             Button(action: { dismiss() }) {

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -42,13 +42,12 @@ struct LocationNotesView: View {
     private var header: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text("notes @ #\(geohash)")
-                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                HStack(spacing: 4) {
                     let c = manager.notes.count
-                    Text("(\(c) \(c == 1 ? "note" : "notes"))")
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(secondaryTextColor)
+                    Text("\(c) \(c == 1 ? "note" : "notes") ")
+                        .font(.system(size: 16, weight: .regular, design: .monospaced))
+                    Text("@ #\(geohash)")
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
                 }
                 if let buildingName = locationManager.locationNames[.building], !buildingName.isEmpty {
                     Text(buildingName)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -42,8 +42,14 @@ struct LocationNotesView: View {
     private var header: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("notes @ #\(geohash) (\(manager.notes.count))")
-                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                HStack(spacing: 6) {
+                    Text("notes @ #\(geohash)")
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    let c = manager.notes.count
+                    Text("(\(c) \(c == 1 ? "note" : "notes"))")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(secondaryTextColor)
+                }
                 if let buildingName = locationManager.locationNames[.building], !buildingName.isEmpty {
                     Text(buildingName)
                         .font(.system(size: 12, design: .monospaced))

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -26,18 +26,12 @@ struct LocationNotesView: View {
     }
 
     var body: some View {
-        ZStack {
-            VStack(spacing: 0) {
-                header
-                Divider()
-                list
-                Divider()
-                input
-            }
-            if manager.isLoading {
-                MatrixRainView()
-                    .transition(.opacity)
-            }
+        VStack(spacing: 0) {
+            header
+            Divider()
+            list
+            Divider()
+            input
         }
         .background(backgroundColor)
         .foregroundColor(textColor)
@@ -121,108 +115,5 @@ struct LocationNotesView: View {
         guard !content.isEmpty else { return }
         manager.send(content: content, nickname: viewModel.nickname)
         draft = ""
-    }
-}
-
-// MARK: - Matrix Rain Loader
-struct MatrixRainView: View {
-    @Environment(\.colorScheme) var colorScheme
-    private var fg: Color { colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0) }
-    private let charset = Array("01abcdefghijklmnopqrstuvwxyzｱｲｳｴｵｶｷｸｹｺﾊﾋﾌﾍﾎ0123456789")
-
-    var body: some View {
-        GeometryReader { geo in
-            let w = max(geo.size.width, 1)
-            let h = max(geo.size.height, 1)
-            let colWidth: CGFloat = 14
-            let cols = max(Int(w / colWidth), 6)
-            ZStack {
-                ForEach(0..<cols, id: \.self) { i in
-                    RainColumn(charset: charset,
-                               columnWidth: colWidth,
-                               height: h,
-                               speed: Double.random(in: 2.8...4.8),
-                               delay: Double.random(in: 0...1.2),
-                               color: fg)
-                    .frame(width: colWidth)
-                    .position(x: CGFloat(i) * colWidth + colWidth/2, y: h/2)
-                }
-            }
-            .background(Color.black.opacity(colorScheme == .dark ? 0.75 : 0.65))
-            .overlay(
-                VStack(spacing: 6) {
-                    Text("loading notes…")
-                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        .foregroundColor(fg)
-                        .padding(.top, 12)
-                    Spacer()
-                }
-            )
-        }
-        .ignoresSafeArea(edges: .bottom)
-        .allowsHitTesting(false)
-    }
-}
-
-struct RainColumn: View {
-    let charset: [Character]
-    let columnWidth: CGFloat
-    let height: CGFloat
-    let speed: Double
-    let delay: Double
-    let color: Color
-    @State private var y: CGFloat = 0
-    @State private var glyphs: [String] = []
-    @State private var timer: Timer?
-
-    var body: some View {
-        let font = Font.system(size: 12, weight: .regular, design: .monospaced)
-        VStack(spacing: 0) {
-            ForEach(Array(glyphs.enumerated()), id: \.offset) { idx, ch in
-                Text(ch)
-                    .font(font)
-                    .foregroundColor(color.opacity(opacity(for: idx)))
-                    .frame(width: columnWidth, alignment: .center)
-            }
-        }
-        .offset(y: y)
-        .onAppear {
-            let count = max(Int(height / 14) + 12, 24)
-            glyphs = randomGlyphs(count)
-            startGlyphTimer()
-            y = -height
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                withAnimation(.linear(duration: speed).repeatForever(autoreverses: false)) {
-                    y = height * 2
-                }
-            }
-        }
-        .onDisappear { stopGlyphTimer() }
-    }
-
-    private func opacity(for idx: Int) -> Double {
-        let p = Double(idx) / Double(max(glyphs.count, 1))
-        return 0.15 + (1.0 - p) * 0.85
-    }
-
-    private func randomGlyphs(_ n: Int) -> [String] {
-        (0..<n).map { _ in String(charset.randomElement() ?? "0") }
-    }
-
-    private func startGlyphTimer() {
-        stopGlyphTimer()
-        timer = Timer.scheduledTimer(withTimeInterval: 0.20, repeats: true) { _ in
-            if glyphs.isEmpty { return }
-            let changes = Int.random(in: 1...3)
-            for _ in 0..<changes {
-                let idx = Int.random(in: 0..<glyphs.count)
-                glyphs[idx] = String(charset.randomElement() ?? "1")
-            }
-        }
-    }
-
-    private func stopGlyphTimer() {
-        timer?.invalidate()
-        timer = nil
     }
 }

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -6,6 +6,7 @@ struct LocationNotesView: View {
     let geohash: String
 
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dismiss) private var dismiss
     @State private var draft: String = ""
 
     init(geohash: String) {
@@ -53,6 +54,15 @@ struct LocationNotesView: View {
                     .foregroundColor(secondaryTextColor)
             }
             Spacer()
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundColor(textColor)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
         }
         .frame(height: 44)
         .padding(.horizontal, 12)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -72,9 +72,6 @@ struct LocationNotesView: View {
                             Text(note.displayName)
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                                 .foregroundColor(secondaryTextColor)
-                            Text(note.createdAt, style: .relative)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(secondaryTextColor.opacity(0.8))
                         }
                         Text(note.content)
                             .font(.system(size: 14, design: .monospaced))

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -125,7 +125,7 @@ struct LocationNotesView: View {
 }
 
 // MARK: - Matrix Rain Loader
-private struct MatrixRainView: View {
+struct MatrixRainView: View {
     @Environment(\.colorScheme) var colorScheme
     private var fg: Color { colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0) }
     private let charset = Array("01abcdefghijklmnopqrstuvwxyzｱｲｳｴｵｶｷｸｹｺﾊﾋﾌﾍﾎ0123456789")
@@ -164,7 +164,7 @@ private struct MatrixRainView: View {
     }
 }
 
-private struct RainColumn: View {
+struct RainColumn: View {
     let charset: [Character]
     let columnWidth: CGFloat
     let height: CGFloat

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -37,6 +37,9 @@ struct LocationNotesView: View {
         .background(backgroundColor)
         .foregroundColor(textColor)
         .onDisappear { manager.cancel() }
+        .onChange(of: geohash) { newValue in
+            manager.setGeohash(newValue)
+        }
     }
 
     private var header: some View {
@@ -45,7 +48,7 @@ struct LocationNotesView: View {
                 HStack(spacing: 4) {
                     let c = manager.notes.count
                     Text("\(c) \(c == 1 ? "note" : "notes") ")
-                        .font(.system(size: 16, weight: .regular, design: .monospaced))
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
                     Text("@ #\(geohash)")
                         .font(.system(size: 16, weight: .bold, design: .monospaced))
                 }

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -44,7 +44,11 @@ struct LocationNotesView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("notes @ #\(geohash)")
                     .font(.system(size: 16, weight: .bold, design: .monospaced))
-                if let blockName = locationManager.locationNames[.block], !blockName.isEmpty {
+                if let buildingName = locationManager.locationNames[.building], !buildingName.isEmpty {
+                    Text(buildingName)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(secondaryTextColor)
+                } else if let blockName = locationManager.locationNames[.block], !blockName.isEmpty {
                     Text(blockName)
                         .font(.system(size: 12, design: .monospaced))
                         .foregroundColor(secondaryTextColor)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -4,15 +4,17 @@ struct LocationNotesView: View {
     @EnvironmentObject var viewModel: ChatViewModel
     @StateObject private var manager: LocationNotesManager
     let geohash: String
+    let onNotesCountChanged: ((Int) -> Void)?
 
     @Environment(\.colorScheme) var colorScheme
     @ObservedObject private var locationManager = LocationChannelManager.shared
     @Environment(\.dismiss) private var dismiss
     @State private var draft: String = ""
 
-    init(geohash: String) {
+    init(geohash: String, onNotesCountChanged: ((Int) -> Void)? = nil) {
         let gh = geohash.lowercased()
         self.geohash = gh
+        self.onNotesCountChanged = onNotesCountChanged
         _manager = StateObject(wrappedValue: LocationNotesManager(geohash: gh))
     }
 
@@ -39,6 +41,10 @@ struct LocationNotesView: View {
         .onDisappear { manager.cancel() }
         .onChange(of: geohash) { newValue in
             manager.setGeohash(newValue)
+        }
+        .onAppear { onNotesCountChanged?(manager.notes.count) }
+        .onChange(of: manager.notes.count) { newValue in
+            onNotesCountChanged?(newValue)
         }
     }
 

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -2,15 +2,16 @@ import SwiftUI
 
 struct LocationNotesView: View {
     @EnvironmentObject var viewModel: ChatViewModel
-    @ObservedObject var manager: LocationNotesManager
+    @StateObject private var manager: LocationNotesManager
     let geohash: String
 
     @Environment(\.colorScheme) var colorScheme
     @State private var draft: String = ""
 
     init(geohash: String) {
-        self.geohash = geohash.lowercased()
-        self.manager = LocationNotesManager(geohash: self.geohash)
+        let gh = geohash.lowercased()
+        self.geohash = gh
+        _manager = StateObject(wrappedValue: LocationNotesManager(geohash: gh))
     }
 
     private var backgroundColor: Color {

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -72,6 +72,9 @@ struct LocationNotesView: View {
                             Text(note.displayName)
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                                 .foregroundColor(secondaryTextColor)
+                            Text(note.createdAt, style: .time)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(secondaryTextColor.opacity(0.8))
                         }
                         Text(note.content)
                             .font(.system(size: 14, design: .monospaced))

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -122,7 +122,8 @@ struct LocationNotesView: View {
         let now = Date()
         if let days = Calendar.current.dateComponents([.day], from: date, to: now).day, days < 7 {
             // Relative (minute/hour/day), no seconds
-            return Self.relativeFormatter.string(from: date, to: now) ?? ""
+            let rel = Self.relativeFormatter.string(from: date, to: now) ?? ""
+            return rel.isEmpty ? "" : "\(rel) ago"
         } else {
             // Absolute date (MMM d or MMM d, yyyy if different year)
             let sameYear = Calendar.current.isDate(date, equalTo: now, toGranularity: .year)

--- a/bitchat/Views/LocationNotesView.swift
+++ b/bitchat/Views/LocationNotesView.swift
@@ -72,7 +72,7 @@ struct LocationNotesView: View {
                             Text(note.displayName)
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                                 .foregroundColor(secondaryTextColor)
-                            Text(note.createdAt, style: .time)
+                            Text(timestampText(for: note.createdAt))
                                 .font(.system(size: 11, design: .monospaced))
                                 .foregroundColor(secondaryTextColor.opacity(0.8))
                         }
@@ -116,4 +116,39 @@ struct LocationNotesView: View {
         manager.send(content: content, nickname: viewModel.nickname)
         draft = ""
     }
+
+    // MARK: - Timestamp Formatting
+    private func timestampText(for date: Date) -> String {
+        let now = Date()
+        if let days = Calendar.current.dateComponents([.day], from: date, to: now).day, days < 7 {
+            // Relative (minute/hour/day), no seconds
+            return Self.relativeFormatter.string(from: date, to: now) ?? ""
+        } else {
+            // Absolute date (MMM d or MMM d, yyyy if different year)
+            let sameYear = Calendar.current.isDate(date, equalTo: now, toGranularity: .year)
+            let fmt = sameYear ? Self.absDateFormatter : Self.absDateYearFormatter
+            return fmt.string(from: date)
+        }
+    }
+
+    private static let relativeFormatter: DateComponentsFormatter = {
+        let f = DateComponentsFormatter()
+        f.allowedUnits = [.day, .hour, .minute]
+        f.maximumUnitCount = 1
+        f.unitsStyle = .abbreviated
+        f.collapsesLargestUnit = true
+        return f
+    }()
+
+    private static let absDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("MMM d")
+        return f
+    }()
+
+    private static let absDateYearFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("MMM d, y")
+        return f
+    }()
 }


### PR DESCRIPTION
## Summary
This draft PR adds location notes (Nostr kind 1) scoped to the current building (geohash precision 8), with a focused UI flow and careful perf/UX behavior:

- Publish/view kind‑1 notes tagged with `#g=<geohash>` and optional `#n=<nickname>` (no teleport tag)
- Mesh toolbar notes entry (icon blue when notes exist, grey otherwise)
- A dedicated notes sheet that follows your current building as you walk (live updates with 10 m distance filter)
- Haptic on building change while the sheet is open (iOS)
- Count moved into sheet header (“1 note @ #ghash” / “N notes @ #ghash”)
- Reverse‑geocoded building name (fallback: block) displayed under the title
- EOSE handling for subscriptions (initial load completion) with safe 2s fallback
- Uses GeoRelays for send/subscribe (closest relays by geohash)

## UI/UX Details
- Toolbar
  - Notes icon: `long.text.page.and.pencil`
  - Color: grey if zero notes; blue if one or more
  - Hidden when location isn’t authorized
- Notes Sheet
  - Title: “1 note @ #<8‑geohash>” or “N notes @ #<8‑geohash>” (count is bold)
  - Subtitle: building name if available, else block name
  - Live location updates only while sheet is open; 10 m distance filter
  - Haptic feedback on building geohash change (iOS only)
  - Message list reverse‑chron; monospaced text; no delete; timestamps are relative (<7d) or absolute

## Networking
- Notes and counts subscribe at precision 8 (building) via `GeoRelayDirectory.closestRelays(...)`
- EOSE tracked per subscription; managers expose `initialLoadComplete`
- No periodic polling; live updates only while the sheet is visible

## Implementation Highlights
- `NostrProtocol.createGeohashTextNote(...)` (kind 1) — tags: `g`, optional `n` (no `t/teleport`)
- `NostrRelayManager.subscribe(..., onEOSE:)` — EOSE callback + 2s fallback, Swift 6 isolation-safe
- `LocationNotesManager` — subscribes/sends notes; live geohash switch in-place
- `LocationNotesCounter` — subscribes to current building geohash for toolbar state
- `LocationChannelManager` — reverse-geocoding + live refresh (10 m) API used only while sheet is open

## Notable Defaults & Safety
- Tor enforced path remains; EOSE fallback prevents “stuck” initial loads
- Building precision (8) is not exposed in the channel selector; user-visible channels remain block/city/etc.
- Toolbar does a one‑shot refresh on appear when needed (authorized + empty channels) to initialize state without keeping live updates on

## Testing Notes
- Walk across building boundaries with sheet open; header + list should follow and light haptic should fire once per change
- With sheet closed, toolbar icon reflects presence (grey/blue) after a one‑shot refresh
- Poor network: initial load should complete via fallback timer; live events continue afterward

## Future Work (Nice-to-have)
- Vote (up/down) support via replaceable events (kind 30001) with geohash tags
- Debounce haptic at borders if needed
- Optional sorting by score (top) in addition to reverse‑chron
