### PR TITLE
add option to turn off tor, gate default relays connection on mutual favorites

### DIFF
--- a/bitchat/Services/NetworkActivationService.swift
+++ b/bitchat/Services/NetworkActivationService.swift
@@ -10,9 +10,12 @@ final class NetworkActivationService: ObservableObject {
     static let shared = NetworkActivationService()
 
     @Published private(set) var activationAllowed: Bool = false
+    @Published private(set) var userTorEnabled: Bool = true
 
     private var cancellables = Set<AnyCancellable>()
     private var started = false
+    private let torPreferenceKey = "networkActivationService.userTorEnabled"
+    private var torAutoStartDesired: Bool = false
 
     private init() {}
 
@@ -20,9 +23,23 @@ final class NetworkActivationService: ObservableObject {
         guard !started else { return }
         started = true
 
+        if let stored = UserDefaults.standard.object(forKey: torPreferenceKey) as? Bool {
+            userTorEnabled = stored
+        } else {
+            userTorEnabled = true
+        }
+
         // Initial compute
-        activationAllowed = Self.computeAllowed()
-        TorManager.shared.setAutoStartAllowed(activationAllowed)
+        let allowed = basePolicyAllowed()
+        activationAllowed = allowed
+        torAutoStartDesired = allowed && userTorEnabled
+        TorManager.shared.setAutoStartAllowed(torAutoStartDesired)
+        applyTorState(torDesired: torAutoStartDesired)
+        if allowed {
+            NostrRelayManager.shared.connect()
+        } else {
+            NostrRelayManager.shared.disconnect()
+        }
 
         // React to location permission changes
         LocationChannelManager.shared.$permissionState
@@ -41,30 +58,56 @@ final class NetworkActivationService: ObservableObject {
             .store(in: &cancellables)
     }
 
+    func setUserTorEnabled(_ enabled: Bool) {
+        guard enabled != userTorEnabled else { return }
+        userTorEnabled = enabled
+        UserDefaults.standard.set(enabled, forKey: torPreferenceKey)
+        NotificationCenter.default.post(
+            name: .TorUserPreferenceChanged,
+            object: nil,
+            userInfo: ["enabled": enabled]
+        )
+        reevaluate()
+    }
+
     private func reevaluate() {
-        let allowed = Self.computeAllowed()
-        if allowed != activationAllowed {
+        let allowed = basePolicyAllowed()
+        let torDesired = allowed && userTorEnabled
+        let statusChanged = allowed != activationAllowed
+        let torChanged = torDesired != torAutoStartDesired
+        if statusChanged {
             SecureLogger.info("NetworkActivationService: activationAllowed -> \(allowed)", category: .session)
             activationAllowed = allowed
-            TorManager.shared.setAutoStartAllowed(allowed)
-            if allowed {
-                // Kick Tor + relays if we're now permitted
-                TorManager.shared.startIfNeeded()
-                // If app is in foreground, begin relay connections
-                if TorManager.shared.isForeground() {
-                    NostrRelayManager.shared.connect()
-                }
-            } else {
-                // Transitioned to disallowed: disconnect relays and shut down Tor
+        }
+        if statusChanged || torChanged {
+            torAutoStartDesired = torDesired
+            TorManager.shared.setAutoStartAllowed(torDesired)
+            applyTorState(torDesired: torDesired)
+        }
+
+        if allowed {
+            if torChanged {
+                // Reset relay sockets when switching transport path (Tor ↔︎ direct)
                 NostrRelayManager.shared.disconnect()
-                TorManager.shared.goDormantOnBackground()
             }
+            NostrRelayManager.shared.connect()
+        } else if statusChanged {
+            NostrRelayManager.shared.disconnect()
         }
     }
 
-    private static func computeAllowed() -> Bool {
+    private func basePolicyAllowed() -> Bool {
         let permOK = LocationChannelManager.shared.permissionState == .authorized
         let hasMutual = !FavoritesPersistenceService.shared.mutualFavorites.isEmpty
         return permOK || hasMutual
+    }
+
+    private func applyTorState(torDesired: Bool) {
+        TorURLSession.shared.setProxyMode(useTor: torDesired)
+        if torDesired {
+            TorManager.shared.startIfNeeded()
+        } else {
+            TorManager.shared.shutdownCompletely()
+        }
     }
 }

--- a/bitchat/Services/Tor/TorManager.swift
+++ b/bitchat/Services/Tor/TorManager.swift
@@ -539,6 +539,24 @@ final class TorManager: ObservableObject {
         }
     }
 
+    func shutdownCompletely() {
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            _ = tor_host_shutdown()
+            await MainActor.run {
+                self.isDormant = false
+                self.isReady = false
+                self.socksReady = false
+                self.bootstrapProgress = 0
+                self.bootstrapSummary = ""
+                self.isStarting = false
+                self.didStart = false
+                self.restarting = false
+                self.controlMonitorStarted = false
+            }
+        }
+    }
+
     private func restartTor() async {
         await MainActor.run {
             // Announce restart so UI can notify the user

--- a/bitchat/Services/Tor/TorNotifications.swift
+++ b/bitchat/Services/Tor/TorNotifications.swift
@@ -4,4 +4,5 @@ extension Notification.Name {
     static let TorDidBecomeReady = Notification.Name("TorDidBecomeReady")
     static let TorWillRestart = Notification.Name("TorWillRestart")
     static let TorWillStart = Notification.Name("TorWillStart")
+    static let TorUserPreferenceChanged = Notification.Name("TorUserPreferenceChanged")
 }

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -778,6 +778,12 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
             name: .TorWillStart,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleTorPreferenceChanged(_:)),
+            name: .TorUserPreferenceChanged,
+            object: nil
+        )
         #else
         NotificationCenter.default.addObserver(
             self,
@@ -828,6 +834,12 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
             name: .TorWillStart,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleTorPreferenceChanged(_:)),
+            name: .TorUserPreferenceChanged,
+            object: nil
+        )
         #endif
     }
     
@@ -867,6 +879,14 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
                 self.addGeohashOnlySystemMessage("tor started. routing all chats via tor for privacy.")
                 self.torInitialReadyAnnounced = true
             }
+        }
+    }
+
+    @objc private func handleTorPreferenceChanged(_ notification: Notification) {
+        Task { @MainActor in
+            self.torStatusAnnounced = false
+            self.torInitialReadyAnnounced = false
+            self.torRestartPending = false
         }
     }
     


### PR DESCRIPTION
## Summary
- gate default nostr relays on mutual favorites and react to changes
- add tor toggle in location channels sheet with direct relay support
- ensure tor shutdown/reset and status messaging follow preference flips

## Testing
- not run (please run Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project bitchat.xcodeproj -scheme bitchat -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 15" test

Build settings from command line:
    SDKROOT = iphonesimulator26.0

Resolve Package Graph


Resolved source packages:
  swift-secp256k1: https://github.com/21-DOT-DEV/swift-secp256k1 @ 0.21.1
  BitLogger: /Users/jack/vibe/bitchat/localPackages/BitLogger @ local)