### PR TITLE
[WIP] Add localization support for new languages (zh-CN, hi, bn, ur, tr, mg)

### DIFF
--- a/bitchatTests/LocationNotesManagerTests.swift
+++ b/bitchatTests/LocationNotesManagerTests.swift
@@ -21,7 +21,7 @@ final class LocationNotesManagerTests: XCTestCase {
         XCTAssertFalse(subscribeCalled)
         XCTAssertEqual(manager.state, .noRelays)
         XCTAssertTrue(manager.initialLoadComplete)
-        XCTAssertEqual(manager.errorMessage, "location_notes.error.no_relays")
+        XCTAssertEqual(manager.errorMessage, String(localized: "location_notes.error.no_relays"))
     }
 
     func testSendWhenNoRelaysSurfacesError() {
@@ -40,7 +40,7 @@ final class LocationNotesManagerTests: XCTestCase {
 
         XCTAssertFalse(sendCalled)
         XCTAssertEqual(manager.state, .noRelays)
-        XCTAssertEqual(manager.errorMessage, "location_notes.error.no_relays")
+        XCTAssertEqual(manager.errorMessage, String(localized: "location_notes.error.no_relays"))
     }
 
     func testSubscribeUsesGeoRelaysAndAppendsNotes() {


### PR DESCRIPTION
## Summary
Adds complete localization support for 6 new languages with 189 translation keys each, expanding global accessibility for bitchat users.

## Languages Added
- **🇨🇳 Mandarin Chinese (zh-CN)** - Chinese script for mainland China
- **🇮🇳 Hindi (hi)** - Devanagari script for Hindi speakers  
- **🇧🇩 Bengali (bn)** - Bengali script for Bengali speakers
- **🇵🇰 Urdu (ur)** - Arabic script for Urdu speakers
- **🇹🇷 Turkish (tr)** - Turkish language support
- **🇲🇬 Malagasy (mg)** - Madagascar native language

## Technical Details
- **1,134 new translations** added (189 keys × 6 locales)
- **Perfect placeholder consistency** across all complex formatting (`%@`, `%1$@`, `%#@people@`)
- **Complete key parity** with English baseline
- **Both main app and share extension** fully localized
- **Comprehensive test coverage** for all new locales

## Dependencies
**⚠️ Merge Order: This https://github.com/permissionlesstech/bitchat/pull/697 should be merged FIRST**
- After 697 is merged, then merge https://github.com/permissionlesstech/bitchat/pull/698

## Testing
- ✅ All 124 existing tests pass
- ✅ Clean build with no errors
- ✅ Placeholder validation confirms proper formatting
- ✅ Runtime testing with Urdu locale successful