### PR TITLE
Gate Tor/Nostr start behind permissions or mutual favorites; clean lifecycle + UX

### DIFF
--- a/bitchat/Services/NetworkActivationService.swift
+++ b/bitchat/Services/NetworkActivationService.swift
@@ -1,0 +1,70 @@
+import Foundation
+import BitLogger
+import Combine
+
+/// Coordinates when the app is allowed to start Tor and connect to Nostr relays.
+/// Policy: permit start when either location permissions are authorized OR
+/// there exists at least one mutual favorite. Otherwise, do not start.
+@MainActor
+final class NetworkActivationService: ObservableObject {
+    static let shared = NetworkActivationService()
+
+    @Published private(set) var activationAllowed: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
+    private var started = false
+
+    private init() {}
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        // Initial compute
+        activationAllowed = Self.computeAllowed()
+        TorManager.shared.setAutoStartAllowed(activationAllowed)
+
+        // React to location permission changes
+        LocationChannelManager.shared.$permissionState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reevaluate()
+            }
+            .store(in: &cancellables)
+
+        // React to mutual favorites changes
+        FavoritesPersistenceService.shared.$mutualFavorites
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reevaluate()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func reevaluate() {
+        let allowed = Self.computeAllowed()
+        if allowed != activationAllowed {
+            SecureLogger.info("NetworkActivationService: activationAllowed -> \(allowed)", category: .session)
+            activationAllowed = allowed
+            TorManager.shared.setAutoStartAllowed(allowed)
+            if allowed {
+                // Kick Tor + relays if we're now permitted
+                TorManager.shared.startIfNeeded()
+                // If app is in foreground, begin relay connections
+                if TorManager.shared.isForeground() {
+                    NostrRelayManager.shared.connect()
+                }
+            } else {
+                // Transitioned to disallowed: disconnect relays and shut down Tor
+                NostrRelayManager.shared.disconnect()
+                TorManager.shared.goDormantOnBackground()
+            }
+        }
+    }
+
+    private static func computeAllowed() -> Bool {
+        let permOK = LocationChannelManager.shared.permissionState == .authorized
+        let hasMutual = !FavoritesPersistenceService.shared.mutualFavorites.isEmpty
+        return permOK || hasMutual
+    }
+}

--- a/bitchat/Services/Tor/TorNotifications.swift
+++ b/bitchat/Services/Tor/TorNotifications.swift
@@ -3,4 +3,5 @@ import Foundation
 extension Notification.Name {
     static let TorDidBecomeReady = Notification.Name("TorDidBecomeReady")
     static let TorWillRestart = Notification.Name("TorWillRestart")
+    static let TorWillStart = Notification.Name("TorWillStart")
 }


### PR DESCRIPTION
## Summary
Gates Tor and Nostr startup behind explicit conditions and hardens the lifecycle:
- Do not start Tor or connect to relays unless either (a) location permissions are authorized, or (b) at least one mutual favorite exists.
- On background, fully stop Tor for a deterministic, clean restart on foreground (when allowed).
- When conditions become disallowed, disconnect all relays and stop Tor.
- Prevent any Nostr reconnect attempts, subscriptions or sends while disabled.
- Improve UX with clear system messages: starting, restarted, and ready.

## Why
- Avoid launching network services when users have not opted-in (no location + no mutual favorites).
- Reduce power/network usage and avoid error-prone half-suspended Tor states when the app backgrounds for a while.
- Eliminate double-start and reconnect thrash which was caused by lifecycle races.

## Behavior Changes
- Startup: Tor/Nostr will remain off until one of: (1) user authorizes location, or (2) a mutual favorite is created.
- Background: App sends Tor dormant (full stop). On foreground, Tor restarts only if allowed; sessions are rebuilt and relays reconnect.
- Disable path: If user revokes location and removes the last mutual favorite, the app disconnects relays and shuts down Tor.
- Nostr: No more reconnect attempts or sends while disabled; removes noisy "Tor not ready; skipping…" logs.

## Implementation
- New: `NetworkActivationService`
  - Computes `activationAllowed` = `LocationChannelManager.permissionState == .authorized || !FavoritesPersistenceService.mutualFavorites.isEmpty`.
  - Updates `TorManager.allowAutoStart` and triggers start/stop + relay connect/disconnect on transitions.
- `TorManager`
  - Adds global `allowAutoStart` gate and `setAutoStartAllowed(_:)`.
  - `startIfNeeded()`/`ensureRunningOnForeground()` respect the gate; posts `TorWillStart` before boot.
  - Always stop Tor on background; post `TorDidBecomeReady` when 100% bootstrapped.
- `NostrRelayManager`
  - Respects global gate in `connect`, `ensureConnections`, `subscribe`, `sendEvent`, `connectToRelay`.
  - `handleDisconnection` avoids scheduling backoff when disabled.
- `ChatViewModel`
  - Shows "starting tor…" on `TorWillStart`, and "tor started…" once on initial `TorDidBecomeReady`.
  - Keeps existing restart messages ("tor restarting…", "tor restarted…").
- `BitchatApp`
  - Replaces unconditional Tor start with `NetworkActivationService.shared.start()`.
  - On background: always stop Tor; on foreground: rebuild sessions and reconnect only when allowed.

## User-visible Messages
- "starting tor…" when Tor begins bootstrapping.
- "tor started. routing all chats via tor for privacy." after initial readiness.
- "tor restarting…" and "tor restarted…" for lifecycles across backgrounds.

## Testing Notes
- Cold launch with no location and no mutual favorites: Tor should not start; no relay activity.
- Add mutual favorite: Tor starts once; relays connect; no duplicate start.
- Enable location while app backgrounds (Settings) and return: Tor restarts cleanly; Nostr reconnects.
- Disable location and remove mutual favorite: Relays disconnect; Tor shuts down; no reconnect attempts.
- Open a geohash channel during transitions: system messages appear as described.

## Backward Compatibility
- No data migrations. New service observes existing publishers and notifications.

## Follow-ups (optional)
- Surface activation state in UI settings.
- Consider a small grace window to defer Tor stop on short background bounces.

## Files Changed
- `bitchat/Services/NetworkActivationService.swift` (new)
- `bitchat/Services/Tor/TorManager.swift`
- `bitchat/Services/Tor/TorNotifications.swift`
- `bitchat/Nostr/NostrRelayManager.swift`
- `bitchat/BitchatApp.swift`
- `bitchat/ViewModels/ChatViewModel.swift`

