### PR TITLE
Ignore self when opening message actions

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -462,7 +462,12 @@ struct ContentView: View {
                         selectedMessageSender = viewModel.messages.last(where: { $0.senderPeerID == peerID && $0.sender != "system" })?.sender
                     }
                 }
-                showMessageActions = true
+                if viewModel.isSelfSender(peerID: selectedMessageSenderID, displayName: selectedMessageSender) {
+                    selectedMessageSender = nil
+                    selectedMessageSenderID = nil
+                } else {
+                    showMessageActions = true
+                }
             }
             .onOpenURL { url in
                 guard url.scheme == "bitchat", url.host == "geohash" else { return }


### PR DESCRIPTION
## Summary
- resolve display name & identity for geohash posts before showing the message action sheet
- block the sheet when the linked message belongs to the local user
- add a short-key mapping on geohash sends so subsequent lookups succeed

## Testing
- xcodebuild -project bitchat.xcodeproj -scheme "bitchat (macOS)" -configuration Debug CODE_SIGNING_ALLOWED=NO build