### PR TITLE
InputValidator to handle prefixes explicitly

### DIFF
--- a/bitchat/Utils/InputValidator.swift
+++ b/bitchat/Utils/InputValidator.swift
@@ -20,6 +20,13 @@ struct InputValidator {
     
     /// Validates a peer ID from any source (short 16-hex, full 64-hex, or internal alnum/-/_ up to 64)
     static func validatePeerID(_ peerID: String) -> Bool {
+        // Handle different prefixes
+        if peerID.starts(with: "nostr_") || peerID.starts(with: "nostr:") || peerID.starts(with: "noise:") {
+            return validatePeerID(String(peerID.dropFirst(6)))
+        } else if peerID.starts(with: "mesh:") || peerID.starts(with: "name:") {
+            return validatePeerID(String(peerID.dropFirst(5)))
+        }
+        
         // Accept short routing IDs (exact 16-hex)
         if PeerIDResolver.isShortID(peerID) { return true }
         // If length equals short-hex length but isn't valid hex, reject

--- a/bitchatTests/Utils/InputValidatorTests.swift
+++ b/bitchatTests/Utils/InputValidatorTests.swift
@@ -33,5 +33,42 @@ final class InputValidatorTests: XCTestCase {
         let tooLong = String(repeating: "a", count: 65)
         XCTAssertFalse(InputValidator.validatePeerID(tooLong))
     }
+
+    func test_valid_prefixes() {
+        let hex64 = String(repeating: "a", count: 64)
+        XCTAssertTrue(InputValidator.validatePeerID("noise:\(hex64)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr:\(hex64)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr_\(hex64)"))
+        
+        let hex63 = String(repeating: "a", count: 63)
+        XCTAssertTrue(InputValidator.validatePeerID("noise:\(hex63)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr:\(hex63)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr_\(hex63)"))
+        
+        let hex16 = String(repeating: "a", count: 16)
+        XCTAssertTrue(InputValidator.validatePeerID("noise:\(hex16)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr:\(hex16)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr_\(hex16)"))
+        
+        let hex8 = String(repeating: "a", count: 8)
+        XCTAssertTrue(InputValidator.validatePeerID("noise:\(hex8)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr:\(hex8)"))
+        XCTAssertTrue(InputValidator.validatePeerID("nostr_\(hex8)"))
+        
+        let mesh = "mesh:abcdefg"
+        XCTAssertTrue(InputValidator.validatePeerID("name:\(mesh)"))
+        
+        let name = "name:some_name"
+        XCTAssertTrue(InputValidator.validatePeerID("name:\(name)"))
+        
+        let badName = "name:bad:name"
+        XCTAssertFalse(InputValidator.validatePeerID("name:\(badName)"))
+        
+        // Too long
+        let hex65 = String(repeating: "a", count: 65)
+        XCTAssertFalse(InputValidator.validatePeerID("noise:\(hex65)"))
+        XCTAssertFalse(InputValidator.validatePeerID("nostr:\(hex65)"))
+        XCTAssertFalse(InputValidator.validatePeerID("nostr_\(hex65)"))
+    }
 }
 


### PR DESCRIPTION
@jackjackbits, could you double check if these new tests are following expected behavior or are they also going to cause the issues that are described in the first point of #640 because I cloned this validator into Peer.swift (and can clone these new tests too)?

Or if I didn't understand the expectation correctly, could you give me example valid inputs and example broken inputs so we can add them to tests and make sure the new implementation also has them?