### PR TITLE
Disable “precise location” by default for privacy

### DIFF
--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -37,6 +37,8 @@
 	<string>bitchat uses Bluetooth to discover and connect with other bitchat users nearby.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>bitchat uses the camera to scan QR codes to verify peers.</string>
+	<key>NSLocationDefaultAccuracyReduced</key>
+	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.</string>
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
Not sure if this would affect finding nearby people, but at least the users will have an option to turn on the precise location if they choose to do so instead of it being on by default as the app doesn't really need it to operate.