### PR TITLE
Comment out broken tests

### DIFF
--- a/bitchatTests/FontBitchatTests.swift
+++ b/bitchatTests/FontBitchatTests.swift
@@ -3,14 +3,14 @@ import XCTest
 @testable import bitchat
 
 final class FontBitchatTests: XCTestCase {
-    func testMonospacedMapping() {
-        XCTAssertEqual(Font.bitchatSystem(size: 10, design: .monospaced), Font.system(.caption2, design: .monospaced))
-        XCTAssertEqual(Font.bitchatSystem(size: 14, design: .monospaced), Font.system(.body, design: .monospaced))
-        XCTAssertEqual(Font.bitchatSystem(size: 20, design: .monospaced), Font.system(.title2, design: .monospaced))
-    }
-
-    func testWeightIsPreserved() {
-        let bold = Font.bitchatSystem(size: 14, weight: .bold, design: .monospaced)
-        XCTAssertEqual(bold, Font.system(.body, design: .monospaced).weight(.bold))
-    }
+//    func testMonospacedMapping() {
+//        XCTAssertEqual(Font.bitchatSystem(size: 10, design: .monospaced), Font.system(.caption2, design: .monospaced))
+//        XCTAssertEqual(Font.bitchatSystem(size: 14, design: .monospaced), Font.system(.body, design: .monospaced))
+//        XCTAssertEqual(Font.bitchatSystem(size: 20, design: .monospaced), Font.system(.title2, design: .monospaced))
+//    }
+//
+//    func testWeightIsPreserved() {
+//        let bold = Font.bitchatSystem(size: 14, weight: .bold, design: .monospaced)
+//        XCTAssertEqual(bold, Font.system(.body, design: .monospaced).weight(.bold))
+//    }
 }


### PR DESCRIPTION
We can't compare Font's as it's not a value type, we can either have a custom "spec" struct that would accept values so we create a Font using that (then we can test that "spec") - or we need to use Snapshot testing to validate UI