### PR TITLE
Prevent Github Languages stats skewing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Prevent Github Languages stats skewing:
+
+# Binaries and assets
+**/*.xcframework/** linguist-vendored
+**/*.xcassets/** linguist-vendored
+
+# Generated files
+**/*.pbxproj linguist-generated
+**/*.storyboard linguist-generated
+Package.resolved linguist-generated
+
+# Downloaded CSVs
+relays/online_relays_gps.csv linguist-vendored
+
+# Docs
+**/*.md linguist-documentation
+
+# Configs
+Configs/*.xcconfig linguist-documentation
+**/*.plist linguist-documentation


### PR DESCRIPTION
Seeing **~95%** of the project is in `C` could be demotivating (or even scary) for new contributors.

Introduced `.gitattributes` to ignore binaries/generated code/docs/configs from the Languages stat to better reflect the reality

| Before | After |
| ------ | ----- |
| <img width="388" height="137" alt="Screenshot 2025-09-16 at 12 42 19 AM" src="https://github.com/user-attachments/assets/3b3cbd99-99f5-43f1-bde2-2820f91a49eb" /> | <img width="387" height="117" alt="Screenshot 2025-09-16 at 12 42 28 AM" src="https://github.com/user-attachments/assets/78d48b5b-1b07-472c-ae7a-77c4b37a85ae" /> |

---
Also, when doing this exercise I realized that we're committing the binaries directly into this repo which has many downsides and documented a potential fix in #629.