### PR TITLE
Add new languages

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -93,6 +93,12 @@
             "state": "translated",
             "value": "bitchat"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
         }
       }
     },
@@ -187,6 +193,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "关闭"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধ করুন"
           }
         }
       }
@@ -283,6 +295,12 @@
             "state": "translated",
             "value": "完成"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সম্পন্ন"
+          }
         }
       }
     },
@@ -377,6 +395,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "私密消息使用 noise 协议加密"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "গোপন বার্তাগুলো নোইজ প্রোটোকলের মাধ্যমে এনক্রিপ্ট করা হয়"
           }
         }
       }
@@ -473,6 +497,12 @@
             "state": "translated",
             "value": "端到端加密"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এন্ড-টু-এন্ড এনক্রিপশন"
+          }
         }
       }
     },
@@ -567,6 +597,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "消息通过同伴中继，传得更远"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বার্তাগুলো সহ-পিয়ারদের মাধ্যমে রিলে হয়ে দূরেও পৌঁছে যায়"
           }
         }
       }
@@ -663,6 +699,12 @@
             "state": "translated",
             "value": "扩展范围"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বর্ধিত পরিসর"
+          }
         }
       }
     },
@@ -757,6 +799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "你喜欢的人加入时立刻提醒"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনার প্রিয় মানুষ যোগ দিলে বিজ্ঞপ্তি পান"
           }
         }
       }
@@ -853,6 +901,12 @@
             "state": "translated",
             "value": "收藏"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয়সমূহ"
+          }
         }
       }
     },
@@ -947,6 +1001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "geohash 频道让你通过去中心化匿名中继与附近地区的人聊天"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডিসেন্ট্রালাইজড বেনামি রিলে দিয়ে কাছাকাছি অঞ্চলের মানুষের সাথে কথা বলার জন্য জিওহ্যাশ চ্যানেল"
           }
         }
       }
@@ -1043,6 +1103,12 @@
             "state": "translated",
             "value": "本地频道"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "স্থানীয় চ্যানেল"
+          }
         }
       }
     },
@@ -1137,6 +1203,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "使用 @nickname 提醒特定的人"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নির্দিষ্ট কাউকে জানানোর জন্য @nickname ব্যবহার করুন"
           }
         }
       }
@@ -1233,6 +1305,12 @@
             "state": "translated",
             "value": "提及"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মেনশন"
+          }
         }
       }
     },
@@ -1327,6 +1405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "利用低功耗 bluetooth 离线工作"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লুটুথ লো এনার্জি ব্যবহার করে ইন্টারনেট ছাড়াই কাজ করে"
           }
         }
       }
@@ -1423,6 +1507,12 @@
             "state": "translated",
             "value": "离线通信"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অফলাইন যোগাযোগ"
+          }
         }
       }
     },
@@ -1517,6 +1607,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "功能"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বৈশিষ্ট্য"
           }
         }
       }
@@ -1613,6 +1709,12 @@
             "state": "translated",
             "value": "• 轻点 #mesh 切换频道"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• চ্যানেল বদলাতে #mesh ট্যাপ করুন"
+          }
         }
       }
     },
@@ -1707,6 +1809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• 三击聊天即可清除"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• চ্যাট মুছতে তিনবার ট্যাপ করুন"
           }
         }
       }
@@ -1803,6 +1911,12 @@
             "state": "translated",
             "value": "• 输入 / 查看指令"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• কমান্ডের জন্য / টাইপ করুন"
+          }
         }
       }
     },
@@ -1897,6 +2011,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• 轻点人物图标打开侧栏"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• সাইডবার খুলতে মানুষ আইকনে ট্যাপ করুন"
           }
         }
       }
@@ -1993,6 +2113,12 @@
             "state": "translated",
             "value": "• 轻点昵称即可设置"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• আপনার ডাকনামে ট্যাপ করে সেট করুন"
+          }
         }
       }
     },
@@ -2087,6 +2213,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• 轻点同伴名字开始 dm"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ডিএম শুরু করতে পিয়ারের নাম ট্যাপ করুন"
           }
         }
       }
@@ -2183,6 +2315,12 @@
             "state": "translated",
             "value": "使用方法"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যবহারের নিয়ম"
+          }
         }
       }
     },
@@ -2277,6 +2415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "定期生成新的 peer id"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নিয়মিত নতুন পিয়ার আইডি তৈরি হয়"
           }
         }
       }
@@ -2373,6 +2517,12 @@
             "state": "translated",
             "value": "临时身份"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অস্থায়ী পরিচয়"
+          }
         }
       }
     },
@@ -2467,6 +2617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无服务器、无账号、无数据收集"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কোনো সার্ভার, অ্যাকাউন্ট বা ডেটা সংগ্রহ নেই"
           }
         }
       }
@@ -2563,6 +2719,12 @@
             "state": "translated",
             "value": "无跟踪"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ট্র্যাকিং নেই"
+          }
         }
       }
     },
@@ -2657,6 +2819,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "三击标志立即清除全部数据"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোগোতে তিনবার ট্যাপ করলে সঙ্গে সঙ্গে সব ডেটা মুছে যাবে"
           }
         }
       }
@@ -2753,6 +2921,12 @@
             "state": "translated",
             "value": "紧急模式"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্যানিক মোড"
+          }
         }
       }
     },
@@ -2848,6 +3022,12 @@
             "state": "translated",
             "value": "隐私"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "গোপনীয়তা"
+          }
         }
       }
     },
@@ -2939,6 +3119,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "bn": {
           "stringUnit": {
             "state": "translated",
             "value": "sidegroupchat"
@@ -3038,6 +3224,12 @@
             "state": "translated",
             "value": "私信安全尚未完全审计。在此警告消失前不要用于关键情境。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যক্তিগত বার্তার নিরাপত্তা এখনো সম্পূর্ণ অডিট হয়নি। এই সতর্কতা না থাকা পর্যন্ত জরুরি পরিস্থিতিতে ব্যবহার করবেন না।"
+          }
         }
       }
     },
@@ -3132,6 +3324,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "警告"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সতর্কতা"
           }
         }
       }
@@ -3228,6 +3426,12 @@
             "state": "translated",
             "value": "取消"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বাতিল"
+          }
         }
       }
     },
@@ -3322,6 +3526,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "关闭"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধ করুন"
           }
         }
       }
@@ -3418,6 +3628,12 @@
             "state": "translated",
             "value": "复制"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কপি করুন"
+          }
         }
       }
     },
@@ -3512,6 +3728,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "确定"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ঠিক আছে"
           }
         }
       }
@@ -3608,6 +3830,12 @@
             "state": "translated",
             "value": "关闭"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধ"
+          }
         }
       }
     },
@@ -3702,6 +3930,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "开启"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "চালু"
           }
         }
       }
@@ -3798,6 +4032,12 @@
             "state": "translated",
             "value": "未知"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অজানা"
+          }
         }
       }
     },
@@ -3892,6 +4132,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加入收藏"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয়তে যোগ করুন"
           }
         }
       }
@@ -3988,6 +4234,12 @@
             "state": "translated",
             "value": "通过 Nostr 可用"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নোস্টরে উপলব্ধ"
+          }
         }
       }
     },
@@ -4082,6 +4334,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "返回主聊天"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মুখ্য চ্যাটে ফিরুন"
           }
         }
       }
@@ -4178,6 +4436,12 @@
             "state": "translated",
             "value": "通过 mesh 已连接"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মেশের মাধ্যমে সংযুক্ত"
+          }
         }
       }
     },
@@ -4272,6 +4536,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加密状态：%@"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশনের অবস্থা: %@"
           }
         }
       }
@@ -4368,6 +4638,12 @@
             "state": "translated",
             "value": "位置频道"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অবস্থান চ্যানেল"
+          }
         }
       }
     },
@@ -4463,6 +4739,12 @@
             "state": "translated",
             "value": "此位置的笔记"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই স্থানের লোকেশন নোট"
+          }
         }
       }
     },
@@ -4557,6 +4839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开未读私聊"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "না পড়া ব্যক্তিগত চ্যাট খুলুন"
           }
         }
       }
@@ -5037,6 +5325,12 @@
               }
             }
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
         }
       }
     },
@@ -5131,6 +5425,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "与 %@ 的私聊"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-এর সঙ্গে ব্যক্তিগত চ্যাট"
           }
         }
       }
@@ -5227,6 +5527,12 @@
             "state": "translated",
             "value": "可通过 mesh 到达"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মেশের মাধ্যমে পৌঁছানো সম্ভব"
+          }
         }
       }
     },
@@ -5321,6 +5627,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "移出收藏"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয় থেকে সরান"
           }
         }
       }
@@ -5417,6 +5729,12 @@
             "state": "translated",
             "value": "输入要发送的消息"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বার্তা পাঠাতে একটি বার্তা লিখুন"
+          }
         }
       }
     },
@@ -5511,6 +5829,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "双击发送"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পাঠাতে দুইবার ট্যাপ করুন"
           }
         }
       }
@@ -5607,6 +5931,12 @@
             "state": "translated",
             "value": "发送消息"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বার্তা পাঠান"
+          }
         }
       }
     },
@@ -5701,6 +6031,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "切换 #%@ 的书签"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@-এর জন্য বুকমার্ক টগল করুন"
           }
         }
       }
@@ -5797,6 +6133,12 @@
             "state": "translated",
             "value": "双击切换收藏状态"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয় অবস্থা বদলাতে দুইবার ট্যাপ করুন"
+          }
         }
       }
     },
@@ -5891,6 +6233,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "轻点查看加密指纹"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশন ফিঙ্গারপ্রিন্ট দেখতে ট্যাপ করুন"
           }
         }
       }
@@ -5987,6 +6335,12 @@
             "state": "translated",
             "value": "屏蔽"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লক করুন"
+          }
         }
       }
     },
@@ -6081,6 +6435,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "私信"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডিরেক্ট মেসেজ"
           }
         }
       }
@@ -6177,6 +6537,12 @@
             "state": "translated",
             "value": "拥抱"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আলিঙ্গন"
+          }
         }
       }
     },
@@ -6271,6 +6637,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "提及"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মেনশন"
           }
         }
       }
@@ -6367,6 +6739,12 @@
             "state": "translated",
             "value": "拍打"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "চপেটাঘাত"
+          }
         }
       }
     },
@@ -6461,6 +6839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "操作"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অ্যাকশন"
           }
         }
       }
@@ -6557,6 +6941,12 @@
             "state": "translated",
             "value": "bluetooth 已关闭。请在设置中开启以使用 bitchat。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লুটুথ বন্ধ আছে। bitchat ব্যবহার করতে সেটিংসে ব্লুটুথ চালু করুন।"
+          }
         }
       }
     },
@@ -6651,6 +7041,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bitchat 需要 bluetooth 权限以连接附近设备。请在设置中启用访问。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নিকটবর্তী ডিভাইসের সাথে যুক্ত হতে bitchat-এর ব্লুটুথ অনুমতি দরকার। দয়া করে সেটিংসে ব্লুটুথ অ্যাক্সেস সক্রিয় করুন।"
           }
         }
       }
@@ -6747,6 +7143,12 @@
             "state": "translated",
             "value": "设置"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সেটিংস"
+          }
         }
       }
     },
@@ -6841,6 +7243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要 bluetooth"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লুটুথ প্রয়োজন"
           }
         }
       }
@@ -6937,6 +7345,12 @@
             "state": "translated",
             "value": "此设备不支持 bluetooth。bitchat 需要 bluetooth 才能运行。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই ডিভাইস ব্লুটুথ সমর্থন করে না। bitchat চালাতে ব্লুটুথ দরকার।"
+          }
         }
       }
     },
@@ -7031,6 +7445,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "位置频道的截图会暴露你的位置。公开分享前请三思。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন চ্যানেলের স্ক্রিনশট আপনার অবস্থান প্রকাশ করবে। প্রকাশ করার আগে ভেবে দেখুন।"
           }
         }
       }
@@ -7127,6 +7547,12 @@
             "state": "translated",
             "value": "注意"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সতর্কতা"
+          }
         }
       }
     },
@@ -7221,6 +7647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "屏蔽或查看已屏蔽的同伴"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লক বা ব্লক করা পিয়ারদের তালিকা দেখুন"
           }
         }
       }
@@ -7317,6 +7749,12 @@
             "state": "translated",
             "value": "清除聊天消息"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "চ্যাট মেসেজ মুছে দিন"
+          }
         }
       }
     },
@@ -7411,6 +7849,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加入收藏"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয়তে যোগ করুন"
           }
         }
       }
@@ -7507,6 +7951,12 @@
             "state": "translated",
             "value": "送出温暖拥抱"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কাউকে উষ্ণ আলিঙ্গন পাঠান"
+          }
         }
       }
     },
@@ -7601,6 +8051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "发送私信"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যক্তিগত বার্তা পাঠান"
           }
         }
       }
@@ -7697,6 +8153,12 @@
             "state": "translated",
             "value": "用鳟鱼拍某人"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কারওকে ট্রাউট মাছ দিয়ে চপেটাঘাত করুন"
+          }
         }
       }
     },
@@ -7791,6 +8253,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消屏蔽同伴"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কাউকে আনব্লক করুন"
           }
         }
       }
@@ -7887,6 +8355,12 @@
             "state": "translated",
             "value": "移出收藏"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রিয় থেকে সরিয়ে দিন"
+          }
         }
       }
     },
@@ -7981,6 +8455,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "查看谁在线"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কে অনলাইনে আছে দেখুন"
           }
         }
       }
@@ -8077,6 +8557,12 @@
             "state": "translated",
             "value": "已送达 %2$d 人中的 %1$d 人"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d জন সদস্যের মধ্যে %1$d জনের কাছে পৌঁছেছে"
+          }
         }
       }
     },
@@ -8171,6 +8657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已送达 %@"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-এর কাছে পৌঁছেছে"
           }
         }
       }
@@ -8267,6 +8759,12 @@
             "state": "translated",
             "value": "失败：%@"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যর্থ: %@"
+          }
         }
       }
     },
@@ -8361,6 +8859,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已读：%@"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ পড়েছে"
           }
         }
       }
@@ -8457,6 +8961,12 @@
             "state": "translated",
             "value": "用户已被屏蔽"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যবহারকারী ব্লক করা"
+          }
         }
       }
     },
@@ -8551,6 +9061,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不能给自己发消息"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নিজেকে বার্তা পাঠানো যায় না"
           }
         }
       }
@@ -8647,6 +9163,12 @@
             "state": "translated",
             "value": "发送错误"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পাঠাতে ত্রুটি"
+          }
         }
       }
     },
@@ -8741,6 +9263,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未知收件人"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অজানা প্রাপক"
           }
         }
       }
@@ -8837,6 +9365,12 @@
             "state": "translated",
             "value": "同伴不可达"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পিয়ার পৌঁছানো যাচ্ছে না"
+          }
         }
       }
     },
@@ -8931,6 +9465,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "成员"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মানুষ"
           }
         }
       }
@@ -9027,6 +9567,12 @@
             "state": "translated",
             "value": "验证：展示我的 qr 或扫描好友"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাই: আমার QR দেখান বা বন্ধুরটি স্ক্যান করুন"
+          }
         }
       }
     },
@@ -9121,6 +9667,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "输入消息..."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "একটি বার্তা লিখুন..."
           }
         }
       }
@@ -9217,6 +9769,12 @@
             "state": "translated",
             "value": "昵称"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডাকনাম"
+          }
         }
       }
     },
@@ -9311,6 +9869,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "启用位置"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন চালু করুন"
           }
         }
       }
@@ -9407,6 +9971,12 @@
             "state": "translated",
             "value": "复制消息"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বার্তা কপি করুন"
+          }
         }
       }
     },
@@ -9501,6 +10071,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "收起"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কম দেখান"
           }
         }
       }
@@ -9597,6 +10173,12 @@
             "state": "translated",
             "value": "展开"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আরও দেখান"
+          }
         }
       }
     },
@@ -9691,6 +10273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "位置不可用"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অবস্থান অনুপলব্ধ"
           }
         }
       }
@@ -9787,6 +10375,12 @@
             "state": "translated",
             "value": "笔记"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নোট"
+          }
         }
       }
     },
@@ -9881,6 +10475,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "通过 cashu 支付"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ক্যাশু দিয়ে পরিশোধ করুন"
           }
         }
       }
@@ -9977,6 +10577,12 @@
             "state": "translated",
             "value": "通过 lightning 支付"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লাইটনিং দিয়ে পরিশোধ করুন"
+          }
         }
       }
     },
@@ -10071,6 +10677,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在建立加密"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশন স্থাপিত হচ্ছে"
           }
         }
       }
@@ -10167,6 +10779,12 @@
             "state": "translated",
             "value": "加密失败"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশন ব্যর্থ হয়েছে"
+          }
         }
       }
     },
@@ -10261,6 +10879,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未加密"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট করা নেই"
           }
         }
       }
@@ -10357,6 +10981,12 @@
             "state": "translated",
             "value": "已加密"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট করা"
+          }
         }
       }
     },
@@ -10451,6 +11081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已加密并验证"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট ও যাচাইকৃত"
           }
         }
       }
@@ -10547,6 +11183,12 @@
             "state": "translated",
             "value": "正在建立加密..."
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশন স্থাপিত হচ্ছে..."
+          }
         }
       }
     },
@@ -10641,6 +11283,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加密失败"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপশন ব্যর্থ হয়েছে"
           }
         }
       }
@@ -10737,6 +11385,12 @@
             "state": "translated",
             "value": "未加密"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট করা নেই"
+          }
         }
       }
     },
@@ -10831,6 +11485,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已加密"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট করা"
           }
         }
       }
@@ -10927,6 +11587,12 @@
             "state": "translated",
             "value": "已加密并验证"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এনক্রিপ্ট করা ও যাচাইকৃত"
+          }
         }
       }
     },
@@ -11021,6 +11687,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "标记为已验证"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাইকৃত হিসেবে চিহ্নিত করুন"
           }
         }
       }
@@ -11117,6 +11789,12 @@
             "state": "translated",
             "value": "移除验证"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাইকরণ সরান"
+          }
         }
       }
     },
@@ -11211,6 +11889,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ 未验证"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ যাচাইকৃত নয়"
           }
         }
       }
@@ -11307,6 +11991,12 @@
             "state": "translated",
             "value": "✓ 已验证"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ যাচাইকৃত"
+          }
         }
       }
     },
@@ -11401,6 +12091,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "暂不可用 - handshake 进行中"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "উপলব্ধ নয় - হ্যান্ডশেক চলছে"
           }
         }
       }
@@ -11497,6 +12193,12 @@
             "state": "translated",
             "value": "你已经核实了此人的身份。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনি এই ব্যক্তির পরিচয় যাচাই করেছেন।"
+          }
         }
       }
     },
@@ -11591,6 +12293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "通过安全渠道与 %@ 比对这些指纹。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নিরাপদ চ্যানেলে %@-এর সঙ্গে এই ফিঙ্গারপ্রিন্ট মিলিয়ে দেখুন।"
           }
         }
       }
@@ -11687,6 +12395,12 @@
             "state": "translated",
             "value": "对方指纹："
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "তাদের ফিঙ্গারপ্রিন্ট:"
+          }
         }
       }
     },
@@ -11781,6 +12495,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "安全验证"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নিরাপত্তা যাচাই"
           }
         }
       }
@@ -11877,6 +12597,12 @@
             "state": "translated",
             "value": "你的指纹："
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনার ফিঙ্গারপ্রিন্ট:"
+          }
         }
       }
     },
@@ -11971,6 +12697,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "屏蔽"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লক করুন"
           }
         }
       }
@@ -12067,6 +12799,12 @@
             "state": "translated",
             "value": "取消屏蔽"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আনব্লক করুন"
+          }
         }
       }
     },
@@ -12161,6 +12899,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "附近没人..."
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কাছে কেউ নেই..."
           }
         }
       }
@@ -12257,6 +13001,12 @@
             "state": "translated",
             "value": "在 geohash 中已屏蔽"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "জিওহ্যাশে ব্লক করা"
+          }
         }
       }
     },
@@ -12351,6 +13101,12 @@
           "stringUnit": {
             "state": "translated",
             "value": " (你)"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (আপনি)"
           }
         }
       }
@@ -12447,6 +13203,12 @@
             "state": "translated",
             "value": "打开设置"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সেটিংস খুলুন"
+          }
         }
       }
     },
@@ -12541,6 +13303,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "移除位置访问"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন অ্যাক্সেস সরান"
           }
         }
       }
@@ -12637,6 +13405,12 @@
             "state": "translated",
             "value": "获取位置和我的 geohash"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন অনুমতি ও আমার জিওহ্যাশ নিন"
+          }
         }
       }
     },
@@ -12731,6 +13505,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "瞬移"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "টেলিপোর্ট"
           }
         }
       }
@@ -12827,6 +13607,12 @@
             "state": "translated",
             "value": "已收藏"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বুকমার্ক করা"
+          }
         }
       }
     },
@@ -12921,6 +13707,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "使用 geohash 频道与附近的人聊天。只会共享粗略 geohash，从不泄露精确 GPS。所有流量通过 tor 路由来隐藏你的 IP。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "জিওহ্যাশ চ্যানেল দিয়ে কাছাকাছি অঞ্চলের মানুষের সঙ্গে চ্যাট করুন। শুধুই স্থূল জিওহ্যাশ শেয়ার হয়, কখনো সঠিক GPS নয়। আপনার IP টর দিয়ে সব ট্রাফিক রাউট করে লুকানো থাকে।"
           }
         }
       }
@@ -13017,6 +13809,12 @@
             "state": "translated",
             "value": "无效的 geohash"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অবৈধ জিওহ্যাশ"
+          }
         }
       }
     },
@@ -13111,6 +13909,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在寻找附近频道…"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কাছাকাছি চ্যানেল খোঁজা হচ্ছে…"
           }
         }
       }
@@ -13207,6 +14011,12 @@
             "state": "translated",
             "value": "mesh"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মেশ"
+          }
         }
       }
     },
@@ -13301,6 +14111,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "位置权限被拒。请在设置中启用以使用位置频道。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন অনুমতি অস্বীকৃত। লোকেশন চ্যানেল ব্যবহার করতে সেটিংসে সক্রিয় করুন।"
           }
         }
       }
@@ -13781,6 +14597,12 @@
               }
             }
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
         }
       }
     },
@@ -13876,6 +14698,12 @@
             "state": "translated",
             "value": "#%@ • %@"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
         }
       }
     },
@@ -13967,6 +14795,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "bn": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ • %2$@"
@@ -14066,6 +14900,12 @@
             "state": "translated",
             "value": "#位置频道"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#লোকেশন চ্যানেল"
+          }
         }
       }
     },
@@ -14160,6 +15000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "为位置频道隐藏你的 IP。推荐：开启。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন চ্যানেলের জন্য আপনার IP লুকায়। সুপারিশ: চালু রাখুন।"
           }
         }
       }
@@ -14256,6 +15102,12 @@
             "state": "translated",
             "value": "tor 路由"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor রাউটিং"
+          }
         }
       }
     },
@@ -14350,6 +15202,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "街区"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্লক"
           }
         }
       }
@@ -14446,6 +15304,12 @@
             "state": "translated",
             "value": "楼栋"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ভবন"
+          }
         }
       }
     },
@@ -14540,6 +15404,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "城市"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শহর"
           }
         }
       }
@@ -14636,6 +15506,12 @@
             "state": "translated",
             "value": "社区"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পাড়া"
+          }
         }
       }
     },
@@ -14730,6 +15606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "省份"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "প্রদেশ"
           }
         }
       }
@@ -14826,6 +15708,12 @@
             "state": "translated",
             "value": "区域"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অঞ্চল"
+          }
         }
       }
     },
@@ -14920,6 +15808,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "关闭"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধ করুন"
           }
         }
       }
@@ -15016,6 +15910,12 @@
             "state": "translated",
             "value": "重试"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আবার চেষ্টা করুন"
+          }
         }
       }
     },
@@ -15110,6 +16010,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "为此地点添加简短的常驻笔记，方便其他访客发现。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই স্থানে অন্যরা খুঁজে পেতে পারে এমন ছোট স্থায়ী নোট যোগ করুন।"
           }
         }
       }
@@ -15206,6 +16112,12 @@
             "state": "translated",
             "value": "成为这里的第一条笔记。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই জায়গার জন্য প্রথম নোট যোগ করুন।"
+          }
         }
       }
     },
@@ -15300,6 +16212,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "尚无笔记"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এখনও কোনো নোট নেই"
           }
         }
       }
@@ -15396,6 +16314,12 @@
             "state": "translated",
             "value": "无法发送笔记。%@"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নোট পাঠাতে ব্যর্থ। %@"
+          }
         }
       }
     },
@@ -15490,6 +16414,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "附近没有可用的地理中继。稍后再试。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই স্থানের কাছে কোনো জিও রিলে নেই। কিছুক্ষণ পরে আবার চেষ্টা করুন।"
           }
         }
       }
@@ -15970,6 +16900,12 @@
               }
             }
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
         }
       }
     },
@@ -16064,6 +17000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在加载笔记…"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নোট লোড হচ্ছে…"
           }
         }
       }
@@ -16160,6 +17102,12 @@
             "state": "translated",
             "value": "正在加载最新笔记…"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "সাম্প্রতিক নোট লোড হচ্ছে…"
+          }
         }
       }
     },
@@ -16254,6 +17202,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "附近没有地理中继"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কাছে কোনো জিও রিলে নেই"
           }
         }
       }
@@ -16350,6 +17304,12 @@
             "state": "translated",
             "value": "为此地点添加笔记"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "এই স্থানের জন্য একটি নোট যোগ করুন"
+          }
         }
       }
     },
@@ -16444,6 +17404,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "地理中继不可用；笔记已暂停"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "জিও রিলে অনুপলব্ধ; নোট স্থগিত"
           }
         }
       }
@@ -16540,6 +17506,12 @@
             "state": "translated",
             "value": "笔记依赖地理中继。检查连接后再试。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নোট জিও রিলের উপর নির্ভরশীল। সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।"
+          }
         }
       }
     },
@@ -16634,6 +17606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "新消息"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নতুন বার্তা"
           }
         }
       }
@@ -16730,6 +17708,12 @@
             "state": "translated",
             "value": "无法与 %@ 开始聊天：用户已被屏蔽。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-এর সঙ্গে চ্যাট শুরু করা যায় না: ব্যক্তি ব্লক করা আছে।"
+          }
         }
       }
     },
@@ -16824,6 +17808,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法与 %@ 开始聊天：离线消息需要互相关注。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-এর সঙ্গে চ্যাট শুরু করা যায় না: অফলাইন মেসেজিংয়ের জন্য পারস্পরিক প্রিয় দরকার।"
           }
         }
       }
@@ -16920,6 +17910,12 @@
             "state": "translated",
             "value": "用户"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ব্যবহারকারী"
+          }
         }
       }
     },
@@ -17014,6 +18010,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法发送：用户已被屏蔽。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বার্তা পাঠানো যায় না: ব্যক্তি ব্লক করা আছে।"
           }
         }
       }
@@ -17110,6 +18112,12 @@
             "state": "translated",
             "value": "无法向 %@ 发送：用户已被屏蔽。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-কে বার্তা পাঠানো যায় না: ব্যক্তি ব্লক করা আছে।"
+          }
         }
       }
     },
@@ -17204,6 +18212,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法向 %@ 发送：对方无法通过 mesh 或 Nostr 到达。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-কে বার্তা পাঠানো যায় না - পিয়ার মেশ বা নোস্টরে পৌঁছানো যাচ্ছে না।"
           }
         }
       }
@@ -17300,6 +18314,12 @@
             "state": "translated",
             "value": "已在 geohash 聊天中屏蔽 %@"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "জিওহ্যাশ চ্যাটে %@ ব্লক করা হয়েছে"
+          }
         }
       }
     },
@@ -17394,6 +18414,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已在 geohash 聊天中解除屏蔽 %@"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "জিওহ্যাশ চ্যাটে %@ আনব্লক করা হয়েছে"
           }
         }
       }
@@ -17490,6 +18516,12 @@
             "state": "translated",
             "value": "发送失败：你不在位置频道中"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পাঠানো যায় না: লোকেশন চ্যানেলে নেই"
+          }
         }
       }
     },
@@ -17584,6 +18616,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法发送到位置频道"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লোকেশন চ্যানেলে পাঠাতে ব্যর্থ"
           }
         }
       }
@@ -17680,6 +18718,12 @@
             "state": "translated",
             "value": "开发构建：tor 绕过已启用。"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ডেভেলপমেন্ট বিল্ড: Tor বাইপাস সক্রিয়।"
+          }
         }
       }
     },
@@ -17774,6 +18818,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "tor 已重启。网络路由已恢复。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor পুনরায় চালু হয়েছে। নেটওয়ার্ক রাউটিং পুনরুদ্ধার হয়েছে।"
           }
         }
       }
@@ -17870,6 +18920,12 @@
             "state": "translated",
             "value": "tor 正在重启以恢复连接..."
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor সংযোগ ফিরিয়ে আনতে পুনরায় চালু হচ্ছে..."
+          }
         }
       }
     },
@@ -17964,6 +19020,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "tor 已启动。所有聊天通过 tor 路由以保护 IP。"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor চালু হয়েছে। IP গোপন রাখতে সব চ্যাট Tor দিয়ে যাচ্ছে।"
           }
         }
       }
@@ -18060,6 +19122,12 @@
             "state": "translated",
             "value": "正在启动 tor..."
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor চালু হচ্ছে..."
+          }
         }
       }
     },
@@ -18154,6 +19222,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "验证 QR 码"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাই QR কোড"
           }
         }
       }
@@ -18250,6 +19324,12 @@
             "state": "translated",
             "value": "扫描验证我"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আমাকে যাচাই করতে স্ক্যান করুন"
+          }
         }
       }
     },
@@ -18344,6 +19424,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "QR 不可用"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR অনুপলব্ধ"
           }
         }
       }
@@ -18440,6 +19526,12 @@
             "state": "translated",
             "value": "粘贴 QR 内容以验证："
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাই করতে QR বিষয়বস্তু পেস্ট করুন:"
+          }
         }
       }
     },
@@ -18534,6 +19626,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "扫描好友的 QR"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধুর QR স্ক্যান করুন"
           }
         }
       }
@@ -18630,6 +19728,12 @@
             "state": "translated",
             "value": "QR 无效或已过期"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "অবৈধ বা মেয়াদোত্তীর্ণ QR পেলোড"
+          }
         }
       }
     },
@@ -18724,6 +19828,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未找到匹配的同伴"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "মিলে যাওয়া পিয়ার খুঁজে পাওয়া যায়নি"
           }
         }
       }
@@ -18820,6 +19930,12 @@
             "state": "translated",
             "value": "已请求 %@ 的验证"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-এর জন্য যাচাই অনুরোধ করা হয়েছে"
+          }
         }
       }
     },
@@ -18914,6 +20030,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "验证"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাই করুন"
           }
         }
       }
@@ -19010,6 +20132,12 @@
             "state": "translated",
             "value": "验证"
           }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যাচাই"
+          }
         }
       }
     },
@@ -19103,6 +20231,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "bn": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -10473,7 +10473,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "sstablishing encryption..."
+            "value": "establishing encryption..."
           }
         },
         "es": {

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -111,6 +111,12 @@
             "state": "translated",
             "value": "bitchat"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
         }
       }
     },
@@ -223,6 +229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "kapat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fechar"
           }
         }
       }
@@ -337,6 +349,12 @@
             "state": "translated",
             "value": "BİTTİ"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CONCLUÍDO"
+          }
         }
       }
     },
@@ -449,6 +467,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "özel mesajlar noise protokolü ile şifrelenir"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mensagens privadas encriptadas com o protocolo Noise"
           }
         }
       }
@@ -563,6 +587,12 @@
             "state": "translated",
             "value": "uçtan uca şifreleme"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptação ponta a ponta"
+          }
         }
       }
     },
@@ -675,6 +705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "mesajlar eşler üzerinden aktarılarak uzağa ulaşır"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mensagens retransmitidas entre pares para chegar mais longe"
           }
         }
       }
@@ -789,6 +825,12 @@
             "state": "translated",
             "value": "genişletilmiş menzil"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alcance alargado"
+          }
         }
       }
     },
@@ -901,6 +943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "favori kişileriniz katıldığında bildirim alın"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "recebe notificações quando as tuas pessoas favoritas entram"
           }
         }
       }
@@ -1015,6 +1063,12 @@
             "state": "translated",
             "value": "favoriler"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favoritos"
+          }
         }
       }
     },
@@ -1127,6 +1181,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "merkeziyetsiz anonim röleler üzerinden yakın bölgelerdeki insanlarla sohbet etmek için geohash kanalları"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "canais geohash para conversar com pessoas em regiões próximas através de relés descentralizados anónimos"
           }
         }
       }
@@ -1241,6 +1301,12 @@
             "state": "translated",
             "value": "yerel kanallar"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "canais locais"
+          }
         }
       }
     },
@@ -1353,6 +1419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "belirli kişileri bildirmek için @nickname kullanın"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usa @nickname para avisar pessoas específicas"
           }
         }
       }
@@ -1467,6 +1539,12 @@
             "state": "translated",
             "value": "bahsetmeler"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "menções"
+          }
         }
       }
     },
@@ -1579,6 +1657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bluetooth Low Energy kullanarak internet olmadan çalışır"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "funciona sem internet usando Bluetooth de baixo consumo"
           }
         }
       }
@@ -1693,6 +1777,12 @@
             "state": "translated",
             "value": "çevrimdışı iletişim"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "comunicação offline"
+          }
         }
       }
     },
@@ -1805,6 +1895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ÖZELLİKLER"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FUNCIONALIDADES"
           }
         }
       }
@@ -1919,6 +2015,12 @@
             "state": "translated",
             "value": "• kanalı değiştirmek için #mesh'e dokunun"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• toca em #mesh para mudar de canal"
+          }
         }
       }
     },
@@ -2031,6 +2133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• sohbeti temizlemek için sohbete üç kez dokunun"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• toca três vezes no chat para o limpar"
           }
         }
       }
@@ -2145,6 +2253,12 @@
             "state": "translated",
             "value": "• komutlar için / yazın"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• escreve / para ver os comandos"
+          }
         }
       }
     },
@@ -2257,6 +2371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• kenar çubuğunu açmak için insan simgesine dokunun"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• toca no ícone das pessoas para abrir a barra lateral"
           }
         }
       }
@@ -2371,6 +2491,12 @@
             "state": "translated",
             "value": "• takma adınızı üzerine dokunarak ayarlayın"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• define o teu apelido tocando nele"
+          }
         }
       }
     },
@@ -2483,6 +2609,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• bir eşin adına dokunarak DM başlatın"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• toca no nome de um par para iniciar um DM"
           }
         }
       }
@@ -2597,6 +2729,12 @@
             "state": "translated",
             "value": "NASIL KULLANILIR"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "COMO USAR"
+          }
         }
       }
     },
@@ -2709,6 +2847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "yeni eş kimliği düzenli olarak oluşturulur"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "novo ID de par gerado regularmente"
           }
         }
       }
@@ -2823,6 +2967,12 @@
             "state": "translated",
             "value": "geçici kimlik"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "identidade efémera"
+          }
         }
       }
     },
@@ -2935,6 +3085,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "sunucu, hesap veya veri toplama yok"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem servidores, contas ou recolha de dados"
           }
         }
       }
@@ -3049,6 +3205,12 @@
             "state": "translated",
             "value": "izleme yok"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem rastreio"
+          }
         }
       }
     },
@@ -3161,6 +3323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "logoya üç kez dokunun, tüm veriler anında silinsin"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toca três vezes no logótipo para limpar todos os dados de imediato"
           }
         }
       }
@@ -3275,6 +3443,12 @@
             "state": "translated",
             "value": "panik modu"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "modo pânico"
+          }
         }
       }
     },
@@ -3388,6 +3562,12 @@
             "state": "translated",
             "value": "GİZLİLİK"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRIVACIDADE"
+          }
         }
       }
     },
@@ -3497,6 +3677,12 @@
           }
         },
         "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "pt": {
           "stringUnit": {
             "state": "translated",
             "value": "sidegroupchat"
@@ -3614,6 +3800,12 @@
             "state": "translated",
             "value": "özel mesaj güvenliği henüz tamamen denetlenmedi. bu uyarı kaybolana kadar kritik durumlarda kullanmayın."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a segurança das mensagens privadas ainda não foi totalmente auditada. não uses em situações críticas até este aviso desaparecer."
+          }
         }
       }
     },
@@ -3726,6 +3918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "UYARI"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AVISO"
           }
         }
       }
@@ -3840,6 +4038,12 @@
             "state": "translated",
             "value": "iptal"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cancelar"
+          }
         }
       }
     },
@@ -3952,6 +4156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "kapat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fechar"
           }
         }
       }
@@ -4066,6 +4276,12 @@
             "state": "translated",
             "value": "kopyala"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copiar"
+          }
         }
       }
     },
@@ -4178,6 +4394,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "TAMAM"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
@@ -4292,6 +4514,12 @@
             "state": "translated",
             "value": "kapalı"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desligado"
+          }
         }
       }
     },
@@ -4404,6 +4632,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "açık"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ligado"
           }
         }
       }
@@ -4518,6 +4752,12 @@
             "state": "translated",
             "value": "bilinmiyor"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desconhecido"
+          }
         }
       }
     },
@@ -4630,6 +4870,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "favorilere ekle"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "adicionar aos favoritos"
           }
         }
       }
@@ -4744,6 +4990,12 @@
             "state": "translated",
             "value": "Nostr üzerinden kullanılabilir"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "disponível através do Nostr"
+          }
         }
       }
     },
@@ -4856,6 +5108,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ana sohbete dön"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "voltar ao chat principal"
           }
         }
       }
@@ -4970,6 +5228,12 @@
             "state": "translated",
             "value": "mesh üzerinden bağlı"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ligado por mesh"
+          }
         }
       }
     },
@@ -5082,6 +5346,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreleme durumu: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "estado da encriptação: %@"
           }
         }
       }
@@ -5196,6 +5466,12 @@
             "state": "translated",
             "value": "konum kanalları"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "canais de localização"
+          }
         }
       }
     },
@@ -5309,6 +5585,12 @@
             "state": "translated",
             "value": "bu yer için konum notları"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notas de localização deste lugar"
+          }
         }
       }
     },
@@ -5421,6 +5703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "okunmamış özel sohbeti aç"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abrir chat privado não lido"
           }
         }
       }
@@ -5919,6 +6207,12 @@
             "state": "translated",
             "value": "%#@people@"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
         }
       }
     },
@@ -6031,6 +6325,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ ile özel sohbet"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chat privado com %@"
           }
         }
       }
@@ -6145,6 +6445,12 @@
             "state": "translated",
             "value": "mesh üzerinden ulaşılabilir"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "acessível por mesh"
+          }
         }
       }
     },
@@ -6257,6 +6563,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "favorilerden kaldır"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remover dos favoritos"
           }
         }
       }
@@ -6371,6 +6683,12 @@
             "state": "translated",
             "value": "bir mesaj göndermek için metin girin"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "escreve uma mensagem para enviar"
+          }
         }
       }
     },
@@ -6483,6 +6801,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "göndermek için çift dokunun"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toca duas vezes para enviar"
           }
         }
       }
@@ -6597,6 +6921,12 @@
             "state": "translated",
             "value": "mesaj gönder"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enviar mensagem"
+          }
         }
       }
     },
@@ -6709,6 +7039,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#%@ için yer işaretini değiştir"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alternar o marcador de #%@"
           }
         }
       }
@@ -6823,6 +7159,12 @@
             "state": "translated",
             "value": "favori durumunu değiştirmek için çift dokunun"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toca duas vezes para alternar o estado de favorito"
+          }
         }
       }
     },
@@ -6935,6 +7277,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreleme parmak izini görmek için dokunun"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toca para ver a impressão de encriptação"
           }
         }
       }
@@ -7049,6 +7397,12 @@
             "state": "translated",
             "value": "engelle"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloquear"
+          }
         }
       }
     },
@@ -7161,6 +7515,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "doğrudan mesaj"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mensagem direta"
           }
         }
       }
@@ -7275,6 +7635,12 @@
             "state": "translated",
             "value": "sarıl"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abraçar"
+          }
         }
       }
     },
@@ -7387,6 +7753,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bahset"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mencionar"
           }
         }
       }
@@ -7501,6 +7873,12 @@
             "state": "translated",
             "value": "tokatla"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dar uma chapada"
+          }
         }
       }
     },
@@ -7613,6 +7991,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "eylemler"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ações"
           }
         }
       }
@@ -7727,6 +8111,12 @@
             "state": "translated",
             "value": "Bluetooth kapalı. bitchat'i kullanmak için ayarlardan Bluetooth'u açın."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Bluetooth está desligado. Ativa o Bluetooth em Definições para usar o bitchat."
+          }
         }
       }
     },
@@ -7839,6 +8229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bitchat'in yakın cihazlara bağlanması için Bluetooth izni gerekir. lütfen ayarlardan Bluetooth erişimini etkinleştirin."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O bitchat precisa de autorização de Bluetooth para se ligar a dispositivos próximos. Ativa o acesso em Definições."
           }
         }
       }
@@ -7953,6 +8349,12 @@
             "state": "translated",
             "value": "ayarlar"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "definições"
+          }
         }
       }
     },
@@ -8065,6 +8467,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bluetooth gerekli"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth necessário"
           }
         }
       }
@@ -8179,6 +8587,12 @@
             "state": "translated",
             "value": "bu cihaz Bluetooth'u desteklemiyor. bitchat'in çalışması için Bluetooth gerekli."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo não suporta Bluetooth. O bitchat precisa de Bluetooth para funcionar."
+          }
         }
       }
     },
@@ -8291,6 +8705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konum kanallarının ekran görüntüleri konumunuzu ortaya çıkarır. paylaşmadan önce iki kez düşünün."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturas de ecrã dos canais de localização revelam a tua localização. Pensa antes de partilhar publicamente."
           }
         }
       }
@@ -8405,6 +8825,12 @@
             "state": "translated",
             "value": "dikkat"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "atenção"
+          }
         }
       }
     },
@@ -8517,6 +8943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "engelle veya engellenen eşleri listele"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloquear ou listar pares bloqueados"
           }
         }
       }
@@ -8631,6 +9063,12 @@
             "state": "translated",
             "value": "sohbet mesajlarını temizle"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "limpar mensagens do chat"
+          }
         }
       }
     },
@@ -8743,6 +9181,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "favorilere ekle"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "adicionar aos favoritos"
           }
         }
       }
@@ -8857,6 +9301,12 @@
             "state": "translated",
             "value": "birine sıcak bir sarılma gönder"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enviar um abraço caloroso"
+          }
         }
       }
     },
@@ -8969,6 +9419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "özel mesaj gönder"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enviar mensagem privada"
           }
         }
       }
@@ -9083,6 +9539,12 @@
             "state": "translated",
             "value": "birine alabalıkla tokat at"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dar uma chapada a alguém com uma truta"
+          }
         }
       }
     },
@@ -9195,6 +9657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bir eşin engelini kaldır"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desbloquear um par"
           }
         }
       }
@@ -9309,6 +9777,12 @@
             "state": "translated",
             "value": "favorilerden çıkar"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remover dos favoritos"
+          }
         }
       }
     },
@@ -9421,6 +9895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "kimler çevrimiçi gör"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ver quem está online"
           }
         }
       }
@@ -9535,6 +10015,12 @@
             "state": "translated",
             "value": "%2$d üyeden %1$d kişiye ulaştı"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "entregue a %1$d de %2$d membros"
+          }
         }
       }
     },
@@ -9647,6 +10133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@'a iletildi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "entregue a %@"
           }
         }
       }
@@ -9761,6 +10253,12 @@
             "state": "translated",
             "value": "başarısız: %@"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "falhou: %@"
+          }
         }
       }
     },
@@ -9873,6 +10371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ okudu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lido por %@"
           }
         }
       }
@@ -9987,6 +10491,12 @@
             "state": "translated",
             "value": "kullanıcı engellendi"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "utilizador bloqueado"
+          }
         }
       }
     },
@@ -10099,6 +10609,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "kendine mesaj gönderemezsin"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível enviar mensagem a ti próprio"
           }
         }
       }
@@ -10213,6 +10729,12 @@
             "state": "translated",
             "value": "gönderme hatası"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "erro ao enviar"
+          }
         }
       }
     },
@@ -10325,6 +10847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bilinmeyen alıcı"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "destinatário desconhecido"
           }
         }
       }
@@ -10439,6 +10967,12 @@
             "state": "translated",
             "value": "eşe ulaşılamıyor"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "par inacessível"
+          }
         }
       }
     },
@@ -10551,6 +11085,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "KİŞİLER"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PESSOAS"
           }
         }
       }
@@ -10665,6 +11205,12 @@
             "state": "translated",
             "value": "doğrulama: QR kodumu göster veya bir arkadaşını tara"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificação: mostra o meu QR ou lê o de um amigo"
+          }
         }
       }
     },
@@ -10777,6 +11323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bir mesaj yazın..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "escreve uma mensagem..."
           }
         }
       }
@@ -10891,6 +11443,12 @@
             "state": "translated",
             "value": "takma ad"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "apelido"
+          }
         }
       }
     },
@@ -11003,6 +11561,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konumu etkinleştir"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ativar localização"
           }
         }
       }
@@ -11117,6 +11681,12 @@
             "state": "translated",
             "value": "mesajı kopyala"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copiar mensagem"
+          }
         }
       }
     },
@@ -11229,6 +11799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "daha az göster"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mostrar menos"
           }
         }
       }
@@ -11343,6 +11919,12 @@
             "state": "translated",
             "value": "daha fazla göster"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mostrar mais"
+          }
         }
       }
     },
@@ -11455,6 +12037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konum kullanılamıyor"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "localização indisponível"
           }
         }
       }
@@ -11569,6 +12157,12 @@
             "state": "translated",
             "value": "notlar"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notas"
+          }
         }
       }
     },
@@ -11681,6 +12275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "cashu ile öde"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pagar com Cashu"
           }
         }
       }
@@ -11795,6 +12395,12 @@
             "state": "translated",
             "value": "lightning ile öde"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pagar com Lightning"
+          }
         }
       }
     },
@@ -11907,6 +12513,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreleme kuruluyor"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a estabelecer encriptação"
           }
         }
       }
@@ -12021,6 +12633,12 @@
             "state": "translated",
             "value": "şifreleme başarısız"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptação falhada"
+          }
         }
       }
     },
@@ -12133,6 +12751,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifrelenmedi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem encriptação"
           }
         }
       }
@@ -12247,6 +12871,12 @@
             "state": "translated",
             "value": "şifreli"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptado"
+          }
         }
       }
     },
@@ -12359,6 +12989,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreli ve doğrulandı"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptado e verificado"
           }
         }
       }
@@ -12473,6 +13109,12 @@
             "state": "translated",
             "value": "şifreleme kuruluyor..."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a estabelecer encriptação..."
+          }
         }
       }
     },
@@ -12585,6 +13227,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreleme başarısız"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptação falhada"
           }
         }
       }
@@ -12699,6 +13347,12 @@
             "state": "translated",
             "value": "şifrelenmedi"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem encriptação"
+          }
         }
       }
     },
@@ -12811,6 +13465,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "şifreli"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptado"
           }
         }
       }
@@ -12925,6 +13585,12 @@
             "state": "translated",
             "value": "şifreli ve doğrulandı"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encriptado e verificado"
+          }
         }
       }
     },
@@ -13037,6 +13703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "doğrulandı olarak işaretle"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "marcar como verificado"
           }
         }
       }
@@ -13151,6 +13823,12 @@
             "state": "translated",
             "value": "doğrulamayı kaldır"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remover verificação"
+          }
         }
       }
     },
@@ -13263,6 +13941,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ DOĞRULANMADI"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ NÃO VERIFICADO"
           }
         }
       }
@@ -13377,6 +14061,12 @@
             "state": "translated",
             "value": "✓ DOĞRULANDI"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ VERIFICADO"
+          }
         }
       }
     },
@@ -13489,6 +14179,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "kullanılamıyor - el sıkışma sürüyor"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "indisponível - aperto de mão em curso"
           }
         }
       }
@@ -13603,6 +14299,12 @@
             "state": "translated",
             "value": "bu kişinin kimliğini doğruladınız."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "confirmaste a identidade desta pessoa."
+          }
         }
       }
     },
@@ -13715,6 +14417,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bu parmak izlerini %@ ile güvenli bir kanalda karşılaştırın."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "compara estas impressões com %@ num canal seguro."
           }
         }
       }
@@ -13829,6 +14537,12 @@
             "state": "translated",
             "value": "onların parmak izi:"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "impressão digital desta pessoa:"
+          }
         }
       }
     },
@@ -13941,6 +14655,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "güvenlik doğrulaması"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificação de segurança"
           }
         }
       }
@@ -14055,6 +14775,12 @@
             "state": "translated",
             "value": "sizin parmak iziniz:"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a tua impressão digital:"
+          }
         }
       }
     },
@@ -14167,6 +14893,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "engelle"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloquear"
           }
         }
       }
@@ -14281,6 +15013,12 @@
             "state": "translated",
             "value": "engeli kaldır"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desbloquear"
+          }
         }
       }
     },
@@ -14393,6 +15131,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "yakında kimse yok..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ninguém por perto..."
           }
         }
       }
@@ -14507,6 +15251,12 @@
             "state": "translated",
             "value": "geohash'te engellendi"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloqueado em geohash"
+          }
         }
       }
     },
@@ -14619,6 +15369,12 @@
           "stringUnit": {
             "state": "translated",
             "value": " (sen)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (tu)"
           }
         }
       }
@@ -14733,6 +15489,12 @@
             "state": "translated",
             "value": "ayarları aç"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abrir definições"
+          }
         }
       }
     },
@@ -14845,6 +15607,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konum erişimini kaldır"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remover acesso à localização"
           }
         }
       }
@@ -14959,6 +15727,12 @@
             "state": "translated",
             "value": "konum izni ve geohash'lerimi al"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "obter permissões de localização e os meus geohash"
+          }
         }
       }
     },
@@ -15071,6 +15845,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ışınlan"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teletransportar"
           }
         }
       }
@@ -15185,6 +15965,12 @@
             "state": "translated",
             "value": "yer imleri"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "marcados"
+          }
         }
       }
     },
@@ -15297,6 +16083,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "geohash kanallarıyla yakınınızdaki insanlarla sohbet edin. yalnızca kaba bir geohash paylaşılır, tam GPS asla değil. IP adresiniz tüm trafik Tor üzerinden yönlendirilerek gizlenir."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conversa com pessoas perto de ti usando canais geohash. apenas um geohash de baixa precisão é partilhado, nunca GPS exato. o teu IP fica oculto ao encaminhar todo o tráfego através do Tor."
           }
         }
       }
@@ -15411,6 +16203,12 @@
             "state": "translated",
             "value": "geçersiz geohash"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash inválido"
+          }
         }
       }
     },
@@ -15524,6 +16322,12 @@
             "state": "translated",
             "value": "yakındaki kanallar aranıyor…"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a procurar canais próximos…"
+          }
         }
       }
     },
@@ -15633,6 +16437,12 @@
           }
         },
         "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "pt": {
           "stringUnit": {
             "state": "translated",
             "value": "mesh"
@@ -15749,6 +16559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konum izni reddedildi. konum kanallarını kullanmak için ayarlardan etkinleştirin."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "permissão de localização negada. ativa nas definições para usar canais de localização."
           }
         }
       }
@@ -16247,6 +17063,12 @@
             "state": "translated",
             "value": "%1$@ [%2$#@people_count@]"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
         }
       }
     },
@@ -16356,6 +17178,12 @@
           }
         },
         "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "pt": {
           "stringUnit": {
             "state": "translated",
             "value": "#%1$@ • %2$@"
@@ -16473,6 +17301,12 @@
             "state": "translated",
             "value": "%1$@ • %2$@"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
         }
       }
     },
@@ -16585,6 +17419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#konum kanalları"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#canais de localização"
           }
         }
       }
@@ -16699,6 +17539,12 @@
             "state": "translated",
             "value": "konum kanalları için IP'nizi gizler. önerilen: açık."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "oculta o teu IP para canais de localização. recomendado: ligado."
+          }
         }
       }
     },
@@ -16811,6 +17657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor yönlendirmesi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "encaminhamento Tor"
           }
         }
       }
@@ -16925,6 +17777,12 @@
             "state": "translated",
             "value": "blok"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloco"
+          }
         }
       }
     },
@@ -17037,6 +17895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bina"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "edifício"
           }
         }
       }
@@ -17151,6 +18015,12 @@
             "state": "translated",
             "value": "şehir"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cidade"
+          }
         }
       }
     },
@@ -17263,6 +18133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "mahalle"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bairro"
           }
         }
       }
@@ -17377,6 +18253,12 @@
             "state": "translated",
             "value": "il"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "província"
+          }
         }
       }
     },
@@ -17489,6 +18371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bölge"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "região"
           }
         }
       }
@@ -17603,6 +18491,12 @@
             "state": "translated",
             "value": "kapat"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fechar"
+          }
         }
       }
     },
@@ -17715,6 +18609,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "yeniden dene"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tentar novamente"
           }
         }
       }
@@ -17829,6 +18729,12 @@
             "state": "translated",
             "value": "bu konuma gelen diğer ziyaretçilerin bulması için kısa kalıcı notlar ekleyin."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "adiciona pequenas notas permanentes a este local para outros visitantes encontrarem."
+          }
         }
       }
     },
@@ -17941,6 +18847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bu yer için ilk notu sen ekle."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sê o primeiro a adicionar uma nota para este sítio."
           }
         }
       }
@@ -18055,6 +18967,12 @@
             "state": "translated",
             "value": "henüz not yok"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ainda sem notas"
+          }
         }
       }
     },
@@ -18168,6 +19086,12 @@
             "state": "translated",
             "value": "not gönderilemedi. %@"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "falha ao enviar a nota. %@"
+          }
         }
       }
     },
@@ -18280,6 +19204,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bu konuma yakın geo röle yok. birazdan yeniden deneyin."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem relés geográficos disponíveis perto deste local. tenta novamente em breve."
           }
         }
       }
@@ -18778,6 +19708,12 @@
             "state": "translated",
             "value": "#%1$@ • %2$#@note_count@"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
         }
       }
     },
@@ -18890,6 +19826,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "notlar yükleniyor…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a carregar notas…"
           }
         }
       }
@@ -19004,6 +19946,12 @@
             "state": "translated",
             "value": "son notlar yükleniyor…"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a carregar notas recentes…"
+          }
         }
       }
     },
@@ -19116,6 +20064,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "yakında geo röle yok"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sem relés geográficos por perto"
           }
         }
       }
@@ -19230,6 +20184,12 @@
             "state": "translated",
             "value": "bu yer için bir not ekleyin"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "adiciona uma nota para este local"
+          }
         }
       }
     },
@@ -19342,6 +20302,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "geo röleler kullanılamıyor; notlar durduruldu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "relés geográficos indisponíveis; notas em pausa"
           }
         }
       }
@@ -19456,6 +20422,12 @@
             "state": "translated",
             "value": "notlar geo rölelere bağlıdır. bağlantıyı kontrol edip tekrar deneyin."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "as notas dependem de relés geográficos. verifica a ligação e tenta de novo."
+          }
         }
       }
     },
@@ -19568,6 +20540,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "yeni mesajlar"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "novas mensagens"
           }
         }
       }
@@ -19682,6 +20660,12 @@
             "state": "translated",
             "value": "%@ ile sohbet başlatılamıyor: kişi engelli."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível iniciar o chat com %@: a pessoa está bloqueada."
+          }
         }
       }
     },
@@ -19794,6 +20778,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ ile sohbet başlatılamıyor: çevrimdışı mesajlaşma için karşılıklı favori gerekiyor."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível iniciar o chat com %@: precisam de ser favoritos mútuos para mensagens offline."
           }
         }
       }
@@ -19908,6 +20898,12 @@
             "state": "translated",
             "value": "kullanıcı"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "utilizador"
+          }
         }
       }
     },
@@ -20020,6 +21016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "mesaj gönderilemiyor: kişi engelli."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível enviar mensagem: a pessoa está bloqueada."
           }
         }
       }
@@ -20134,6 +21136,12 @@
             "state": "translated",
             "value": "%@'a mesaj gönderilemiyor: kişi engelli."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível enviar mensagem a %@: a pessoa está bloqueada."
+          }
         }
       }
     },
@@ -20246,6 +21254,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@'a mesaj gönderilemiyor - eş mesh veya Nostr üzerinden ulaşılamıyor."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não é possível enviar mensagem a %@ - o par não está acessível por mesh ou Nostr."
           }
         }
       }
@@ -20360,6 +21374,12 @@
             "state": "translated",
             "value": "geohash sohbetlerinde %@ engellendi"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bloqueado nos chats geohash"
+          }
         }
       }
     },
@@ -20472,6 +21492,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "geohash sohbetlerinde %@ engeli kaldırıldı"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ desbloqueado nos chats geohash"
           }
         }
       }
@@ -20586,6 +21612,12 @@
             "state": "translated",
             "value": "gönderilemiyor: konum kanalında değilsiniz"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não foi possível enviar: não estás num canal de localização"
+          }
         }
       }
     },
@@ -20698,6 +21730,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "konum kanalına gönderme başarısız"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "falha ao enviar para o canal de localização"
           }
         }
       }
@@ -20812,6 +21850,12 @@
             "state": "translated",
             "value": "geliştirme yapısı: Tor atlatması etkin."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "compilação de desenvolvimento: bypass do Tor ativo."
+          }
         }
       }
     },
@@ -20924,6 +21968,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor yeniden başlatıldı. ağ yönlendirmesi geri geldi."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Tor foi reiniciado. O encaminhamento de rede foi restaurado."
           }
         }
       }
@@ -21038,6 +22088,12 @@
             "state": "translated",
             "value": "Tor bağlantıyı kurtarmak için yeniden başlatılıyor..."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Tor está a reiniciar para recuperar a conectividade..."
+          }
         }
       }
     },
@@ -21150,6 +22206,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor başlatıldı. IP gizliliği için tüm sohbetler Tor üzerinden yönlendiriliyor."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Tor foi iniciado. Todas as conversas são encaminhadas via Tor para ocultar o IP."
           }
         }
       }
@@ -21264,6 +22326,12 @@
             "state": "translated",
             "value": "Tor başlatılıyor..."
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Tor está a iniciar..."
+          }
         }
       }
     },
@@ -21376,6 +22444,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "doğrulama QR kodu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "código QR de verificação"
           }
         }
       }
@@ -21490,6 +22564,12 @@
             "state": "translated",
             "value": "beni doğrulamak için tara"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digitaliza para me verificares"
+          }
         }
       }
     },
@@ -21602,6 +22682,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "QR mevcut değil"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR indisponível"
           }
         }
       }
@@ -21716,6 +22802,12 @@
             "state": "translated",
             "value": "doğrulamak için QR içeriğini yapıştırın:"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cola o conteúdo do QR para validar:"
+          }
         }
       }
     },
@@ -21828,6 +22920,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bir arkadaşının QR'ını tara"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Digitaliza o QR de um amigo"
           }
         }
       }
@@ -21942,6 +23040,12 @@
             "state": "translated",
             "value": "geçersiz veya süresi dolmuş QR yükü"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "payload de QR inválido ou expirado"
+          }
         }
       }
     },
@@ -22054,6 +23158,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "eş bulunamadı"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "não foi possível encontrar o par correspondente"
           }
         }
       }
@@ -22168,6 +23278,12 @@
             "state": "translated",
             "value": "%@ için doğrulama istendi"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificação solicitada para %@"
+          }
         }
       }
     },
@@ -22280,6 +23396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "doğrula"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "validar"
           }
         }
       }
@@ -22394,6 +23516,12 @@
             "state": "translated",
             "value": "DOĞRULA"
           }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VERIFICAR"
+          }
         }
       }
     },
@@ -22505,6 +23633,12 @@
           }
         },
         "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "pt": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -117,6 +117,66 @@
             "state": "translated",
             "value": "bitchat"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
         }
       }
     },
@@ -235,6 +295,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "fechar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đóng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "isara"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tutup"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zamknij"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sluiten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மூடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stäng"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند کریں"
           }
         }
       }
@@ -355,6 +475,66 @@
             "state": "translated",
             "value": "CONCLUÍDO"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เสร็จสิ้น"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XONG"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TAPOS"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SELESAI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GOTOWE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KLAAR"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "முடிந்தது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KLART"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مکمل"
+          }
         }
       }
     },
@@ -473,6 +653,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "mensagens privadas encriptadas com o protocolo Noise"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私密訊息使用 noise 協議加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อความส่วนตัวถูกเข้ารหัสด้วยโปรโตคอล Noise"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tin nhắn riêng tư được mã hóa bằng giao thức Noise"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ang mga pribadong mensahe ay ini-encrypt gamit ang Noise protocol"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pesan pribadi dienkripsi dengan protokol noise"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "prywatne wiadomości są szyfrowane protokołem Noise"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "privéberichten worden versleuteld met het Noise-protocol"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தனிப்பட்ட செய்திகள் Noise நெறிமுறையால் குறியாக்கம் செய்யப்படுகின்றன"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "privata meddelanden krypteras med Noise-protokollet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نجی پیغامات Noise پروٹوکول سے خفیہ کیے جاتے ہیں"
           }
         }
       }
@@ -593,6 +833,66 @@
             "state": "translated",
             "value": "encriptação ponta a ponta"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端到端加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเข้ารหัสปลายทางถึงปลายทาง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mã hóa đầu cuối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "end-to-end na pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enkripsi ujung ke ujung"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "szyfrowanie end-to-end"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "end-to-end-versleuteling"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "முற்றிலும் குறியாக்கம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ända-till-ände-kryptering"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اینڈ ٹو اینڈ انکرپشن"
+          }
         }
       }
     },
@@ -711,6 +1011,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "mensagens retransmitidas entre pares para chegar mais longe"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "訊息透過同伴中繼，傳得更遠"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อความส่งต่อผ่านเพียร์เพื่อไปได้ไกลขึ้น"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tin nhắn được chuyển tiếp qua các nút ngang hàng để đi xa hơn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ipinapasa ang mga mensahe sa mga peer para makarating sa malalayo"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pesan diteruskan antar peer sehingga jangkauannya lebih jauh"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wiadomości są przekazywane przez peerów, aby dotrzeć dalej"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "berichten worden via peers doorgestuurd om verder te reiken"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "செய்திகள் துணை இணைப்புகளின் மூலம் பரிமாறி தூரம் சென்றடைகின்றன"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "meddelanden vidarebefordras via peers för att nå längre"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیغامات ہم منصبوں کے ذریعے آگے بڑھا کر دور تک پہنچتے ہیں"
           }
         }
       }
@@ -831,6 +1191,66 @@
             "state": "translated",
             "value": "alcance alargado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擴展範圍"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ระยะสื่อสารที่กว้างขึ้น"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "phạm vi mở rộng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mas malawak na saklaw"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jangkauan diperluas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "większy zasięg"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "groter bereik"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "விரிந்த வரம்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "utökat räckvidd"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وسیع دائرہ"
+          }
         }
       }
     },
@@ -949,6 +1369,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "recebe notificações quando as tuas pessoas favoritas entram"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你喜歡的人加入時立刻提醒"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รับการแจ้งเตือนเมื่อคนโปรดของคุณเข้าร่วม"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhận thông báo khi những người yêu thích của bạn tham gia"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tumanggap ng abiso kapag sumali ang paborito mong mga tao"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dapatkan notifikasi saat orang favoritmu bergabung"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "otrzymuj powiadomienia, gdy dołączają twoje ulubione osoby"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ontvang meldingen wanneer je favoriete mensen meedoen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்களுக்குப் பிரியமானவர்கள் சேர்ந்தவுடன் அறிவிப்பு பெறுங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "få aviseringar när dina favoriter ansluter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جب آپ کے پسندیدہ لوگ شامل ہوں تو اطلاع پائیں"
           }
         }
       }
@@ -1069,6 +1549,66 @@
             "state": "translated",
             "value": "favoritos"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ulubione"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorieten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சிறப்புப் பட்டியல்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favoriter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ"
+          }
         }
       }
     },
@@ -1187,6 +1727,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "canais geohash para conversar com pessoas em regiões próximas através de relés descentralizados anónimos"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash 頻道讓你透過去中心化匿名中繼與附近地區的人聊天"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่อง geohash สำหรับพูดคุยกับคนในพื้นที่ใกล้เคียงผ่านรีเลย์แบบกระจายศูนย์และไม่ระบุตัว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "các kênh geohash để trò chuyện với mọi người ở vùng lân cận thông qua các relay ẩn danh phi tập trung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga geohash channel para makipag-chat sa mga tao sa karatig na lugar sa pamamagitan ng mga desentralisado at anonimong relay"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanal geohash untuk ngobrol dengan orang di wilayah sekitar lewat relay anonim terdesentralisasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanały geohash do rozmów z osobami w pobliżu przez zdecentralizowane, anonimowe przekaźniki"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash-kanalen om te chatten met mensen in de buurt via gedecentraliseerde, anonieme relais"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மையமற்ற மறை நெட்வொர்க் ரிலேக்கள் மூலம் அருகிலுள்ள பகுதிகளில் உள்ளவர்களுடன் பேச geohash சேனல்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash-kanaler för att chatta med folk i närheten via decentraliserade, anonyma reläer"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر مرکزی گمنام ریلوں کے ذریعے قریب کے لوگوں سے بات کرنے کیلئے geohash چینلز"
           }
         }
       }
@@ -1307,6 +1907,66 @@
             "state": "translated",
             "value": "canais locais"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地頻道"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่องท้องถิ่น"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kênh địa phương"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga lokal na channel"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanal lokal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanały lokalne"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lokale kanalen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உள்ளூர் சேனல்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lokala kanaler"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مقامی چینلز"
+          }
         }
       }
     },
@@ -1425,6 +2085,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "usa @nickname para avisar pessoas específicas"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 @nickname 提醒特定的人"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้ @nickname เพื่อแจ้งเตือนบุคคลเฉพาะ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dùng @nickname để thông báo cho người cụ thể"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gumamit ng @nickname para abisuhan ang partikular na tao"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "guna @nickname untuk memberi tahu orang tertentu"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "użyj @nickname, aby powiadomić konkretną osobę"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gebruik @nickname om een specifiek persoon te pingen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறிப்பிட்டவரை அறிவிக்க @nickname பயன்படுத்துங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "använd @nickname för att meddela en specifik person"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کسی مخصوص شخص کو خبردار کرنے کیلئے @nickname استعمال کریں"
           }
         }
       }
@@ -1545,6 +2265,66 @@
             "state": "translated",
             "value": "menções"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提及"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การกล่าวถึง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhắc tới"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga banggit"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mention"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wzmianki"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vermeldingen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மேற்கோள்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "omnämnanden"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذکر"
+          }
         }
       }
     },
@@ -1663,6 +2443,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "funciona sem internet usando Bluetooth de baixo consumo"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用低功耗 bluetooth 離線工作"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทำงานได้แม้ไม่มีอินเทอร์เน็ตด้วย Bluetooth พลังงานต่ำ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hoạt động không cần internet bằng Bluetooth năng lượng thấp"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gumagana kahit walang internet gamit ang Bluetooth Low Energy"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "berfungsi tanpa internet menggunakan bluetooth low energy"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "działa bez internetu dzięki Bluetooth Low Energy"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "werkt zonder internet met Bluetooth Low Energy"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth குறைந்த மின்சாரத்தைப் பயன்படுத்தி இணையமின்றி இயங்குகிறது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fungerar utan internet med Bluetooth Low Energy"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth Low Energy کے ساتھ بغیر انٹرنیٹ کے کام کرتا ہے"
           }
         }
       }
@@ -1783,6 +2623,66 @@
             "state": "translated",
             "value": "comunicação offline"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "離線通信"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การสื่อสารออฟไลน์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "liên lạc ngoại tuyến"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "offline na komunikasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "komunikasi offline"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "komunikacja offline"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "offline communicatie"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஆஃப்லைன் தொடர்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "offlinekommunikation"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آف لائن مواصلات"
+          }
         }
       }
     },
@@ -1901,6 +2801,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "FUNCIONALIDADES"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "功能"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฟีเจอร์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TÍNH NĂNG"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MGA TAMPOK"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FITUR"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FUNKCJE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FUNCTIES"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அம்சங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FUNKTIONER"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خصوصیات"
           }
         }
       }
@@ -2021,6 +2981,66 @@
             "state": "translated",
             "value": "• toca em #mesh para mudar de canal"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 輕點 #mesh 切換頻道"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• แตะ #mesh เพื่อเปลี่ยนช่อง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• chạm #mesh để đổi kênh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• i-tap ang #mesh para magpalit ng channel"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ketuk #mesh untuk ganti kanal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• stuknij #mesh, aby zmienić kanał"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tik op #mesh om van kanaal te wisselen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• சேனலை மாற்ற #mesh ஐத் தட்டவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tryck på #mesh för att byta kanal"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• چینل بدلنے کیلئے #mesh پر ٹیپ کریں"
+          }
         }
       }
     },
@@ -2139,6 +3159,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "• toca três vezes no chat para o limpar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 三擊聊天即可清除"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• แตะหน้าจอแชทสามครั้งเพื่อล้างข้อความ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• chạm ba lần vào khung chat để xóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• i-triple tap ang chat para linisin"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ketuk chat tiga kali untuk menghapus"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• stuknij okno czatu trzykrotnie, aby wyczyścić"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tik drie keer op de chat om te wissen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• உரையாடலை அழிக்க மூன்று முறை தட்டுங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tryck tre gånger i chatten för att rensa"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• چیٹ صاف کرنے کیلئے تین بار ٹیپ کریں"
           }
         }
       }
@@ -2259,6 +3339,66 @@
             "state": "translated",
             "value": "• escreve / para ver os comandos"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 輸入 / 查看指令"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• พิมพ์ / เพื่อแสดงคำสั่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• gõ / để xem lệnh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• mag-type ng / para sa mga utos"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ketik / untuk melihat perintah"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• wpisz /, aby zobaczyć polecenia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• typ / voor opdrachten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• கட்டளைகளை காண / என்பதைத் தட்டச்சுங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• skriv / för kommandon"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• کمانڈز کیلئے / ٹائپ کریں"
+          }
         }
       }
     },
@@ -2377,6 +3517,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "• toca no ícone das pessoas para abrir a barra lateral"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 輕點人物圖示打開側欄"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• แตะไอคอนคนเพื่อเปิดแถบด้านข้าง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• chạm biểu tượng người để mở thanh bên"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• i-tap ang icon ng tao para buksan ang sidebar"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ketuk ikon orang untuk membuka sidebar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• stuknij ikonę osób, aby otworzyć panel boczny"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tik op het personen-icoon om de zijbalk te openen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• பக்கப்பட்டியைத் திறக்க மனிதர் சின்னத்தைத் தட்டுங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tryck på personikonen för att öppna sidomenyn"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• سائیڈ بار کھولنے کیلئے لوگوں کا آئیکن ٹیپ کریں"
           }
         }
       }
@@ -2497,6 +3697,66 @@
             "state": "translated",
             "value": "• define o teu apelido tocando nele"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 輕點暱稱即可設定"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ตั้งชื่อเล่นโดยแตะที่ชื่อของคุณ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• đặt biệt danh bằng cách chạm vào tên bạn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• itakda ang iyong palayaw sa pag-tap dito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• atur nama panggilanmu dengan mengetuknya"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ustaw swój pseudonim, stukając go"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• stel je bijnaam in door erop te tikken"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• உங்கள் புனைப் பெயரைத் தட்டிக் கொண்டு அமைக்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ställ in ditt smeknamn genom att trycka på det"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• اپنا نک نیم سیٹ کرنے کیلئے اس پر ٹیپ کریں"
+          }
         }
       }
     },
@@ -2615,6 +3875,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "• toca no nome de um par para iniciar um DM"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 輕點同伴名字開始 dm"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• แตะชื่อเพียร์เพื่อเริ่ม DM"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• chạm tên một nút ngang hàng để mở DM"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• i-tap ang pangalan ng peer para magsimula ng DM"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ketuk nama peer untuk mulai dm"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• stuknij nazwę peera, aby rozpocząć DM"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tik op de naam van een peer om een DM te starten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• peer பெயரைத் தட்டி DM தொடங்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• tryck på en peers namn för att starta ett DM"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• DM شروع کرنے کیلئے کسی ہم منصب کے نام پر ٹیپ کریں"
           }
         }
       }
@@ -2735,6 +4055,66 @@
             "state": "translated",
             "value": "COMO USAR"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用方法"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วิธีใช้งาน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CÁCH SỬ DỤNG"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PAANO GAMITIN"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CARA PAKAI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JAK UŻYWAĆ"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GEBRUIKSAANWIJZING"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பயன்படுத்துவது எப்படி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SÅ HÄR ANVÄNDER DU"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استعمال کرنے کا طریقہ"
+          }
         }
       }
     },
@@ -2853,6 +4233,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "novo ID de par gerado regularmente"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定期生成新的 peer id"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สร้างรหัสเพียร์ใหม่เป็นระยะ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tạo ID nút mới định kỳ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "regular na lumilikha ng bagong peer ID"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "id peer baru dibuat secara berkala"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nowe ID peera generowane regularnie"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieuw peer-ID wordt regelmatig aangemaakt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "புதிய peer ID வழக்கமாக உருவாக்கப்படுகிறது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nytt peer-ID skapas regelbundet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نیا peer ID باقاعدگی سے بنایا جاتا ہے"
           }
         }
       }
@@ -2973,6 +4413,66 @@
             "state": "translated",
             "value": "identidade efémera"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "臨時身份"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวตนชั่วคราว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "danh tính tạm thời"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "panandaliang pagkakakilanlan"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "identitas sementara"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tymczasowa tożsamość"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tijdelijke identiteit"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தற்காலிக அடையாளம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tillfällig identitet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عارضی شناخت"
+          }
         }
       }
     },
@@ -3091,6 +4591,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "sem servidores, contas ou recolha de dados"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無伺服器、無帳號、無數據收集"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีเซิร์ฟเวอร์ บัญชี หรือการเก็บข้อมูล"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không máy chủ, không tài khoản, không thu thập dữ liệu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang mga server, account, o pagkuha ng data"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tanpa server, akun, atau pengumpulan data"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bez serwerów, kont ani zbierania danych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geen servers, accounts of dataverzameling"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சர்வர்கள் இல்லை, கணக்குகள் இல்லை, தரவுச் சேகரிப்பு இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inga servrar, konton eller datainsamling"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوئی سرور، اکاؤنٹس یا ڈیٹا جمع نہیں کیا جاتا"
           }
         }
       }
@@ -3211,6 +4771,66 @@
             "state": "translated",
             "value": "sem rastreio"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無跟蹤"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีการติดตาม"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không theo dõi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang pagsubaybay"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tanpa pelacakan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak śledzenia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geen tracking"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பின்தொடர்வு இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ingen spårning"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹریسنگ نہیں"
+          }
         }
       }
     },
@@ -3329,6 +4949,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "toca três vezes no logótipo para limpar todos os dados de imediato"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "三擊標誌立即清除全部數據"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะโลโก้สามครั้งเพื่อลบข้อมูลทั้งหมดทันที"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chạm logo ba lần để xóa toàn bộ dữ liệu ngay lập tức"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-tap ang logo nang tatlong beses para agad burahin ang lahat ng data"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ketuk logo tiga kali untuk langsung menghapus semua data"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuknij logo trzy razy, aby natychmiast usunąć wszystkie dane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tik drie keer op het logo om alle data direct te wissen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "எல்லா தரவையும் உடனடியாக நீக்க லோகோவை மூன்று முறைத் தட்டுங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tryck tre gånger på logotypen för att radera all data direkt"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام ڈیٹا فوری صاف کرنے کیلئے لوگو پر تین بار ٹیپ کریں"
           }
         }
       }
@@ -3449,6 +5129,66 @@
             "state": "translated",
             "value": "modo pânico"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "緊急模式"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหมดฉุกเฉิน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chế độ khẩn cấp"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "panic mode"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mode panik"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tryb paniki"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "paniekmodus"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பதற்ற நிலை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "panikläge"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پینک موڈ"
+          }
         }
       }
     },
@@ -3568,6 +5308,66 @@
             "state": "translated",
             "value": "PRIVACIDADE"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱私"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความเป็นส่วนตัว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QUYỀN RIÊNG TƯ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRIBASYA"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRIVASI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRYWATNOŚĆ"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRIVACY"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தனியுரிமை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRIVAT"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رازداری"
+          }
         }
       }
     },
@@ -3683,6 +5483,66 @@
           }
         },
         "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "ur": {
           "stringUnit": {
             "state": "translated",
             "value": "sidegroupchat"
@@ -3806,6 +5666,66 @@
             "state": "translated",
             "value": "a segurança das mensagens privadas ainda não foi totalmente auditada. não uses em situações críticas até este aviso desaparecer."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私信安全尚未完全審計。在此警告消失前不要用於關鍵情境。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความปลอดภัยของข้อความส่วนตัวยังไม่ได้รับการตรวจสอบทั้งหมด อย่าใช้ในสถานการณ์วิกฤติจนกว่าคำเตือนนี้จะหายไป"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bảo mật tin nhắn riêng tư vẫn chưa được kiểm toán đầy đủ. đừng dùng cho tình huống quan trọng cho tới khi cảnh báo này biến mất."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi pa ganap na na-audit ang seguridad ng pribadong mensahe. huwag gamitin para sa kritikal na sitwasyon hangga't hindi nawawala ang babalang ito."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "keamanan pesan pribadi belum diaudit sepenuhnya. jangan diguna untuk situasi kritis sampai peringatan ini hilang."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bezpieczeństwo wiadomości prywatnych nie zostało jeszcze w pełni sprawdzone. nie używaj w sytuacjach krytycznych, dopóki to ostrzeżenie nie zniknie."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "de beveiliging van privéberichten is nog niet volledig geaudit. gebruik dit niet in kritieke situaties totdat deze melding verdwijnt."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தனிப்பட்ட செய்தி பாதுகாப்பு இன்னும் முழுமையாக ஆய்வு செய்யப்படவில்லை. இந்த எச்சரிக்கை மறையும் வரை முக்கிய அவசரங்களுக்கு பயன்படுத்தாதீர்கள்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "säkerheten för privata meddelanden är ännu inte fullständigt granskad. använd inte i kritiska situationer förrän detta meddelande försvinner."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نجی پیغامات کی سیکیورٹی کا ابھی مکمل آڈٹ نہیں ہوا۔ اس انتباہ کے ختم ہونے تک اسے اہم حالات میں استعمال نہ کریں۔"
+          }
         }
       }
     },
@@ -3924,6 +5844,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "AVISO"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คำเตือน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CẢNH BÁO"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BABALA"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PERINGATAN"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OSTRZEŻENIE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WAARSCHUWING"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "எச்சரிக்கை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VARNING"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتباہ"
           }
         }
       }
@@ -4044,6 +6024,66 @@
             "state": "translated",
             "value": "cancelar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยกเลิก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hủy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanselahin"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "batal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "anuluj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "annuleren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ரத்து"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "avbryt"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منسوخ کریں"
+          }
         }
       }
     },
@@ -4162,6 +6202,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "fechar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đóng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "isara"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tutup"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zamknij"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sluiten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மூடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stäng"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند کریں"
           }
         }
       }
@@ -4282,6 +6382,66 @@
             "state": "translated",
             "value": "copiar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sao chép"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopyahin"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "salin"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiëren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நகலெடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقل کریں"
+          }
         }
       }
     },
@@ -4400,6 +6560,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "OK"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確定"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตกลง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ĐỒNG Ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹھیک"
           }
         }
       }
@@ -4520,6 +6740,66 @@
             "state": "translated",
             "value": "desligado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "patay"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mati"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wył."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uit"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஆஃப்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "av"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند"
+          }
         }
       }
     },
@@ -4638,6 +6918,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "ligado"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bukas"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nyala"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wł."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aan"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஆன்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "på"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چالو"
           }
         }
       }
@@ -4758,6 +7098,66 @@
             "state": "translated",
             "value": "desconhecido"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่ทราบ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không rõ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi alam"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak diketahui"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieznane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onbekend"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அறியவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "okänt"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نامعلوم"
+          }
         }
       }
     },
@@ -4876,6 +7276,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "adicionar aos favoritos"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เพิ่มในรายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thêm vào mục yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "idagdag sa mga paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tambah ke favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dodaj do ulubionych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aan favorieten toevoegen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிரியப்பட்டதில் சேர்க்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lägg till i favoriter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ میں شامل کریں"
           }
         }
       }
@@ -4996,6 +7456,66 @@
             "state": "translated",
             "value": "disponível através do Nostr"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過 Nostr 可用"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้งานได้ผ่าน Nostr"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "có sẵn qua Nostr"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magagamit sa Nostr"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tersedia melalui nostr"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dostępne przez Nostr"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beschikbaar via Nostr"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr வழியாக கிடைக்கிறது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tillgänglig via Nostr"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr کے ذریعے دستیاب"
+          }
         }
       }
     },
@@ -5114,6 +7634,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "voltar ao chat principal"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回主聊天"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กลับไปยังห้องแชทหลัก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "quay lại phòng chat chính"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bumalik sa pangunahing chat"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kembali ke chat utama"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wróć do głównego czatu"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terug naar hoofdchat"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "முதன்மை உரையாடலுக்கு திரும்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tillbaka till huvudchatten"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرکزی چیٹ پر واپس جائیں"
           }
         }
       }
@@ -5234,6 +7814,66 @@
             "state": "translated",
             "value": "ligado por mesh"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過 mesh 已連線"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อผ่านเครือข่าย mesh"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang kết nối qua mesh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nakakonekta sa pamamagitan ng mesh"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terhubung lewat mesh"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "połączono przez mesh"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verbonden via mesh"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh மூலம் இணைக்கப்பட்டுள்ளது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ansluten via mesh"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh کے ذریعے جڑا ہوا"
+          }
         }
       }
     },
@@ -5352,6 +7992,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "estado da encriptação: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加密狀態：%@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สถานะการเข้ารหัส: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trạng thái mã hóa: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "estado ng pag-encrypt: %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "status enkripsi: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stan szyfrowania: %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleutelingsstatus: %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்க நிலை: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "krypteringsstatus: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن کی حالت: %@"
           }
         }
       }
@@ -5472,6 +8172,66 @@
             "state": "translated",
             "value": "canais de localização"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置頻道"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่องตามตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kênh theo vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga channel batay sa lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanal lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanały lokalizacyjne"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "locatiekanalen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட சேனல்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "platskanaler"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن چینلز"
+          }
         }
       }
     },
@@ -5591,6 +8351,66 @@
             "state": "translated",
             "value": "notas de localização deste lugar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此位置的筆記"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกตำแหน่งสำหรับสถานที่นี้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ghi chú vị trí cho nơi này"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga tala para sa lugar na ito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "catatan lokasi untuk tempat ini"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notatki lokalizacyjne dla tego miejsca"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "locatienotities voor deze plek"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த இடத்திற்கான குறிப்புகள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "platsanteckningar för den här platsen"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اس جگہ کیلئے لوکیشن نوٹس"
+          }
         }
       }
     },
@@ -5709,6 +8529,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "abrir chat privado não lido"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開未讀私聊"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดแชทส่วนตัวที่ยังไม่ได้อ่าน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mở chat riêng chưa đọc"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buksan ang hindi pa nababasang pribadong chat"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buka chat pribadi belum dibaca"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "otwórz nieprzeczytany czat prywatny"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ongelezen privéchat openen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "படிக்காத தனியுரையாடலைத் திறக்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "öppna oläst privat chatt"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نہ پڑھی گئی نجی چیٹ کھولیں"
           }
         }
       }
@@ -6213,6 +9093,66 @@
             "state": "translated",
             "value": "%#@people@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
         }
       }
     },
@@ -6331,6 +9271,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "chat privado com %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與 %@ 的私聊"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แชทส่วนตัวกับ %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chat riêng với %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pribadong chat kasama si %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chat pribadi dengan %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "czat prywatny z %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "privéchat met %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ உடன் தனியுரையாடல்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "privat chatt med %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کے ساتھ نجی چیٹ"
           }
         }
       }
@@ -6451,6 +9451,66 @@
             "state": "translated",
             "value": "acessível por mesh"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可透過 mesh 到達"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ติดต่อได้ผ่าน mesh"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "liên hệ được qua mesh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "maabot sa pamamagitan ng mesh"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dapat dijangkau lewat mesh"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "osiągalny przez mesh"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bereikbaar via mesh"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh மூலம் அணுகலாம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nåbar via mesh"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh کے ذریعے قابل رسائی"
+          }
         }
       }
     },
@@ -6569,6 +9629,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "remover dos favoritos"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移出收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "นำออกจากรายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xóa khỏi yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alisin sa mga paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hapus dari favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usuń z ulubionych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uit favorieten verwijderen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிரியப்பட்டதை நீக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ta bort från favoriter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ سے ہٹائیں"
           }
         }
       }
@@ -6689,6 +9809,66 @@
             "state": "translated",
             "value": "escreve uma mensagem para enviar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入要發送的訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ข้อความเพื่อส่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhập tin nhắn để gửi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mag-type ng mensahe para ipadala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "masukkan pesan untuk dihantar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wpisz wiadomość, aby wysłać"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "voer een bericht in om te sturen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அனுப்ப உரையை உள்ளிடவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skriv ett meddelande för att skicka"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بھیجنے کیلئے پیغام درج کریں"
+          }
         }
       }
     },
@@ -6807,6 +9987,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "toca duas vezes para enviar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雙擊發送"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะสองครั้งเพื่อส่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chạm hai lần để gửi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-double tap para magpadala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ketuk dua kali untuk menghantar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuknij dwukrotnie, aby wysłać"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dubbelklikken om te versturen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அனுப்ப இருமுறை தட்டவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dubbeltryck för att skicka"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بھیجنے کیلئے دو بار ٹیپ کریں"
           }
         }
       }
@@ -6927,6 +10167,66 @@
             "state": "translated",
             "value": "enviar mensagem"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發送訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งข้อความ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi tin nhắn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magpadala ng mensahe"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hantar pesan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyślij wiadomość"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bericht sturen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "செய்தி அனுப்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skicka meddelande"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیغام بھیجیں"
+          }
         }
       }
     },
@@ -7045,6 +10345,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "alternar o marcador de #%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切換 #%@ 的書簽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับบุ๊กมาร์กสำหรับ #%@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chuyển đánh dấu cho #%@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-toggle ang bookmark para sa #%@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ubah penanda untuk #%@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "przełącz zakładkę dla #%@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bladwijzer voor #%@ schakelen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ க்கான புக்மார்க் மாற்றவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "växla bokmärke för #%@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ کیلئے بُک مارک تبدیل کریں"
           }
         }
       }
@@ -7165,6 +10525,66 @@
             "state": "translated",
             "value": "toca duas vezes para alternar o estado de favorito"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雙擊切換收藏狀態"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะสองครั้งเพื่อสลับสถานะรายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chạm hai lần để chuyển trạng thái yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-double tap para i-toggle ang paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ketuk dua kali untuk mengubah status favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuknij dwukrotnie, aby zmienić stan ulubionych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dubbelklikken om favoriet te schakelen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிரியப்பட்ட நிலையை மாற்ற இருமுறை தட்டவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dubbeltryck för att växla favoritstatus"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ حالت بدلنے کیلئے دو بار ٹیپ کریں"
+          }
         }
       }
     },
@@ -7283,6 +10703,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "toca para ver a impressão de encriptação"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輕點查看加密指紋"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะเพื่อดูลายนิ้วมือการเข้ารหัส"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chạm để xem vân tay mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-tap para makita ang fingerprint ng pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ketuk untuk melihat sidik enkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuknij, by zobaczyć odcisk szyfrowania"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tik om de versleutelingsfingerprint te bekijken"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்க கைரேகையைப் பார்க்க தட்டவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tryck för att visa krypteringsfingeravtryck"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن فنگرپرنٹ دیکھنے کیلئے ٹیپ کریں"
           }
         }
       }
@@ -7403,6 +10883,66 @@
             "state": "translated",
             "value": "bloquear"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏蔽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chặn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-block"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zablokuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokkeren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தடுப்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blockera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بلاک کریں"
+          }
         }
       }
     },
@@ -7521,6 +11061,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "mensagem direta"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私信"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งข้อความส่วนตัว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhắn tin trực tiếp"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "diretsong mensahe"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pesan langsung"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wiadomość prywatna"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "direct bericht"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நேரடி செய்தி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "direktmeddelande"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "براہ راست پیغام"
           }
         }
       }
@@ -7641,6 +11241,66 @@
             "state": "translated",
             "value": "abraçar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擁抱"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กอด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ôm"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yakap"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peluk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "przytul"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "knuffel"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அடைகாக்க"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kram"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلے لگائیں"
+          }
         }
       }
     },
@@ -7759,6 +11419,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "mencionar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提及"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กล่าวถึง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhắc tới"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "banggitin"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sebut"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wspomnij"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vermelden"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மேற்கோள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nämn"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذکر کریں"
           }
         }
       }
@@ -7879,6 +11599,66 @@
             "state": "translated",
             "value": "dar uma chapada"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拍打"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตบ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tát"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sampal"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tampar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "spoliczkuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "meppen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அடி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ge en örfil"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چاپڑ"
+          }
         }
       }
     },
@@ -7997,6 +11777,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "ações"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การกระทำ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hành động"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga aksyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aksi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "akcje"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "acties"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "செயல்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "åtgärder"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کارروائیاں"
           }
         }
       }
@@ -8117,6 +11957,66 @@
             "state": "translated",
             "value": "O Bluetooth está desligado. Ativa o Bluetooth em Definições para usar o bitchat."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth 已關閉。請在設定中開啟以使用 bitchat。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด Bluetooth อยู่ กรุณาเปิดในตั้งค่าเพื่อใช้ bitchat"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth đang tắt. hãy bật trong cài đặt để dùng bitchat."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naka-off ang bluetooth. pakibuksan sa settings para magamit ang bitchat."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth dimatikan. Hidupkan Bluetooth dalam Tetapan untuk menggunakan bitchat."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth jest wyłączony. włącz bluetooth w ustawieniach, aby używać bitchat."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth staat uit. zet bluetooth aan in instellingen om bitchat te gebruiken."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth அணைக்கப்பட்டுள்ளது. bitchat பயன்படுத்த அமைப்பில் Bluetooth ஐ இயக்கவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth är avstängt. slå på bluetooth i inställningar för att använda bitchat."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth بند ہے۔ bitchat استعمال کرنے کیلئے سیٹنگز میں Bluetooth آن کریں۔"
+          }
         }
       }
     },
@@ -8235,6 +12135,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "O bitchat precisa de autorização de Bluetooth para se ligar a dispositivos próximos. Ativa o acesso em Definições."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat 需要 bluetooth 權限以連線至附近裝置。請在設定中啟用存取權限。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat ต้องการสิทธิ์ Bluetooth เพื่อเชื่อมต่อกับอุปกรณ์ใกล้เคียง กรุณาเปิดสิทธิ์ในตั้งค่า"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat cần quyền bluetooth để kết nối thiết bị gần. hãy bật quyền trong cài đặt."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kailangan ng bitchat ng pahintulot sa bluetooth upang kumonekta sa mga kalapit na device. pakiactivate sa settings."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat memerlukan kebenaran Bluetooth untuk disambungkan kepada peranti berhampiran. Benarkan capaian dalam Tetapan."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat potrzebuje uprawnień bluetooth, aby łączyć się z pobliskimi urządzeniami. włącz dostęp w ustawieniach."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat heeft bluetooth-toegang nodig om verbinding te maken met apparaten in de buurt. schakel dit in bij instellingen."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அருகிலுள்ள சாதனங்களை இணைக்க bitchat க்கு Bluetooth அனுமதி தேவை. அமைப்பில் அனுமதி வழங்கவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat behöver bluetooth-behörighet för att ansluta till enheter i närheten. aktivera åtkomst i inställningar."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قریب کے آلات سے جڑنے کیلئے bitchat کو Bluetooth اجازت درکار ہے۔ سیٹنگز میں رسائی فعال کریں۔"
           }
         }
       }
@@ -8355,6 +12315,66 @@
             "state": "translated",
             "value": "definições"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตั้งค่า"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "settings"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tetapan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ustawienia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instellingen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அமைப்புகள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inställningar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹنگز"
+          }
         }
       }
     },
@@ -8473,6 +12493,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bluetooth necessário"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要 bluetooth"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต้องใช้ Bluetooth"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cần bluetooth"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kailangan ng bluetooth"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth diperlukan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wymagany bluetooth"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth vereist"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth தேவையானது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bluetooth krävs"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth درکار ہے"
           }
         }
       }
@@ -8593,6 +12673,66 @@
             "state": "translated",
             "value": "Este dispositivo não suporta Bluetooth. O bitchat precisa de Bluetooth para funcionar."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此裝置不支持 bluetooth。bitchat 需要 bluetooth 才能運行。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อุปกรณ์นี้ไม่รองรับ Bluetooth การใช้งาน bitchat ต้องใช้ Bluetooth"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thiết bị này không hỗ trợ bluetooth. bitchat cần bluetooth để hoạt động."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi sinusuportahan ng device na ito ang bluetooth. kailangan ito ng bitchat para gumana."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peranti ini tidak menyokong Bluetooth. bitchat memerlukan Bluetooth untuk berfungsi."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "to urządzenie nie obsługuje bluetooth. bitchat wymaga bluetooth do działania."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dit apparaat ondersteunt geen bluetooth. bitchat heeft bluetooth nodig om te werken."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த சாதனம் Bluetooth ஐ ஆதரிக்காது. bitchat இயங்க Bluetooth தேவை."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "denna enhet stöder inte bluetooth. bitchat behöver bluetooth för att fungera."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہ ڈیوائس Bluetooth کو سپورٹ نہیں کرتی۔ bitchat کو چلنے کیلئے Bluetooth چاہیے۔"
+          }
         }
       }
     },
@@ -8711,6 +12851,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Capturas de ecrã dos canais de localização revelam a tua localização. Pensa antes de partilhar publicamente."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置頻道的截圖會暴露你的位置。公開分享前請三思。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การจับภาพหน้าจอช่องตำแหน่งจะเผยตำแหน่งของคุณ โปรดคิดก่อนแชร์สาธารณะ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ảnh chụp kênh vị trí sẽ lộ vị trí của bạn. hãy cân nhắc trước khi chia sẻ công khai."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ibinubunyag ng screenshot ng mga channel ng lokasyon ang iyong lokasyon. mag-isip bago magbahagi sa publiko."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tangkapan layar kanal lokasi akan mengungkap lokasimu. pikirkan dulu sebelum membagikannya."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zrzuty ekranu kanałów lokalizacyjnych ujawnią twoją lokalizację. przemyśl to przed publicznym udostępnieniem."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "screenshots van locatiekanalen geven je locatie prijs. denk na voor je publiek deelt."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட சேனல்களின் திரைப் படங்கள் உங்கள் இடத்தை வெளிப்படுத்தும். பொதுவாகப் பகிர்வதற்கு முன் சிந்தியுங்கள்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skärmbilder från platskanaler avslöjar din position. tänk efter innan du delar offentligt."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن چینلز کے اسکرین شاٹس آپ کی لوکیشن ظاہر کر دیں گے۔ عوامی طور پر شیئر کرنے سے پہلے سوچیں۔"
           }
         }
       }
@@ -8831,6 +13031,66 @@
             "state": "translated",
             "value": "atenção"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แจ้งเตือน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lưu ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "paalala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "perhatian"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uwaga"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "let op"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கவனம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "obs"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خبردار"
+          }
         }
       }
     },
@@ -8949,6 +13209,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "bloquear ou listar pares bloqueados"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏蔽或查看已屏蔽的同伴"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บล็อกหรือดูรายชื่อเพียร์ที่ถูกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chặn hoặc xem danh sách nút đã chặn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-block o tingnan ang listahan ng mga na-block na peer"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokir atau lihat peer yang diblokir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zablokuj albo pokaż listę zablokowanych peerów"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokkeer of toon lijst met geblokkeerde peers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தடை செய்யவும் அல்லது தடை செய்யப்பட்ட peer பட்டியலைப் பாருங்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blockera eller visa lista över blockerade peers"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer کو بلاک کریں یا فہرست دیکھیں"
           }
         }
       }
@@ -9069,6 +13389,66 @@
             "state": "translated",
             "value": "limpar mensagens do chat"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除聊天訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ล้างข้อความแชท"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xóa tin nhắn chat"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "burahin ang mga mensahe sa chat"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hapus pesan chat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyczyść wiadomości czatu"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "maak chatberichten leeg"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உரையாடல் செய்திகளை அழிக்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rensa chattmeddelanden"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چیٹ پیغامات صاف کریں"
+          }
         }
       }
     },
@@ -9187,6 +13567,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "adicionar aos favoritos"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เพิ่มในรายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thêm vào yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "idagdag sa mga paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tambah ke favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dodaj do ulubionych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aan favorieten toevoegen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிரியப்பட்டதில் சேர்க்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lägg till i favoriter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ میں شامل کریں"
           }
         }
       }
@@ -9307,6 +13747,66 @@
             "state": "translated",
             "value": "enviar um abraço caloroso"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送出溫暖擁抱"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งกอดอุ่น ๆ ให้ใครสักคน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi một cái ôm ấm áp"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magpadala ng mainit na yakap"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hantar pelukan hangat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyślij komuś ciepły uścisk"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuur iemand een warme knuffel"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஒருவருக்கு வெப்பமான அணைப்பை அனுப்பவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skicka en varm kram"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کسی کو گرمجوشی سے گلے لگائیں"
+          }
         }
       }
     },
@@ -9425,6 +13925,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "enviar mensagem privada"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發送私信"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งข้อความส่วนตัว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi tin nhắn riêng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magpadala ng pribadong mensahe"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hantar pesan pribadi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyślij wiadomość prywatną"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stuur privébericht"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தனியுரையாடல் அனுப்பவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skicka privat meddelande"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نجی پیغام بھیجیں"
           }
         }
       }
@@ -9545,6 +14105,66 @@
             "state": "translated",
             "value": "dar uma chapada a alguém com uma truta"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用鱒魚拍某人"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตบใครสักคนด้วยปลาเทราต์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tát ai đó bằng cá hồi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sampalin ang isang tao gamit ang trout"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tampar seseorang dengan ikan trout"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "spoliczkuj kogoś trocią"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geef iemand een mep met een forel"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஒருவரை trout மீனால் அடிக்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "smäll någon med en öring"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کسی کو ٹراؤٹ سے تھپڑ ماریں"
+          }
         }
       }
     },
@@ -9663,6 +14283,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "desbloquear um par"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消屏蔽同伴"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลิกบล็อกเพียร์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bỏ chặn nút"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alisin ang pag-block sa peer"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buka blokir peer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "odblokuj peera"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer deblokkeren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer தடை நீக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "avblockera peer"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer کا بلاک ہٹائیں"
           }
         }
       }
@@ -9783,6 +14463,66 @@
             "state": "translated",
             "value": "remover dos favoritos"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移出收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "นำออกจากรายการโปรด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xóa khỏi yêu thích"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alisin sa mga paborito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hapus dari favorit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usuń z ulubionych"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uit favorieten verwijderen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிரியப்பட்டதில் இருந்து நீக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ta bort från favoriter"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پسندیدہ سے ہٹا دیں"
+          }
         }
       }
     },
@@ -9901,6 +14641,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "ver quem está online"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看誰在線"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ดูว่าใครออนไลน์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xem ai đang online"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tingnan kung sino ang online"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lihat siapa yang online"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zobacz kto jest online"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bekijk wie online is"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "யார் ஆன்லைனில் உள்ளனர்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "se vem som är online"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دیکھیں کون آن لائن ہے"
           }
         }
       }
@@ -10021,6 +14821,66 @@
             "state": "translated",
             "value": "entregue a %1$d de %2$d membros"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已送達 %2$d 人中的 %1$d 人"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งถึง %1$d จาก %2$d คนแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã gửi tới %1$d trong %2$d thành viên"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naihatid sa %1$d ng %2$d miyembro"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terhantar ke %1$d dari %2$d anggota"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dostarczono do %1$d z %2$d członków"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bezorgd bij %1$d van %2$d leden"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d பேரில் %1$d பேருக்கு வழங்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "levererat till %1$d av %2$d medlemmar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d میں سے %1$d اراکین کو پہنچا دیا گیا"
+          }
         }
       }
     },
@@ -10139,6 +14999,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "entregue a %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已送達 %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งถึง %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi tới %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naihatid kay %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terhantar ke %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dostarczono do %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bezorgd bij %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ க்கு வழங்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "levererat till %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کو پہنچایا گیا"
           }
         }
       }
@@ -10259,6 +15179,66 @@
             "state": "translated",
             "value": "falhou: %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗：%@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ล้มเหลว: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thất bại: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nabigo: %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gagal: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niepowodzenie: %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mislukt: %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தோல்வி: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "misslyckades: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ناکام: %@"
+          }
         }
       }
     },
@@ -10377,6 +15357,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "lido por %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已讀：%@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อ่านโดย %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã đọc bởi %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "binasa ni %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dibaca oleh %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "przeczytane przez %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gelezen door %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ படித்தார்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "läst av %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ نے پڑھا"
           }
         }
       }
@@ -10497,6 +15537,66 @@
             "state": "translated",
             "value": "utilizador bloqueado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用者已被屏蔽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ผู้ใช้ถูกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "người dùng bị chặn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-block ang user"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pengguna diblokir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "użytkownik zablokowany"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gebruiker is geblokkeerd"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பயனர் தடுக்கப்பட்டுள்ளார்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "användaren är blockerad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صارف بلاک ہے"
+          }
         }
       }
     },
@@ -10615,6 +15715,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "não é possível enviar mensagem a ti próprio"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不能給自己發訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถส่งข้อความถึงตัวเองได้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể tự gửi cho chính mình"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi puwedeng magpadala sa sarili mo"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa hantar ke diri sendiri"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie możesz wysłać wiadomości do siebie"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "je kunt jezelf geen bericht sturen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்களுக்கு நீங்களே அனுப்ப முடியாது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte skicka till dig själv"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خود کو پیغام نہیں بھیج سکتے"
           }
         }
       }
@@ -10735,6 +15895,66 @@
             "state": "translated",
             "value": "erro ao enviar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發送錯誤"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เกิดข้อผิดพลาดในการส่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lỗi gửi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "error sa pagpapadala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kesalahan penghantaran"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "błąd wysyłania"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verzendfout"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அனுப்பும் பிழை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sändningsfel"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بھیجنے میں غلطی"
+          }
         }
       }
     },
@@ -10853,6 +16073,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "destinatário desconhecido"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知收件人"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่รู้จักผู้รับ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "người nhận không xác định"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi kilalang tatanggap"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "penerima tidak dikenal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieznany odbiorca"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onbekende ontvanger"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பெறுநர் தெரியவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "okänd mottagare"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نامعلوم وصول کنندہ"
           }
         }
       }
@@ -10973,6 +16253,66 @@
             "state": "translated",
             "value": "par inacessível"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同伴不可達"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ติดต่อเพียร์ไม่ได้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không liên lạc được với nút"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi maabot ang peer"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer tidak dapat dijangkau"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer nieosiągalny"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer onbereikbaar"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer அணுக முடியவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer ej nåbar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "peer تک رسائی نہیں"
+          }
         }
       }
     },
@@ -11091,6 +16431,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "PESSOAS"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成員"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PEOPLE"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PEOPLE"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PEOPLE"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ORANG"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OSOBY"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MENSEN"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PEOPLE"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PERSONER"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PEOPLE"
           }
         }
       }
@@ -11211,6 +16611,66 @@
             "state": "translated",
             "value": "verificação: mostra o meu QR ou lê o de um amigo"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "驗證：展示我的 qr 或掃描好友"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การยืนยัน: แสดง QR ของฉันหรือสแกนของเพื่อน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xác minh: hiển thị QR của tôi hoặc quét của bạn bè"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beripikasyon: ipakita ang aking QR o i-scan ang sa kaibigan"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifikasi: tampilkan qr-ku atau pindai teman"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "weryfikacja: pokaż mój QR lub zeskanuj znajomego"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificatie: toon mijn QR of scan die van een vriend"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்ப்பு: எனது QR ஐ காட்டவும் அல்லது நண்பரின் QR ஐ ஸ்கேன் செய்யவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifiering: visa min QR eller skanna en vän"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توثیق: میرا QR دکھائیں یا دوست کا اسکین کریں"
+          }
         }
       }
     },
@@ -11329,6 +16789,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "escreve uma mensagem..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入訊息..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ข้อความ..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nhập tin nhắn..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mag-type ng mensahe..."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ketik pesan..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wpisz wiadomość..."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "typ een bericht..."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ஒரு செய்தியைத் தட்டச்சு செய்க..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skriv ett meddelande..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیغام ٹائپ کریں..."
           }
         }
       }
@@ -11449,6 +16969,66 @@
             "state": "translated",
             "value": "apelido"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暱稱"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อเล่น"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "biệt danh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "palayaw"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nama panggilan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pseudonim"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bijnaam"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "புனைப் பெயர்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "smeknamn"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نک نیم"
+          }
         }
       }
     },
@@ -11567,6 +17147,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "ativar localização"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用位置"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้งานตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bật vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-on ang lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aktifkan lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "włącz lokalizację"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "locatie inschakelen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இடத்தை இயக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aktivera plats"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن فعال کریں"
           }
         }
       }
@@ -11687,6 +17327,66 @@
             "state": "translated",
             "value": "copiar mensagem"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกข้อความ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sao chép tin nhắn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopyahin ang mensahe"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "salin pesan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiuj wiadomość"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bericht kopiëren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "செய்தியை நகலெடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopiera meddelande"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیغام کاپی کریں"
+          }
         }
       }
     },
@@ -11805,6 +17505,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "mostrar menos"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收起"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงน้อยลง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thu gọn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ipakita nang kaunti"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tampilkan lebih sedikit"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pokaż mniej"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "minder weergeven"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறைவாக காட்ட"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "visa mindre"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کم دکھائیں"
           }
         }
       }
@@ -11925,6 +17685,66 @@
             "state": "translated",
             "value": "mostrar mais"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงเพิ่มเติม"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mở rộng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ipakita pa"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tampilkan lebih banyak"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pokaż więcej"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "meer weergeven"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மேலும் காட்ட"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "visa mer"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مزید دکھائیں"
+          }
         }
       }
     },
@@ -12043,6 +17863,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "localização indisponível"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置不可用"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีข้อมูลตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không có dữ liệu vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lokasi tidak tersedia"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lokalizacja niedostępna"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "locatie niet beschikbaar"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இடம் கிடைக்கவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "plats ej tillgänglig"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن دستیاب نہیں"
           }
         }
       }
@@ -12163,6 +18043,66 @@
             "state": "translated",
             "value": "notas"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筆記"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ghi chú"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga tala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "catatan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notatki"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notities"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறிப்புகள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "anteckningar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوٹس"
+          }
         }
       }
     },
@@ -12281,6 +18221,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "pagar com Cashu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過 cashu 支付"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จ่ายด้วย Cashu"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thanh toán bằng Cashu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magbayad gamit ang Cashu"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bayar via cashu"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zapłać przez Cashu"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "betalen met Cashu"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cashu மூலம் செலுத்தவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "betala med Cashu"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cashu سے ادائیگی کریں"
           }
         }
       }
@@ -12401,6 +18401,66 @@
             "state": "translated",
             "value": "pagar com Lightning"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過 lightning 支付"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จ่ายด้วย Lightning"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thanh toán bằng Lightning"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magbayad gamit ang Lightning"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bayar via lightning"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zapłać przez Lightning"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "betalen met Lightning"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning மூலம் செலுத்தவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "betala med Lightning"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning سے ادائیگی کریں"
+          }
         }
       }
     },
@@ -12519,6 +18579,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "a estabelecer encriptação"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在建立加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังตั้งค่าการเข้ารหัส"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang thiết lập mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagseset up ng pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "menyiapkan enkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trwa ustanawianie szyfrowania"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteling wordt opgezet"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் அமைக்கப்படுகிறது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ställer in kryptering"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن قائم کی جا رہی ہے"
           }
         }
       }
@@ -12639,6 +18759,66 @@
             "state": "translated",
             "value": "encriptação falhada"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加密失敗"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเข้ารหัสล้มเหลว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mã hóa thất bại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nabigo ang pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enkripsi gagal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "szyfrowanie nie powiodło się"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteling mislukt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் தோல்வியடைந்தது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kryptering misslyckades"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن ناکام رہی"
+          }
         }
       }
     },
@@ -12757,6 +18937,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "sem encriptação"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่ได้เข้ารหัส"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chưa mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak terenkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak szyfrowania"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niet versleuteld"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் செய்யப்படவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inte krypterad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر انکرپٹڈ"
           }
         }
       }
@@ -12877,6 +19117,66 @@
             "state": "translated",
             "value": "encriptado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เข้ารหัสแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terenkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zaszyfrowane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteld"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் செய்யப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "krypterad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپٹڈ"
+          }
         }
       }
     },
@@ -12995,6 +19295,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "encriptado e verificado"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已加密並驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เข้ารหัสและยืนยันแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã mã hóa và xác thực"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-encrypt at beripikado"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terenkripsi dan terverifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zaszyfrowane i zweryfikowane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteld en geverifieerd"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கமும் சரிபார்ப்பும் முடிந்தது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "krypterad och verifierad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپٹڈ اور تصدیق شدہ"
           }
         }
       }
@@ -13115,6 +19475,66 @@
             "state": "translated",
             "value": "a estabelecer encriptação..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在建立加密..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังตั้งค่าการเข้ารหัส..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang thiết lập mã hóa..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagseset up ng pag-encrypt..."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "menyiapkan enkripsi..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trwa ustanawianie szyfrowania..."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteling wordt opgezet..."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் அமைக்கப்படுகிறது..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ställer in kryptering..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن قائم کی جا رہی ہے..."
+          }
         }
       }
     },
@@ -13233,6 +19653,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "encriptação falhada"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加密失敗"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเข้ารหัสล้มเหลว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mã hóa thất bại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nabigo ang pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "enkripsi gagal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "szyfrowanie nie powiodło się"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteling mislukt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் தோல்வியடைந்தது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kryptering misslyckades"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپشن ناکام رہی"
           }
         }
       }
@@ -13353,6 +19833,66 @@
             "state": "translated",
             "value": "sem encriptação"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่ได้เข้ารหัส"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chưa mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang pag-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak terenkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak szyfrowania"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niet versleuteld"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கம் இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inte krypterad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر انکرپٹڈ"
+          }
         }
       }
     },
@@ -13471,6 +20011,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "encriptado"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已加密"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เข้ารหัสแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã mã hóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-encrypt"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terenkripsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zaszyfrowane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteld"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "krypterad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپٹڈ"
           }
         }
       }
@@ -13591,6 +20191,66 @@
             "state": "translated",
             "value": "encriptado e verificado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已加密並驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เข้ารหัสและยืนยันแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã mã hóa & xác thực"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-encrypt at beripikado"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terenkripsi dan terverifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zaszyfrowane i zweryfikowane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versleuteld & geverifieerd"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறியாக்கப்பட்ட & சரிபார்க்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "krypterad & verifierad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انکرپٹڈ اور تصدیق شدہ"
+          }
         }
       }
     },
@@ -13709,6 +20369,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "marcar como verificado"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標記為已驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทำเครื่องหมายว่ายืนยันแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đánh dấu đã xác thực"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "markahan bilang beripikado"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tandai sebagai terverifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "oznacz jako zweryfikowane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "markeer als geverifieerd"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்க்கப்பட்டது என குறிக்க"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "markera som verifierad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیق شدہ کے طور پر نشان زد کریں"
           }
         }
       }
@@ -13829,6 +20549,66 @@
             "state": "translated",
             "value": "remover verificação"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบการยืนยัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xóa xác thực"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alisin ang beripikasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hapus verifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usuń weryfikację"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificatie verwijderen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்ப்பை நீக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ta bort verifiering"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیق ہٹائیں"
+          }
         }
       }
     },
@@ -13947,6 +20727,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ NÃO VERIFICADO"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ 未驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ ยังไม่ยืนยัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ CHƯA XÁC THỰC"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ HINDI BERIPIKADO"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ BELUM TERVERIFIKASI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ NIEZWERYFIKOWANE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ NIET GEVERIFICEERD"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ சரிபார்க்கப்படவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ INTE VERIFIERAD"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ تصدیق نہیں ہوئی"
           }
         }
       }
@@ -14067,6 +20907,66 @@
             "state": "translated",
             "value": "✓ VERIFICADO"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 已驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ ยืนยันแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ ĐÃ XÁC THỰC"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ BERIPIKADO"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ TERVERIFIKASI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ ZWERYFIKOWANE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ GEVERIFICEERD"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ சரிபார்க்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ VERIFIERAD"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ تصدیق شدہ"
+          }
         }
       }
     },
@@ -14185,6 +21085,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "indisponível - aperto de mão em curso"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫不可用 - handshake 進行中"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่พร้อม - กำลังจับมือ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chưa sẵn sàng - đang bắt tay"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi pa magagamit - nagpapatuloy ang handshake"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak tersedia - handshake sedang berlangsung"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niedostępne – handshake w toku"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niet beschikbaar - handshake bezig"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கிடைக்கவில்லை - கைச்சாத்து நடந்து கொண்டிருக்கிறது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inte tillgänglig – handskakning pågår"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دستیاب نہیں - ہینڈ شیک جاری ہے"
           }
         }
       }
@@ -14305,6 +21265,66 @@
             "state": "translated",
             "value": "confirmaste a identidade desta pessoa."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已經覈實了此人的身份。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คุณยืนยันตัวตนของคนนี้แล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bạn đã xác thực danh tính người này."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-beripika mo na ang pagkakakilanlan ng taong ito."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kamu sudah memverifikasi identitas orang ini."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zweryfikowałeś tożsamość tej osoby."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "je hebt de identiteit van deze persoon geverifieerd."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த நபரின் அடையாளத்தை நீங்கள் உறுதிப்படுத்தியுள்ளீர்கள்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "du har verifierat den här personens identitet."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ نے اس شخص کی شناخت کی تصدیق کی ہے۔"
+          }
         }
       }
     },
@@ -14423,6 +21443,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "compara estas impressões com %@ num canal seguro."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過安全渠道與 %@ 比對這些指紋。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปรียบเทียบลายนิ้วมือเหล่านี้กับ %@ ผ่านช่องทางที่ปลอดภัย"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "so sánh các vân tay này với %@ qua kênh an toàn."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ikumpara ang mga fingerprint na ito kay %@ sa isang ligtas na channel."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bandingkan sidik ini dengan %@ lewat kanal aman."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "porównaj te odciski z %@ na bezpiecznym kanale."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vergelijk deze fingerprints met %@ via een veilig kanaal."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த கைரேகைகளை %@ உடன் பாதுகாப்பான வழியில் ஒப்பிடவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jämför dessa fingeravtryck med %@ via en säker kanal."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ان فنگر پرنٹس کو %@ کے ساتھ محفوظ چینل پر ملائیں۔"
           }
         }
       }
@@ -14543,6 +21623,66 @@
             "state": "translated",
             "value": "impressão digital desta pessoa:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對方指紋："
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลายนิ้วมือของอีกฝ่าย:"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vân tay của họ:"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fingerprint nila:"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidik mereka:"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ich odcisk:"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hun fingerprint:"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அவர்களின் கைரேகம்:"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "deras fingeravtryck:"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ان کا فنگر پرنٹ:"
+          }
         }
       }
     },
@@ -14661,6 +21801,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "verificação de segurança"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การยืนยันความปลอดภัย"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xác minh bảo mật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beripikasyong panseguridad"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifikasi keamanan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "weryfikacja bezpieczeństwa"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beveiligingsverificatie"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பாதுகாப்பு சரிபார்ப்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "säkerhetsverifiering"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیکیورٹی تصدیق"
           }
         }
       }
@@ -14781,6 +21981,66 @@
             "state": "translated",
             "value": "a tua impressão digital:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的指紋："
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลายนิ้วมือของคุณ:"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vân tay của bạn:"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fingerprint mo:"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidikmu:"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "twój odcisk:"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jouw fingerprint:"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்கள் கைரேகம்:"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ditt fingeravtryck:"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کا فنگر پرنٹ:"
+          }
         }
       }
     },
@@ -14899,6 +22159,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "bloquear"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏蔽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chặn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-block"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zablokuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blokkeren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தடை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blockera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بلاک کریں"
           }
         }
       }
@@ -15019,6 +22339,66 @@
             "state": "translated",
             "value": "desbloquear"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消屏蔽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลิกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bỏ chặn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-unblock"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buka blokir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "odblokuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "deblokkeren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தடை நீக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "avblockera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بلاک ہٹائیں"
+          }
         }
       }
     },
@@ -15137,6 +22517,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "ninguém por perto..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附近沒人..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีใครอยู่ใกล้..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không có ai gần..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang tao sa paligid..."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak ada siapa pun..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nikogo w pobliżu..."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "niemand in de buurt..."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அருகில் யாரும் இல்லை..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ingen i närheten..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قریب کوئی نہیں..."
           }
         }
       }
@@ -15257,6 +22697,66 @@
             "state": "translated",
             "value": "bloqueado em geohash"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 geohash 中已屏蔽"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ถูกบล็อกใน geohash"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã chặn trong geohash"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-block sa geohash"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "diblokir di geohash"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zablokowany w geohash"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geblokkeerd in geohash"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash இல் தடுக்கப்பட்டது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blockerad i geohash"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash میں بلاک شدہ"
+          }
         }
       }
     },
@@ -15375,6 +22875,66 @@
           "stringUnit": {
             "state": "translated",
             "value": " (tu)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (你)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (คุณ)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (bạn)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (ikaw)"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (kamu)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (ty)"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (jij)"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (நீங்கள்)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (du)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (آپ)"
           }
         }
       }
@@ -15495,6 +23055,66 @@
             "state": "translated",
             "value": "abrir definições"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開設定"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่า"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mở cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buksan ang settings"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buka Tetapan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "otwórz ustawienia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open instellingen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அமைப்புகளைத் திறக்க"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "öppna inställningar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹنگز کھولیں"
+          }
         }
       }
     },
@@ -15613,6 +23233,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "remover acesso à localização"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除位置存取權"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "นำสิทธิ์เข้าถึงตำแหน่งออก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gỡ quyền truy cập vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alisin ang access sa lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cabut capaian lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usuń dostęp do lokalizacji"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toegang tot locatie verwijderen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட அணுகலை அகற்று"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ta bort platsåtkomst"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن رسائی ہٹائیں"
           }
         }
       }
@@ -15733,6 +23413,66 @@
             "state": "translated",
             "value": "obter permissões de localização e os meus geohash"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "獲取位置和我的 geohash"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขอสิทธิ์ตำแหน่งและ geohash ของฉัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yêu cầu quyền vị trí và geohash của tôi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kumuha ng access sa lokasyon at mga geohash ko"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ambil lokasiku dan geohash"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uzyskaj uprawnienia lokalizacji i moje geohashe"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vraag locatierechten en mijn geohashes op"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட அனுமதி மற்றும் என் geohash களைப் பெற"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hämta platsbehörighet och mina geohashar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن کی اجازت اور میرے geohash حاصل کریں"
+          }
         }
       }
     },
@@ -15851,6 +23591,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "teletransportar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瞬移"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เทเลพอร์ต"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dịch chuyển"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teleport"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teleport"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teleportuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teleporteer"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "டெலிபோர்ட்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "teleportera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیلی پورٹ"
           }
         }
       }
@@ -15971,6 +23771,66 @@
             "state": "translated",
             "value": "marcados"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已收藏"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ที่คั่นไว้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã đánh dấu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naka-bookmark"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "disimpan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zapisane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bladwijzers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "புக் மார்க் செய்யப்பட்டவை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bokmärken"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بک مارک شدہ"
+          }
         }
       }
     },
@@ -16089,6 +23949,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "conversa com pessoas perto de ti usando canais geohash. apenas um geohash de baixa precisão é partilhado, nunca GPS exato. o teu IP fica oculto ao encaminhar todo o tráfego através do Tor."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 geohash 頻道與附近的人聊天。只會共享粗略 geohash，從不洩露精確 GPS。所有流量透過 tor 路由來隱藏你的 IP。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แชทกับคนใกล้คุณผ่านช่อง geohash แบ่งปันเพียง geohash แบบหยาบ ไม่ใช่ GPS ที่แม่นยำ ที่อยู่ IP ของคุณถูกซ่อนด้วยการส่งข้อมูลผ่าน tor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trò chuyện với người gần bạn bằng các kênh geohash. chỉ chia sẻ geohash thô, không bao giờ là GPS chính xác. địa chỉ IP của bạn được ẩn bằng cách định tuyến toàn bộ lưu lượng qua tor."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "makipag-chat sa mga taong malapit sa iyo gamit ang mga geohash channel. coarse na geohash lang ang ibinabahagi, hindi ang eksaktong GPS. tinatago ang iyong IP address sa pagreruta ng lahat ng traffic sa tor."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ngobrol dengan orang terdekat lewat kanal geohash. hanya geohash kasar yang dibagikan, tidak pernah gps tepat. alamat ip-mu tersembunyi karena seluruh trafik lewat tor."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rozmawiaj z osobami w pobliżu za pomocą kanałów geohash. udostępniany jest tylko zgrubny geohash, nigdy dokładny GPS. twój adres IP jest ukryty przez kierowanie całego ruchu przez tor."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chat met mensen bij jou in de buurt via geohash-kanalen. enkel een grove geohash wordt gedeeld, nooit exacte GPS. je IP-adres wordt verborgen doordat al het verkeer via tor wordt gerouteerd."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash சேனல்கள் மூலம் அருகிலுள்ளவர்களுடன் உரையாடுங்கள். மிகவும் பொது geohash மட்டுமே பகிரப்படும், துல்லியமான GPS அல்ல. உங்கள் IP, அனைத்து போக்குவரத்தையும் tor வழியாக மாற்றுவதன் மூலம் மறைக்கப்படுகிறது."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chatta med folk nära dig via geohash-kanaler. endast en grov geohash delas, aldrig exakt GPS. din IP-adress döljs genom att all trafik går via tor."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قریب کے لوگوں سے گفتگو کیلئے geohash چینلز استعمال کریں۔ صرف عمومی geohash شیئر کیا جاتا ہے، کبھی درست GPS نہیں۔ آپ کا IP tor کے ذریعے ساری ٹریفک روٹ کر کے چھپایا جاتا ہے۔"
           }
         }
       }
@@ -16209,6 +24129,66 @@
             "state": "translated",
             "value": "geohash inválido"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無效的 geohash"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash ไม่ถูกต้อง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash không hợp lệ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "di-wastong geohash"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash tidak valid"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieprawidłowy geohash"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ongeldige geohash"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "தவறான geohash"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ogiltig geohash"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غلط geohash"
+          }
         }
       }
     },
@@ -16328,6 +24308,66 @@
             "state": "translated",
             "value": "a procurar canais próximos…"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在尋找附近頻道…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังค้นหาช่องใกล้คุณ…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang tìm kênh gần…"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "naghahanap ng mga kalapit na channel…"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mencari kanal sekitar…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyszukiwanie kanałów w pobliżu…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kanalen in de buurt zoeken…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அருகிலுள்ள சேனல்கள் தேடப்படுகின்றன…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "söker efter kanaler i närheten…"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قریب کے چینلز تلاش ہو رہے ہیں…"
+          }
         }
       }
     },
@@ -16443,6 +24483,66 @@
           }
         },
         "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
+        },
+        "ur": {
           "stringUnit": {
             "state": "translated",
             "value": "mesh"
@@ -16565,6 +24665,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "permissão de localização negada. ativa nas definições para usar canais de localização."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置權限被拒。請在設定中啟用以使用位置頻道。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปฏิเสธการเข้าถึงตำแหน่ง เปิดในตั้งค่าเพื่อใช้ช่องตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bị từ chối quyền vị trí. hãy bật trong cài đặt để dùng kênh vị trí."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tinanggihan ang pahintulot sa lokasyon. i-enable sa settings para magamit ang mga channel ng lokasyon."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kebenaran lokasi ditolak. aktifkan dalam Tetapan untuk menggunakan kanal lokasi."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "odmówiono dostępu do lokalizacji. włącz w ustawieniach, aby korzystać z kanałów lokalizacji."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "locatierechten geweigerd. schakel dit in instellingen in om locatiekanalen te gebruiken."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட அனுமதி மறுக்கப்பட்டது. இட சேனல்களைப் பயன்படுத்த அமைப்பில் இயக்கவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "platsbehörighet nekad. aktivera i inställningar för att använda platskanaler."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن کی اجازت مسترد کر دی گئی۔ لوکیشن چینلز استعمال کرنے کیلئے سیٹنگز میں فعال کریں۔"
           }
         }
       }
@@ -17069,6 +25229,66 @@
             "state": "translated",
             "value": "%1$@ [%2$#@people_count@]"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
         }
       }
     },
@@ -17184,6 +25404,66 @@
           }
         },
         "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ • %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ • %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "ur": {
           "stringUnit": {
             "state": "translated",
             "value": "#%1$@ • %2$@"
@@ -17307,6 +25587,66 @@
             "state": "translated",
             "value": "%1$@ • %2$@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
         }
       }
     },
@@ -17425,6 +25765,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "#canais de localização"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#位置頻道"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#ช่องตามตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#kênh vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#mga channel ng lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#kanal lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#kanały lokalizacji"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#locatiekanalen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#இட சேனல்கள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#platskanaler"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#لوکیشن چینلز"
           }
         }
       }
@@ -17545,6 +25945,66 @@
             "state": "translated",
             "value": "oculta o teu IP para canais de localização. recomendado: ligado."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為位置頻道隱藏你的 IP。推薦：開啟。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อน IP ของคุณสำหรับช่องตำแหน่ง แนะนำให้เปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ẩn IP của bạn cho kênh vị trí. khuyến nghị: bật."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "itinatago ang iyong IP para sa mga channel ng lokasyon. inirerekomenda: naka-on."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "menyembunyikan ip-mu untuk kanal lokasi. disarankan: aktif."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ukrywa twój IP dla kanałów lokalizacji. zalecane: włączone."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verbergt je IP voor locatiekanalen. aanbevolen: aan."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட சேனல்களுக்கு உங்கள் IP ஐ மறைக்கும். பரிந்துரை: இயக்கப்பட்டது."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "döljer din IP för platskanaler. rekommenderas: på."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن چینلز کیلئے آپ کا IP چھپاتا ہے۔ تجویز: آن رکھیں۔"
+          }
         }
       }
     },
@@ -17663,6 +26123,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "encaminhamento Tor"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor 路由"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การกำหนดเส้นทางผ่าน tor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "định tuyến tor"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor routing"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "perutean tor"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trasowanie tor"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor-routing"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor வழிமுறை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor-routing"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor روٹنگ"
           }
         }
       }
@@ -17783,6 +26303,66 @@
             "state": "translated",
             "value": "bloco"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "街區"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "khối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloke"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blok"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blok"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blok"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிளாக்கு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "block"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بلاک"
+          }
         }
       }
     },
@@ -17901,6 +26481,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "edifício"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "樓棟"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อาคาร"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tòa nhà"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gusali"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gedung"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "budynek"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gebouw"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கட்டிடம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "byggnad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمارت"
           }
         }
       }
@@ -18021,6 +26661,66 @@
             "state": "translated",
             "value": "cidade"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "城市"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เมือง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thành phố"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lungsod"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kota"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "miasto"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stad"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நகரம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stad"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شہر"
+          }
         }
       }
     },
@@ -18139,6 +26839,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "bairro"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "社區"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ย่าน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "khu vực"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "baranggay"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lingkungan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dzielnica"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "buurt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அயல்பகுதி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "grannskap"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محلہ"
           }
         }
       }
@@ -18259,6 +27019,66 @@
             "state": "translated",
             "value": "província"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "省份"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จังหวัด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tỉnh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "probinsya"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "provinsi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "województwo"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "provincie"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மாவட்டம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "län"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صوبہ"
+          }
         }
       }
     },
@@ -18377,6 +27197,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "região"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區域"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภูมิภาค"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vùng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rehiyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wilayah"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "region"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "regio"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிராந்தியம்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "region"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطہ"
           }
         }
       }
@@ -18497,6 +27377,66 @@
             "state": "translated",
             "value": "fechar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đóng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "isara"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tutup"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zamknij"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sluiten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மூடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stäng"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند کریں"
+          }
         }
       }
     },
@@ -18615,6 +27555,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "tentar novamente"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重試"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลองอีกครั้ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thử lại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "subukan muli"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "coba lagi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "spróbuj ponownie"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "opnieuw proberen"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மீண்டும் முயற்சி"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "försök igen"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دوبارہ کوشش کریں"
           }
         }
       }
@@ -18735,6 +27735,66 @@
             "state": "translated",
             "value": "adiciona pequenas notas permanentes a este local para outros visitantes encontrarem."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為此地點添加簡短的常駐筆記，方便其他訪客發現。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เพิ่มบันทึกถาวรสั้น ๆ ให้สถานที่นี้เพื่อให้ผู้มาเยือนคนอื่นพบได้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thêm ghi chú ngắn cố định cho nơi này để người khác tìm thấy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magdagdag ng maiikling permanenteng tala sa lugar na ito para matagpuan ng iba"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tambahkan catatan permanen singkat di tempat ini agar orang lain menemukannya."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dodaj krótkie trwałe notatki o tej lokalizacji, aby inni mogli je znaleźć"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "voeg korte, blijvende notities toe aan deze locatie zodat anderen ze kunnen vinden"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த இடத்திற்கு பிறர் கண்டுபிடிக்க சிறிய நிரந்தர குறிப்புகளைச் சேர்க்கவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lägg till korta beständiga anteckningar för denna plats så att andra hittar dem"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اس جگہ کیلئے مختصر مستقل نوٹس شامل کریں تاکہ دوسرے دیکھ سکیں"
+          }
         }
       }
     },
@@ -18853,6 +27913,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "sê o primeiro a adicionar uma nota para este sítio."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成為這裡的第一條筆記。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เป็นคนแรกที่เพิ่มบันทึกให้จุดนี้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hãy là người đầu tiên thêm ghi chú tại đây"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "maging unang magdagdag para sa puntong ito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jadilah orang pertama yang menambahkannya di sini."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dodaj pierwszą notatkę dla tego miejsca"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wees de eerste die er hier een toevoegt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த இடத்திற்கு முதலில் ஒரு குறிப்பைச் சேர்க்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "var först med en anteckning här"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اس مقام کیلئے پہلا نوٹ آپ شامل کریں"
           }
         }
       }
@@ -18973,6 +28093,66 @@
             "state": "translated",
             "value": "ainda sem notas"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚無筆記"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่มีบันทึก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chưa có ghi chú"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wala pang tala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "belum ada catatan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak notatek"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nog geen notities"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இன்னும் குறிப்புகள் இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inga anteckningar än"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابھی تک کوئی نوٹس نہیں"
+          }
         }
       }
     },
@@ -19092,6 +28272,66 @@
             "state": "translated",
             "value": "falha ao enviar a nota. %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法發送筆記。%@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งบันทึกล้มเหลว %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi ghi chú thất bại. %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nabigong magpadala ng tala. %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa menghantar catatan. %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie udało się wysłać notatki. %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versturen van notitie mislukt. %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறிப்பை அனுப்ப முடியவில்லை. %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kunde inte skicka anteckning. %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوٹ بھیجنا ناکام۔ %@"
+          }
         }
       }
     },
@@ -19210,6 +28450,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "sem relés geográficos disponíveis perto deste local. tenta novamente em breve."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附近沒有可用的地理中繼。稍後再試。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มี geo relay ใกล้สถานที่นี้ ลองอีกครั้งในภายหลัง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không có relay địa lý gần khu vực này. thử lại sau."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang geo relay malapit sa lokasyong ito. subukan muli maya-maya."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak ada relay geo tersedia dekat sini. coba lagi nanti."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak geo relay w pobliżu tej lokalizacji. spróbuj ponownie wkrótce."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geen geo-relays in de buurt van deze locatie. probeer het later opnieuw."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த இடத்துக்கு அருகில் geo relay இல்லை. கொஞ்சம் நேரம் கழித்து முயற்சி செய்யவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inga geo-reläer nära denna plats. försök igen senare."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اس جگہ کے قریب کوئی geo relay دستیاب نہیں۔ کچھ دیر بعد دوبارہ کوشش کریں۔"
           }
         }
       }
@@ -19714,6 +29014,66 @@
             "state": "translated",
             "value": "#%1$@ • %2$#@note_count@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
         }
       }
     },
@@ -19832,6 +29192,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "a carregar notas…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加載筆記…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังโหลดบันทึก…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang tải ghi chú…"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagse-load ng mga tala…"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "memuat catatan…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ładowanie notatek…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notities laden…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறிப்புகள் ஏற்றப்படுகின்றன…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "laddar anteckningar…"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوٹس لوڈ ہو رہے ہیں…"
           }
         }
       }
@@ -19952,6 +29372,66 @@
             "state": "translated",
             "value": "a carregar notas recentes…"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加載最新筆記…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังโหลดบันทึกล่าสุด…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang tải ghi chú gần đây…"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagse-load ng pinakahuling mga tala…"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "memuat catatan terbaru…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ładowanie ostatnich notatek…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "recentste notities laden…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சமீபத்திய குறிப்புகள் ஏற்றப்படுகின்றன…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "laddar senaste anteckningar…"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالیہ نوٹس لوڈ ہو رہے ہیں…"
+          }
         }
       }
     },
@@ -20070,6 +29550,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "sem relés geográficos por perto"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附近沒有地理中繼"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มี geo relay ใกล้เคียง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không có relay địa lý gần đó"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang malapit na geo relay"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak ada relay geo di dekatmu"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brak pobliskich geo relay"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geen geo-relays in de buurt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அருகில் geo relay இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inga geo-reläer i närheten"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قریب کوئی geo relay نہیں"
           }
         }
       }
@@ -20190,6 +29730,66 @@
             "state": "translated",
             "value": "adiciona uma nota para este local"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為此地點添加筆記"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เพิ่มบันทึกให้สถานที่นี้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "thêm ghi chú cho nơi này"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "magdagdag ng tala para sa lugar na ito"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tambahkan catatan untuk tempat ini"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dodaj notatkę do tego miejsca"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "voeg een notitie toe voor deze plek"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இந்த இடத்திற்கான ஒரு குறிப்பைச் சேர்க்கவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lägg till en anteckning för den här platsen"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اس جگہ کیلئے نوٹ شامل کریں"
+          }
         }
       }
     },
@@ -20308,6 +29908,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "relés geográficos indisponíveis; notas em pausa"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地理中繼不可用；筆記已暫停"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo relay ไม่พร้อมใช้งาน บันทึกถูกหยุดชั่วคราว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "relay địa lý không sẵn có; ghi chú bị tạm dừng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi magagamit ang mga geo relay; naka-pause ang mga tala"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "relay geo tidak tersedia; catatan dijeda"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo relay niedostępne; notatki wstrzymane"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo-relays niet beschikbaar; notities gepauzeerd"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo relay கிடைக்கவில்லை; குறிப்புகள் இடைநிறுத்தப்பட்டுள்ளன"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo-reläer otillgängliga; anteckningar pausade"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo relay دستیاب نہیں؛ نوٹس موقوف"
           }
         }
       }
@@ -20428,6 +30088,66 @@
             "state": "translated",
             "value": "as notas dependem de relés geográficos. verifica a ligação e tenta de novo."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筆記依賴地理中繼。檢查連線後再試。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกอาศัย geo relay ตรวจสอบการเชื่อมต่อแล้วลองอีกครั้ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ghi chú phụ thuộc vào relay địa lý. kiểm tra kết nối rồi thử lại."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "umaasa ang mga tala sa mga geo relay. suriin ang koneksyon at subukan ulit."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "catatan bergantung pada relay geo. cek koneksi lalu coba lagi."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notatki polegają na geo relay. sprawdź połączenie i spróbuj ponownie."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notities zijn afhankelijk van geo-relays. controleer de verbinding en probeer opnieuw."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "குறிப்புகள் geo relay மீது நம்புகிறது. இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "anteckningar är beroende av geo-reläer. kontrollera uppkopplingen och försök igen."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نوٹس geo relay پر منحصر ہیں۔ کنکشن چیک کریں اور دوبارہ کوشش کریں۔"
+          }
         }
       }
     },
@@ -20546,6 +30266,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "novas mensagens"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新訊息"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มีข้อความใหม่"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tin nhắn mới"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "may bagong mensahe"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pesan baru"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nowe wiadomości"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieuwe berichten"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "புதிய செய்திகள்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nya meddelanden"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئے پیغامات"
           }
         }
       }
@@ -20666,6 +30446,66 @@
             "state": "translated",
             "value": "não é possível iniciar o chat com %@: a pessoa está bloqueada."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法與 %@ 開始聊天：使用者已被屏蔽。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถเริ่มแชทกับ %@: บุคคลนี้ถูกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể bắt đầu chat với %@: người này bị chặn."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi makapagsimula ng chat kay %@: na-block ang tao."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa mulai chat dengan %@: pengguna diblokir."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można rozpocząć czatu z %@: osoba zablokowana."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan chat met %@ niet starten: persoon is geblokkeerd."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ உடன் உரையாடல் தொடங்க முடியாது: அந்த நபர் தடுக்கப்பட்டுள்ளார்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte starta chatt med %@: personen är blockerad."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کے ساتھ چیٹ شروع نہیں کر سکتے: شخص بلاک ہے۔"
+          }
         }
       }
     },
@@ -20784,6 +30624,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "não é possível iniciar o chat com %@: precisam de ser favoritos mútuos para mensagens offline."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法與 %@ 開始聊天：離線訊息需要互相關注。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถเริ่มแชทกับ %@: ต้องเป็นรายการโปรดทั้งสองฝ่ายเพื่อใช้งานออฟไลน์"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể bắt đầu chat với %@: cần yêu thích lẫn nhau để nhắn ngoại tuyến."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi makapagsimula ng chat kay %@: kailangan ang mutual na paborito para sa offline na mensahe."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa mulai chat dengan %@: butuh favorit bersama untuk offline."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można rozpocząć czatu z %@: potrzebne wzajemne ulubione dla wiadomości offline."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan chat met %@ niet starten: wederzijds favoriet vereist voor offline berichten."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ உடன் உரையாடல் தொடங்க முடியாது: ஆஃப்லைன் செய்திகளுக்கு இருபுறமும் பிரியப்பட்டவர்கள் ஆக வேண்டும்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte starta chatt med %@: ömsesidig favorit krävs för offline-meddelanden."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کے ساتھ چیٹ شروع نہیں کر سکتے: آفلائن پیغامات کیلئے باہمی پسندیدہ ہونا ضروری ہے۔"
           }
         }
       }
@@ -20904,6 +30804,66 @@
             "state": "translated",
             "value": "utilizador"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用者"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ผู้ใช้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "người dùng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "user"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pengguna"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "użytkownik"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gebruiker"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பயனர்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "användare"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صارف"
+          }
         }
       }
     },
@@ -21022,6 +30982,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "não é possível enviar mensagem: a pessoa está bloqueada."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法發送：使用者已被屏蔽。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถส่งข้อความ: บุคคลนี้ถูกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể gửi tin: người này bị chặn."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi makapagpadala ng mensahe: na-block ang tao."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa menghantar: pengguna diblokir."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można wysłać wiadomości: osoba zablokowana."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan bericht niet sturen: persoon is geblokkeerd."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "செய்தி அனுப்ப முடியவில்லை: நபர் தடுக்கப்பட்டுள்ளார்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte skicka meddelande: personen är blockerad."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیغام نہیں بھیج سکتے: شخص بلاک ہے۔"
           }
         }
       }
@@ -21142,6 +31162,66 @@
             "state": "translated",
             "value": "não é possível enviar mensagem a %@: a pessoa está bloqueada."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法向 %@ 發送：使用者已被屏蔽。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถส่งข้อความถึง %@: บุคคลนี้ถูกบล็อก"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể gửi tin cho %@: người này bị chặn."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi maipadala kay %@: na-block ang tao."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa menghantar ke %@: pengguna diblokir."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można wysłać do %@: osoba zablokowana."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan geen bericht sturen naar %@: persoon is geblokkeerd."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ க்கு செய்தி அனுப்ப முடியவில்லை: நபர் தடுக்கப்பட்டுள்ளார்."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte skicka till %@: personen är blockerad."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کو پیغام نہیں بھیج سکتے: شخص بلاک ہے۔"
+          }
         }
       }
     },
@@ -21260,6 +31340,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "não é possível enviar mensagem a %@ - o par não está acessível por mesh ou Nostr."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法向 %@ 發送：對方無法透過 mesh 或 Nostr 到達。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถส่งข้อความถึง %@ - ติดต่อเพียร์ผ่าน mesh หรือ nostr ไม่ได้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không thể gửi tin cho %@ - nút không thể liên lạc qua mesh hoặc nostr."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi maipadala kay %@ - hindi maabot ang peer sa mesh o nostr."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak bisa menghantar ke %@: penerima tidak dapat dijangkau lewat mesh atau nostr."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można wysłać do %@ – peer nieosiągalny przez mesh ani nostr."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan geen bericht sturen naar %@ – peer niet bereikbaar via mesh of nostr."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ க்கு செய்தி அனுப்ப முடியவில்லை - peer mesh அல்லது nostr மூலமாக அணுக முடியவில்லை."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte skicka till %@ – peer nås inte via mesh eller nostr."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کو پیغام نہیں بھیج سکتے - peer mesh یا nostr کے ذریعے دستیاب نہیں۔"
           }
         }
       }
@@ -21380,6 +31520,66 @@
             "state": "translated",
             "value": "%@ bloqueado nos chats geohash"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在 geohash 聊天中屏蔽 %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บล็อก %@ ในแชท geohash"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã chặn %@ trong chat geohash"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "na-block si %@ sa geohash chats"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ diblokir di chat geohash"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zablokowano %@ w czatach geohash"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ geblokkeerd in geohash-chats"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash உரையாடல்களில் %@ தடுக்கப்பட்டார்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blockerade %@ i geohash-chattar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash چیٹس میں %@ کو بلاک کیا"
+          }
         }
       }
     },
@@ -21498,6 +31698,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ desbloqueado nos chats geohash"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在 geohash 聊天中解除屏蔽 %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลิกบล็อก %@ ในแชท geohash"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã bỏ chặn %@ trong chat geohash"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "in-unblock si %@ sa geohash chats"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ dibuka blokirnya di chat geohash"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "odblokowano %@ w czatach geohash"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ gedeblokkeerd in geohash-chats"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash உரையாடல்களில் %@ தடை நீக்கப்பட்டார்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "avblockerade %@ i geohash-chattar"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash چیٹس میں %@ کا بلاک ہٹایا"
           }
         }
       }
@@ -21618,6 +31878,66 @@
             "state": "translated",
             "value": "não foi possível enviar: não estás num canal de localização"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發送失敗：你不在位置頻道中"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งไม่ได้: คุณไม่ได้อยู่ในช่องตำแหน่ง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không gửi được: bạn không ở trong kênh vị trí"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hindi maipadala: wala ka sa channel ng lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gagal menghantar: kamu tidak berada di kanal lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie można wysłać: nie jesteś w kanale lokalizacji"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan niet versturen: je zit niet in een locatiekanaal"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அனுப்ப முடியாது: நீங்கள் இட சேனலில் இல்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kan inte skicka: du är inte i ett platskanal"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نہیں بھیج سکتے: آپ لوکیشن چینل میں نہیں ہیں"
+          }
         }
       }
     },
@@ -21736,6 +32056,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "falha ao enviar para o canal de localização"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法發送到位置頻道"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งไปยังช่องตำแหน่งล้มเหลว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gửi tới kênh vị trí thất bại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nabigong magpadala sa channel ng lokasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gagal menghantar ke kanal lokasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wysłanie do kanału lokalizacji nie powiodło się"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versturen naar locatiekanaal mislukt"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இட சேனலுக்கு அனுப்புதல் தோல்வியடைந்தது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kunde inte skicka till platskanalen"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوکیشن چینل کو بھیجنا ناکام رہا"
           }
         }
       }
@@ -21856,6 +32236,66 @@
             "state": "translated",
             "value": "compilação de desenvolvimento: bypass do Tor ativo."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開發版本：tor 繞過已啟用。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รุ่นสำหรับนักพัฒนา: เปิดใช้งานการข้าม tor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bản dành cho dev: đang bật bỏ qua Tor."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "developer build: naka-enable ang Tor bypass."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "build pengembangan: bypass tor aktif."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wersja deweloperska: obejście Tor włączone."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ontwikkelaarsbuild: Tor-bypass ingeschakeld."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மேம்பாட்டு கட்டிடம்: Tor பயாபாஸ் செயல்படுத்தப்பட்டது."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "utvecklarbuild: Tor-bypass aktiverad."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈیولپر بلڈ: Tor بائی پاس فعال ہے۔"
+          }
         }
       }
     },
@@ -21974,6 +32414,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "O Tor foi reiniciado. O encaminhamento de rede foi restaurado."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor 已重啟。網路路由已恢復。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor เริ่มใหม่ เส้นทางเครือข่ายกลับมาแล้ว"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor đã khởi động lại. định tuyến mạng được khôi phục."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nag-restart ang tor. naibalik ang routing ng network."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor dimulai ulang. perutean dipulihkan."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor uruchomiony ponownie. trasowanie przywrócone."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor opnieuw gestart. netwerkrouting hersteld."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor மீண்டும் தொடங்கியுள்ளது. நெட்வொர்க் வழிமுறை மீட்டெடுக்கப்பட்டது."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor har startats om. nätverksroutingen återställd."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor نے دوبارہ آغاز کر دیا۔ نیٹ ورک روٹنگ بحال ہو گئی۔"
           }
         }
       }
@@ -22094,6 +32594,66 @@
             "state": "translated",
             "value": "O Tor está a reiniciar para recuperar a conectividade..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor 正在重啟以恢復連線..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor กำลังเริ่มใหม่เพื่อกู้คืนการเชื่อมต่อ..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor đang khởi động lại để phục hồi kết nối..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagre-restart ang tor upang ibalik ang koneksyon..."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor sedang dimulai ulang untuk memulihkan konektivitas..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor uruchamia się ponownie, aby przywrócić łączność..."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor wordt opnieuw gestart om verbinding te herstellen..."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இணைப்பை மீட்டெடுக்க tor மீண்டும் தொடங்குகிறது..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor startas om för att återställa anslutningen..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor کنکشن بحال کرنے کیلئے دوبارہ شروع ہو رہا ہے..."
+          }
         }
       }
     },
@@ -22212,6 +32772,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "O Tor foi iniciado. Todas as conversas são encaminhadas via Tor para ocultar o IP."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor 已啟動。所有聊天透過 tor 路由以保護 IP。"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor เริ่มทำงานแล้ว ส่งแชททั้งหมดผ่าน tor เพื่อปกปิด IP"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor đã khởi động. toàn bộ chat đi qua tor để ẩn IP."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nagsimula ang tor. lahat ng chat ay dumadaan sa tor para itago ang IP."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor berjalan. seluruh chat dirutekan lewat tor demi privasi."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor uruchomiony. wszystkie czaty idą przez tor dla prywatności IP."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor gestart. alle chats gaan via tor voor IP-privacy."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor தொடங்கியுள்ளது. IP பாதுகாப்பிற்காக அனைத்து உரையாடலும் tor வழியாக செல்கிறது."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor startad. all chatt routas via tor för IP-integritet."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor شروع ہو گیا۔ IP راز داری کیلئے تمام چیٹس tor سے گزرتی ہیں۔"
           }
         }
       }
@@ -22332,6 +32952,66 @@
             "state": "translated",
             "value": "O Tor está a iniciar..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在啟動 tor..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเริ่ม tor..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đang khởi động tor..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sinisimulan ang tor..."
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "menjalankan tor..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uruchamianie tor..."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor wordt gestart..."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor தொடங்குகிறது..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor startar..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tor شروع ہو رہا ہے..."
+          }
         }
       }
     },
@@ -22450,6 +33130,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "código QR de verificação"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "驗證 QR 碼"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รหัส QR สำหรับยืนยัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mã QR xác minh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR code para sa beripikasyon"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kode qr verifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kod QR do weryfikacji"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR-code voor verificatie"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்ப்பு QR குறியீடு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR-kod för verifiering"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیقی QR کوڈ"
           }
         }
       }
@@ -22570,6 +33310,66 @@
             "state": "translated",
             "value": "Digitaliza para me verificares"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描驗證我"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สแกนเพื่อยืนยันตัวฉัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "quét để xác minh tôi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-scan para i-verify ako"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pindai untuk verifikasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zeskanuj, aby mnie zweryfikować"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "scan om mij te verifiëren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "என்னைச் சரிபார்க்க ஸ்கேன் செய்யவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skanna för att verifiera mig"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مجھے تصدیق کرنے کیلئے اسکین کریں"
+          }
         }
       }
     },
@@ -22688,6 +33488,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "QR indisponível"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR 不可用"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มี QR"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR không khả dụng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang QR"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "qr tidak tersedia"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR niedostępny"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR niet beschikbaar"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR கிடைக்கவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR ej tillgänglig"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR دستیاب نہیں"
           }
         }
       }
@@ -22808,6 +33668,66 @@
             "state": "translated",
             "value": "Cola o conteúdo do QR para validar:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘貼 QR 內容以驗證："
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วางเนื้อหา QR เพื่อยืนยัน:"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dán nội dung QR để kiểm tra:"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-paste ang nilalaman ng QR para beripikahin:"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tempel konten qr untuk validasi:"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wklej zawartość QR, aby zweryfikować:"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "plak QR-inhoud om te valideren:"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்க்க QR உள்ளடக்கத்தை ஒட்டு:"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "klistra in QR-innehåll för att validera:"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیق کیلئے QR مواد چسپاں کریں:"
+          }
         }
       }
     },
@@ -22926,6 +33846,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Digitaliza o QR de um amigo"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描好友的 QR"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สแกน QR ของเพื่อน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "quét QR của bạn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i-scan ang QR ng kaibigan"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pindai qr teman"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zeskanuj QR znajomego"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "scan de QR van een vriend"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நண்பரின் QR ஐ ஸ்கேன் செய்யவும்"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "skanna en väns QR"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دوست کا QR اسکین کریں"
           }
         }
       }
@@ -23046,6 +34026,66 @@
             "state": "translated",
             "value": "payload de QR inválido ou expirado"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR 無效或已過期"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "payload ของ QR ไม่ถูกต้องหรือหมดอายุ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "payload QR không hợp lệ hoặc đã hết hạn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "di-wasto o paso na ang QR payload"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "qr tidak valid atau kedaluwarsa"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nieprawidłowy lub wygasły payload QR"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ongeldige of verlopen QR-payload"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரியானதல்ல அல்லது காலாவதியான QR payload"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ogiltig eller utgången QR-payload"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غلط یا میعاد ختم شدہ QR payload"
+          }
         }
       }
     },
@@ -23164,6 +34204,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "não foi possível encontrar o par correspondente"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到匹配的同伴"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบเพียร์ที่ตรงกัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "không tìm thấy nút phù hợp"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "walang nahanap na kaakibat na peer"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tidak ada peer yang cocok"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie znaleziono dopasowanego peera"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geen overeenkomende peer gevonden"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பொருந்தும் peer கிடைக்கவில்லை"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hittade ingen matchande peer"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملتا جلتا peer نہیں ملا"
           }
         }
       }
@@ -23284,6 +34384,66 @@
             "state": "translated",
             "value": "verificação solicitada para %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已請求 %@ 的驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ร้องขอยืนยันสำหรับ %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "đã yêu cầu xác minh cho %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "humiling ng beripikasyon para kay %@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifikasi diminta untuk %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "poproszono o weryfikację %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verificatie aangevraagd voor %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ க்கான சரிபார்ப்பு கோரப்பட்டுள்ளது"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifiering begärd för %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کیلئے تصدیق کی درخواست کی گئی"
+          }
         }
       }
     },
@@ -23402,6 +34562,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "validar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยืนยัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "xác minh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beripikahin"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "validasi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zweryfikuj"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifiëren"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்க்க"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "verifiera"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیق کریں"
           }
         }
       }
@@ -23522,6 +34742,66 @@
             "state": "translated",
             "value": "VERIFICAR"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "驗證"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยืนยัน"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XÁC MINH"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BERIPIKA"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VERIFIKASI"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WERYFIKACJA"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VERIFICATIE"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "சரிபார்ப்பு"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VERIFIERA"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدیق"
+          }
         }
       }
     },
@@ -23639,6 +34919,66 @@
           }
         },
         "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ur": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -99,6 +99,12 @@
             "state": "translated",
             "value": "bitchat"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
         }
       }
     },
@@ -199,6 +205,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বন্ধ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद करें"
           }
         }
       }
@@ -301,6 +313,12 @@
             "state": "translated",
             "value": "সম্পন্ন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समाप्त"
+          }
         }
       }
     },
@@ -401,6 +419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "গোপন বার্তাগুলো নোইজ প্রোটোকলের মাধ্যমে এনক্রিপ্ট করা হয়"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नॉइज़ प्रोटोकॉल से निजी संदेश एन्क्रिप्ट किए जाते हैं"
           }
         }
       }
@@ -503,6 +527,12 @@
             "state": "translated",
             "value": "এন্ড-টু-এন্ড এনক্রিপশন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एंड-टू-एंड एन्क्रिप्शन"
+          }
         }
       }
     },
@@ -603,6 +633,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বার্তাগুলো সহ-পিয়ারদের মাধ্যমে রিলে হয়ে দূরেও পৌঁছে যায়"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश साथियों के माध्यम से रिले होकर दूर तक पहुँचते हैं"
           }
         }
       }
@@ -705,6 +741,12 @@
             "state": "translated",
             "value": "বর্ধিত পরিসর"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विस्तारित दायरा"
+          }
         }
       }
     },
@@ -805,6 +847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "আপনার প্রিয় মানুষ যোগ দিলে বিজ্ঞপ্তি পান"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जब आपके पसंदीदा लोग जुड़ें तो सूचना पाएं"
           }
         }
       }
@@ -907,6 +955,12 @@
             "state": "translated",
             "value": "প্রিয়সমূহ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा"
+          }
         }
       }
     },
@@ -1007,6 +1061,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ডিসেন্ট্রালাইজড বেনামি রিলে দিয়ে কাছাকাছি অঞ্চলের মানুষের সাথে কথা বলার জন্য জিওহ্যাশ চ্যানেল"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विकेंद्रीकृत गुमनाम रिले के माध्यम से आसपास के क्षेत्रों के लोगों से चैट करने के लिए जियोहैश चैनल"
           }
         }
       }
@@ -1109,6 +1169,12 @@
             "state": "translated",
             "value": "স্থানীয় চ্যানেল"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्थानीय चैनल"
+          }
         }
       }
     },
@@ -1209,6 +1275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নির্দিষ্ট কাউকে জানানোর জন্য @nickname ব্যবহার করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विशेष लोगों को सूचित करने के लिए @nickname उपयोग करें"
           }
         }
       }
@@ -1311,6 +1383,12 @@
             "state": "translated",
             "value": "মেনশন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेंशन"
+          }
         }
       }
     },
@@ -1411,6 +1489,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ব্লুটুথ লো এনার্জি ব্যবহার করে ইন্টারনেট ছাড়াই কাজ করে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लूटूथ लो एनर्जी से इंटरनेट बिना भी काम करता है"
           }
         }
       }
@@ -1513,6 +1597,12 @@
             "state": "translated",
             "value": "অফলাইন যোগাযোগ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑफलाइन संचार"
+          }
         }
       }
     },
@@ -1613,6 +1703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বৈশিষ্ট্য"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विशेषताएँ"
           }
         }
       }
@@ -1715,6 +1811,12 @@
             "state": "translated",
             "value": "• চ্যানেল বদলাতে #mesh ট্যাপ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• चैनल बदलने के लिए #mesh टैप करें"
+          }
         }
       }
     },
@@ -1815,6 +1917,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• চ্যাট মুছতে তিনবার ট্যাপ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• चैट साफ़ करने के लिए तीन बार टैप करें"
           }
         }
       }
@@ -1917,6 +2025,12 @@
             "state": "translated",
             "value": "• কমান্ডের জন্য / টাইপ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• कमांड के लिए / टाइप करें"
+          }
         }
       }
     },
@@ -2017,6 +2131,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• সাইডবার খুলতে মানুষ আইকনে ট্যাপ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• साइडबार खोलने के लिए लोगों वाले आइकन पर टैप करें"
           }
         }
       }
@@ -2119,6 +2239,12 @@
             "state": "translated",
             "value": "• আপনার ডাকনামে ট্যাপ করে সেট করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• अपना उपनाम टैप करके सेट करें"
+          }
         }
       }
     },
@@ -2219,6 +2345,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• ডিএম শুরু করতে পিয়ারের নাম ট্যাপ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• किसी पीयर का नाम टैप करके DM शुरू करें"
           }
         }
       }
@@ -2321,6 +2453,12 @@
             "state": "translated",
             "value": "ব্যবহারের নিয়ম"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपयोग कैसे करें"
+          }
         }
       }
     },
@@ -2421,6 +2559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নিয়মিত নতুন পিয়ার আইডি তৈরি হয়"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नया पीयर आईडी नियमित रूप से बनाया जाता है"
           }
         }
       }
@@ -2523,6 +2667,12 @@
             "state": "translated",
             "value": "অস্থায়ী পরিচয়"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अस्थायी पहचान"
+          }
         }
       }
     },
@@ -2623,6 +2773,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কোনো সার্ভার, অ্যাকাউন্ট বা ডেটা সংগ্রহ নেই"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई सर्वर, खाते या डेटा संग्रह नहीं"
           }
         }
       }
@@ -2725,6 +2881,12 @@
             "state": "translated",
             "value": "ট্র্যাকিং নেই"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ट्रैकिंग नहीं"
+          }
         }
       }
     },
@@ -2825,6 +2987,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোগোতে তিনবার ট্যাপ করলে সঙ্গে সঙ্গে সব ডেটা মুছে যাবে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोगो पर तीन बार टैप करें और तुरंत सारा डेटा साफ़ करें"
           }
         }
       }
@@ -2927,6 +3095,12 @@
             "state": "translated",
             "value": "প্যানিক মোড"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पैनिक मोड"
+          }
         }
       }
     },
@@ -3028,6 +3202,12 @@
             "state": "translated",
             "value": "গোপনীয়তা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोपनीयता"
+          }
         }
       }
     },
@@ -3125,6 +3305,12 @@
           }
         },
         "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "hi": {
           "stringUnit": {
             "state": "translated",
             "value": "sidegroupchat"
@@ -3230,6 +3416,12 @@
             "state": "translated",
             "value": "ব্যক্তিগত বার্তার নিরাপত্তা এখনো সম্পূর্ণ অডিট হয়নি। এই সতর্কতা না থাকা পর্যন্ত জরুরি পরিস্থিতিতে ব্যবহার করবেন না।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निजी संदेश सुरक्षा का अभी पूरा ऑडिट नहीं हुआ है। यह चेतावनी हटने तक गंभीर स्थितियों में उपयोग न करें।"
+          }
         }
       }
     },
@@ -3330,6 +3522,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "সতর্কতা"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चेतावनी"
           }
         }
       }
@@ -3432,6 +3630,12 @@
             "state": "translated",
             "value": "বাতিল"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
+          }
         }
       }
     },
@@ -3532,6 +3736,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বন্ধ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद करें"
           }
         }
       }
@@ -3634,6 +3844,12 @@
             "state": "translated",
             "value": "কপি করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी करें"
+          }
         }
       }
     },
@@ -3734,6 +3950,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ঠিক আছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
           }
         }
       }
@@ -3836,6 +4058,12 @@
             "state": "translated",
             "value": "বন্ধ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद"
+          }
         }
       }
     },
@@ -3936,6 +4164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "চালু"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चालू"
           }
         }
       }
@@ -4038,6 +4272,12 @@
             "state": "translated",
             "value": "অজানা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अज्ञात"
+          }
         }
       }
     },
@@ -4138,6 +4378,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "প্রিয়তে যোগ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा में जोड़ें"
           }
         }
       }
@@ -4240,6 +4486,12 @@
             "state": "translated",
             "value": "নোস্টরে উপলব্ধ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोस्ट्र पर उपलब्ध"
+          }
         }
       }
     },
@@ -4340,6 +4592,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "মুখ্য চ্যাটে ফিরুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मुख्य चैट पर वापस"
           }
         }
       }
@@ -4442,6 +4700,12 @@
             "state": "translated",
             "value": "মেশের মাধ্যমে সংযুক্ত"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेश से जुड़ा"
+          }
         }
       }
     },
@@ -4542,6 +4806,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপশনের অবস্থা: %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन स्थिति: %@"
           }
         }
       }
@@ -4644,6 +4914,12 @@
             "state": "translated",
             "value": "অবস্থান চ্যানেল"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन चैनल"
+          }
         }
       }
     },
@@ -4745,6 +5021,12 @@
             "state": "translated",
             "value": "এই স্থানের লোকেশন নোট"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस स्थान के लोकेशन नोट"
+          }
         }
       }
     },
@@ -4845,6 +5127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "না পড়া ব্যক্তিগত চ্যাট খুলুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपठित निजी चैट खोलें"
           }
         }
       }
@@ -5331,6 +5619,12 @@
             "state": "translated",
             "value": "%#@people@"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
         }
       }
     },
@@ -5431,6 +5725,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-এর সঙ্গে ব্যক্তিগত চ্যাট"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ के साथ निजी चैट"
           }
         }
       }
@@ -5533,6 +5833,12 @@
             "state": "translated",
             "value": "মেশের মাধ্যমে পৌঁছানো সম্ভব"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेश के माध्यम से पहुंच योग्य"
+          }
         }
       }
     },
@@ -5633,6 +5939,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "প্রিয় থেকে সরান"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा से हटाएँ"
           }
         }
       }
@@ -5735,6 +6047,12 @@
             "state": "translated",
             "value": "বার্তা পাঠাতে একটি বার্তা লিখুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश भेजने के लिए संदेश लिखें"
+          }
         }
       }
     },
@@ -5835,6 +6153,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "পাঠাতে দুইবার ট্যাপ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भेजने के लिए डबल टैप करें"
           }
         }
       }
@@ -5937,6 +6261,12 @@
             "state": "translated",
             "value": "বার্তা পাঠান"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश भेजें"
+          }
         }
       }
     },
@@ -6037,6 +6367,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#%@-এর জন্য বুকমার্ক টগল করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ के लिए बुकमार्क टॉगल करें"
           }
         }
       }
@@ -6139,6 +6475,12 @@
             "state": "translated",
             "value": "প্রিয় অবস্থা বদলাতে দুইবার ট্যাপ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा स्थिति बदलने के लिए डबल टैप करें"
+          }
         }
       }
     },
@@ -6239,6 +6581,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপশন ফিঙ্গারপ্রিন্ট দেখতে ট্যাপ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन फिंगरप्रिंट देखने के लिए टैप करें"
           }
         }
       }
@@ -6341,6 +6689,12 @@
             "state": "translated",
             "value": "ব্লক করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लॉक करें"
+          }
         }
       }
     },
@@ -6441,6 +6795,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ডিরেক্ট মেসেজ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डायरेक्ट संदेश"
           }
         }
       }
@@ -6543,6 +6903,12 @@
             "state": "translated",
             "value": "আলিঙ্গন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गले लगाएँ"
+          }
         }
       }
     },
@@ -6643,6 +7009,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "মেনশন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेंशन करें"
           }
         }
       }
@@ -6745,6 +7117,12 @@
             "state": "translated",
             "value": "চপেটাঘাত"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थप्पड़ मारें"
+          }
         }
       }
     },
@@ -6845,6 +7223,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "অ্যাকশন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्रियाएँ"
           }
         }
       }
@@ -6947,6 +7331,12 @@
             "state": "translated",
             "value": "ব্লুটুথ বন্ধ আছে। bitchat ব্যবহার করতে সেটিংসে ব্লুটুথ চালু করুন।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लूटूथ बंद है। bitchat उपयोग करने के लिए सेटिंग्स में ब्लूटूथ चालू करें।"
+          }
         }
       }
     },
@@ -7047,6 +7437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নিকটবর্তী ডিভাইসের সাথে যুক্ত হতে bitchat-এর ব্লুটুথ অনুমতি দরকার। দয়া করে সেটিংসে ব্লুটুথ অ্যাক্সেস সক্রিয় করুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat को पास के उपकरणों से जुड़ने के लिए ब्लूटूथ अनुमति चाहिए। कृपया सेटिंग्स में ब्लूटूथ एक्सेस सक्षम करें।"
           }
         }
       }
@@ -7149,6 +7545,12 @@
             "state": "translated",
             "value": "সেটিংস"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स"
+          }
         }
       }
     },
@@ -7249,6 +7651,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ব্লুটুথ প্রয়োজন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लूटूथ आवश्यक"
           }
         }
       }
@@ -7351,6 +7759,12 @@
             "state": "translated",
             "value": "এই ডিভাইস ব্লুটুথ সমর্থন করে না। bitchat চালাতে ব্লুটুথ দরকার।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह डिवाइस ब्लूटूथ समर्थित नहीं है। bitchat चलाने के लिए ब्लूटूथ जरूरी है।"
+          }
         }
       }
     },
@@ -7451,6 +7865,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোকেশন চ্যানেলের স্ক্রিনশট আপনার অবস্থান প্রকাশ করবে। প্রকাশ করার আগে ভেবে দেখুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन चैनलों के स्क्रीनशॉट आपकी लोकेशन प्रकट करेंगे। सार्वजनिक रूप से साझा करने से पहले सोचें।"
           }
         }
       }
@@ -7553,6 +7973,12 @@
             "state": "translated",
             "value": "সতর্কতা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ध्यान दें"
+          }
         }
       }
     },
@@ -7653,6 +8079,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ব্লক বা ব্লক করা পিয়ারদের তালিকা দেখুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लॉक करें या ब्लॉक पीयरों की सूची देखें"
           }
         }
       }
@@ -7755,6 +8187,12 @@
             "state": "translated",
             "value": "চ্যাট মেসেজ মুছে দিন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चैट संदेश साफ़ करें"
+          }
         }
       }
     },
@@ -7855,6 +8293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "প্রিয়তে যোগ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा में जोड़ें"
           }
         }
       }
@@ -7957,6 +8401,12 @@
             "state": "translated",
             "value": "কাউকে উষ্ণ আলিঙ্গন পাঠান"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी को गर्म आलिंगन भेजें"
+          }
         }
       }
     },
@@ -8057,6 +8507,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ব্যক্তিগত বার্তা পাঠান"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निजी संदेश भेजें"
           }
         }
       }
@@ -8159,6 +8615,12 @@
             "state": "translated",
             "value": "কারওকে ট্রাউট মাছ দিয়ে চপেটাঘাত করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी को ट्राउट से थप्पड़ मारें"
+          }
         }
       }
     },
@@ -8259,6 +8721,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কাউকে আনব্লক করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी पीयर को अनब्लॉक करें"
           }
         }
       }
@@ -8361,6 +8829,12 @@
             "state": "translated",
             "value": "প্রিয় থেকে সরিয়ে দিন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पसंदीदा से हटाएँ"
+          }
         }
       }
     },
@@ -8461,6 +8935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কে অনলাইনে আছে দেখুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कौन ऑनलाइन है देखें"
           }
         }
       }
@@ -8563,6 +9043,12 @@
             "state": "translated",
             "value": "%2$d জন সদস্যের মধ্যে %1$d জনের কাছে পৌঁছেছে"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d सदस्यों में से %1$d को पहुँचाया"
+          }
         }
       }
     },
@@ -8663,6 +9149,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-এর কাছে পৌঁছেছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को पहुँचाया"
           }
         }
       }
@@ -8765,6 +9257,12 @@
             "state": "translated",
             "value": "ব্যর্থ: %@"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विफल: %@"
+          }
         }
       }
     },
@@ -8865,6 +9363,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ পড়েছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ने पढ़ा"
           }
         }
       }
@@ -8967,6 +9471,12 @@
             "state": "translated",
             "value": "ব্যবহারকারী ব্লক করা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपयोगकर्ता ब्लॉक है"
+          }
         }
       }
     },
@@ -9067,6 +9577,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নিজেকে বার্তা পাঠানো যায় না"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "खुद को संदेश नहीं भेज सकते"
           }
         }
       }
@@ -9169,6 +9685,12 @@
             "state": "translated",
             "value": "পাঠাতে ত্রুটি"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भेजने में त्रुटि"
+          }
         }
       }
     },
@@ -9269,6 +9791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "অজানা প্রাপক"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अज्ञात प्राप्तकर्ता"
           }
         }
       }
@@ -9371,6 +9899,12 @@
             "state": "translated",
             "value": "পিয়ার পৌঁছানো যাচ্ছে না"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पीयर पहुंच योग्य नहीं"
+          }
         }
       }
     },
@@ -9471,6 +10005,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "মানুষ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोग"
           }
         }
       }
@@ -9573,6 +10113,12 @@
             "state": "translated",
             "value": "যাচাই: আমার QR দেখান বা বন্ধুরটি স্ক্যান করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापन: मेरा QR दिखाएँ या मित्र का स्कैन करें"
+          }
         }
       }
     },
@@ -9673,6 +10219,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "একটি বার্তা লিখুন..."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश लिखें..."
           }
         }
       }
@@ -9775,6 +10327,12 @@
             "state": "translated",
             "value": "ডাকনাম"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपनाम"
+          }
         }
       }
     },
@@ -9875,6 +10433,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোকেশন চালু করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन सक्षम करें"
           }
         }
       }
@@ -9977,6 +10541,12 @@
             "state": "translated",
             "value": "বার্তা কপি করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश कॉपी करें"
+          }
         }
       }
     },
@@ -10077,6 +10647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কম দেখান"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कम दिखाएँ"
           }
         }
       }
@@ -10179,6 +10755,12 @@
             "state": "translated",
             "value": "আরও দেখান"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "और दिखाएँ"
+          }
         }
       }
     },
@@ -10279,6 +10861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "অবস্থান অনুপলব্ধ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन उपलब्ध नहीं"
           }
         }
       }
@@ -10381,6 +10969,12 @@
             "state": "translated",
             "value": "নোট"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोट्स"
+          }
         }
       }
     },
@@ -10481,6 +11075,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ক্যাশু দিয়ে পরিশোধ করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कैशु से भुगतान करें"
           }
         }
       }
@@ -10583,6 +11183,12 @@
             "state": "translated",
             "value": "লাইটনিং দিয়ে পরিশোধ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइटनिंग से भुगतान करें"
+          }
         }
       }
     },
@@ -10683,6 +11289,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপশন স্থাপিত হচ্ছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन स्थापित हो रहा है"
           }
         }
       }
@@ -10785,6 +11397,12 @@
             "state": "translated",
             "value": "এনক্রিপশন ব্যর্থ হয়েছে"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन विफल हुआ"
+          }
         }
       }
     },
@@ -10885,6 +11503,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপ্ট করা নেই"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्ट नहीं"
           }
         }
       }
@@ -10987,6 +11611,12 @@
             "state": "translated",
             "value": "এনক্রিপ্ট করা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्टेड"
+          }
         }
       }
     },
@@ -11087,6 +11717,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপ্ট ও যাচাইকৃত"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्टेड और सत्यापित"
           }
         }
       }
@@ -11189,6 +11825,12 @@
             "state": "translated",
             "value": "এনক্রিপশন স্থাপিত হচ্ছে..."
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन स्थापित हो रहा है..."
+          }
         }
       }
     },
@@ -11289,6 +11931,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপশন ব্যর্থ হয়েছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्शन विफल हुआ"
           }
         }
       }
@@ -11391,6 +12039,12 @@
             "state": "translated",
             "value": "এনক্রিপ্ট করা নেই"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्ट नहीं"
+          }
         }
       }
     },
@@ -11491,6 +12145,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এনক্রিপ্ট করা"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्टेड"
           }
         }
       }
@@ -11593,6 +12253,12 @@
             "state": "translated",
             "value": "এনক্রিপ্ট করা ও যাচাইকৃত"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एन्क्रिप्टेड और सत्यापित"
+          }
         }
       }
     },
@@ -11693,6 +12359,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "যাচাইকৃত হিসেবে চিহ্নিত করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापित के रूप में चिह्नित करें"
           }
         }
       }
@@ -11795,6 +12467,12 @@
             "state": "translated",
             "value": "যাচাইকরণ সরান"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापन हटाएँ"
+          }
         }
       }
     },
@@ -11895,6 +12573,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ যাচাইকৃত নয়"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ सत्यापित नहीं"
           }
         }
       }
@@ -11997,6 +12681,12 @@
             "state": "translated",
             "value": "✓ যাচাইকৃত"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ सत्यापित"
+          }
         }
       }
     },
@@ -12097,6 +12787,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "উপলব্ধ নয় - হ্যান্ডশেক চলছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपलब्ध नहीं - हैंडशेक जारी है"
           }
         }
       }
@@ -12199,6 +12895,12 @@
             "state": "translated",
             "value": "আপনি এই ব্যক্তির পরিচয় যাচাই করেছেন।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपने इस व्यक्ति की पहचान सत्यापित की है।"
+          }
         }
       }
     },
@@ -12299,6 +13001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নিরাপদ চ্যানেলে %@-এর সঙ্গে এই ফিঙ্গারপ্রিন্ট মিলিয়ে দেখুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इन फिंगरप्रिंट्स की तुलना %@ से सुरक्षित चैनल पर करें।"
           }
         }
       }
@@ -12401,6 +13109,12 @@
             "state": "translated",
             "value": "তাদের ফিঙ্গারপ্রিন্ট:"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उनका फिंगरप्रिंट:"
+          }
         }
       }
     },
@@ -12501,6 +13215,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নিরাপত্তা যাচাই"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुरक्षा सत्यापन"
           }
         }
       }
@@ -12603,6 +13323,12 @@
             "state": "translated",
             "value": "আপনার ফিঙ্গারপ্রিন্ট:"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपका फिंगरप्रिंट:"
+          }
         }
       }
     },
@@ -12703,6 +13429,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ব্লক করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लॉक करें"
           }
         }
       }
@@ -12805,6 +13537,12 @@
             "state": "translated",
             "value": "আনব্লক করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अनब्लॉक करें"
+          }
         }
       }
     },
@@ -12905,6 +13643,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কাছে কেউ নেই..."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आसपास कोई नहीं..."
           }
         }
       }
@@ -13007,6 +13751,12 @@
             "state": "translated",
             "value": "জিওহ্যাশে ব্লক করা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जियोहैश में ब्लॉक"
+          }
         }
       }
     },
@@ -13107,6 +13857,12 @@
           "stringUnit": {
             "state": "translated",
             "value": " (আপনি)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (आप)"
           }
         }
       }
@@ -13209,6 +13965,12 @@
             "state": "translated",
             "value": "সেটিংস খুলুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
+          }
         }
       }
     },
@@ -13309,6 +14071,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোকেশন অ্যাক্সেস সরান"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन एक्सेस हटाएँ"
           }
         }
       }
@@ -13411,6 +14179,12 @@
             "state": "translated",
             "value": "লোকেশন অনুমতি ও আমার জিওহ্যাশ নিন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन अनुमति और मेरे जियोहैश प्राप्त करें"
+          }
         }
       }
     },
@@ -13511,6 +14285,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "টেলিপোর্ট"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेलीपोर्ट"
           }
         }
       }
@@ -13613,6 +14393,12 @@
             "state": "translated",
             "value": "বুকমার্ক করা"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बुकमार्क की गई"
+          }
         }
       }
     },
@@ -13713,6 +14499,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "জিওহ্যাশ চ্যানেল দিয়ে কাছাকাছি অঞ্চলের মানুষের সঙ্গে চ্যাট করুন। শুধুই স্থূল জিওহ্যাশ শেয়ার হয়, কখনো সঠিক GPS নয়। আপনার IP টর দিয়ে সব ট্রাফিক রাউট করে লুকানো থাকে।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जियोहैश चैनलों से आसपास के लोगों से चैट करें। केवल मोटा जियोहैश साझा होता है, कभी सटीक GPS नहीं। आपका IP सारा ट्रैफ़िक Tor से रूट कर छिपा रहता है।"
           }
         }
       }
@@ -13815,6 +14607,12 @@
             "state": "translated",
             "value": "অবৈধ জিওহ্যাশ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अमान्य जियोहैश"
+          }
         }
       }
     },
@@ -13915,6 +14713,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কাছাকাছি চ্যানেল খোঁজা হচ্ছে…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पास के चैनल खोजे जा रहे हैं…"
           }
         }
       }
@@ -14017,6 +14821,12 @@
             "state": "translated",
             "value": "মেশ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेश"
+          }
         }
       }
     },
@@ -14117,6 +14927,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোকেশন অনুমতি অস্বীকৃত। লোকেশন চ্যানেল ব্যবহার করতে সেটিংসে সক্রিয় করুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन अनुमति अस्वीकृत। लोकेशन चैनल उपयोग करने के लिए सेटिंग्स में सक्षम करें।"
           }
         }
       }
@@ -14603,6 +15419,12 @@
             "state": "translated",
             "value": "%1$@ [%2$#@people_count@]"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
         }
       }
     },
@@ -14700,6 +15522,12 @@
           }
         },
         "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "hi": {
           "stringUnit": {
             "state": "translated",
             "value": "#%1$@ • %2$@"
@@ -14805,6 +15633,12 @@
             "state": "translated",
             "value": "%1$@ • %2$@"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
         }
       }
     },
@@ -14905,6 +15739,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#লোকেশন চ্যানেল"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#लोकेशन चैनल"
           }
         }
       }
@@ -15007,6 +15847,12 @@
             "state": "translated",
             "value": "লোকেশন চ্যানেলের জন্য আপনার IP লুকায়। সুপারিশ: চালু রাখুন।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन चैनलों के लिए आपका IP छुपाता है। अनुशंसित: चालू रखें।"
+          }
         }
       }
     },
@@ -15107,6 +15953,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor রাউটিং"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor रूटिंग"
           }
         }
       }
@@ -15209,6 +16061,12 @@
             "state": "translated",
             "value": "ব্লক"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ब्लॉक"
+          }
         }
       }
     },
@@ -15309,6 +16167,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ভবন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भवन"
           }
         }
       }
@@ -15411,6 +16275,12 @@
             "state": "translated",
             "value": "শহর"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शहर"
+          }
         }
       }
     },
@@ -15511,6 +16381,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "পাড়া"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पड़ोस"
           }
         }
       }
@@ -15613,6 +16489,12 @@
             "state": "translated",
             "value": "প্রদেশ"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रांत"
+          }
         }
       }
     },
@@ -15713,6 +16595,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "অঞ্চল"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्षेत्र"
           }
         }
       }
@@ -15815,6 +16703,12 @@
             "state": "translated",
             "value": "বন্ধ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद करें"
+          }
         }
       }
     },
@@ -15915,6 +16809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "আবার চেষ্টা করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फिर प्रयास करें"
           }
         }
       }
@@ -16017,6 +16917,12 @@
             "state": "translated",
             "value": "এই স্থানে অন্যরা খুঁজে পেতে পারে এমন ছোট স্থায়ী নোট যোগ করুন।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस स्थान के लिए अन्य आगंतुकों को मिलने वाले छोटे स्थायी नोट जोड़ें।"
+          }
         }
       }
     },
@@ -16117,6 +17023,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এই জায়গার জন্য প্রথম নোট যোগ করুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस जगह के लिए पहला नोट आप जोड़ें।"
           }
         }
       }
@@ -16219,6 +17131,12 @@
             "state": "translated",
             "value": "এখনও কোনো নোট নেই"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अभी कोई नोट नहीं"
+          }
         }
       }
     },
@@ -16320,6 +17238,12 @@
             "state": "translated",
             "value": "নোট পাঠাতে ব্যর্থ। %@"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोट भेजने में विफल। %@"
+          }
         }
       }
     },
@@ -16420,6 +17344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "এই স্থানের কাছে কোনো জিও রিলে নেই। কিছুক্ষণ পরে আবার চেষ্টা করুন।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस स्थान के पास कोई जियो रिले उपलब्ध नहीं। कुछ देर बाद फिर प्रयास करें।"
           }
         }
       }
@@ -16906,6 +17836,12 @@
             "state": "translated",
             "value": "#%1$@ • %2$#@note_count@"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
         }
       }
     },
@@ -17006,6 +17942,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নোট লোড হচ্ছে…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोट लोड हो रहे हैं…"
           }
         }
       }
@@ -17108,6 +18050,12 @@
             "state": "translated",
             "value": "সাম্প্রতিক নোট লোড হচ্ছে…"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हाल के नोट लोड हो रहे हैं…"
+          }
         }
       }
     },
@@ -17208,6 +18156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "কাছে কোনো জিও রিলে নেই"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पास कोई जियो रिले नहीं"
           }
         }
       }
@@ -17310,6 +18264,12 @@
             "state": "translated",
             "value": "এই স্থানের জন্য একটি নোট যোগ করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस स्थान के लिए नोट जोड़ें"
+          }
         }
       }
     },
@@ -17410,6 +18370,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "জিও রিলে অনুপলব্ধ; নোট স্থগিত"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जियो रिले अनुपलब्ध; नोट रुके हैं"
           }
         }
       }
@@ -17512,6 +18478,12 @@
             "state": "translated",
             "value": "নোট জিও রিলের উপর নির্ভরশীল। সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नोट जियो रिले पर निर्भर हैं। कनेक्शन जांचें और फिर प्रयास करें।"
+          }
         }
       }
     },
@@ -17612,6 +18584,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "নতুন বার্তা"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नए संदेश"
           }
         }
       }
@@ -17714,6 +18692,12 @@
             "state": "translated",
             "value": "%@-এর সঙ্গে চ্যাট শুরু করা যায় না: ব্যক্তি ব্লক করা আছে।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ के साथ चैट शुरू नहीं कर सकते: व्यक्ति ब्लॉक है।"
+          }
         }
       }
     },
@@ -17814,6 +18798,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-এর সঙ্গে চ্যাট শুরু করা যায় না: অফলাইন মেসেজিংয়ের জন্য পারস্পরিক প্রিয় দরকার।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ के साथ चैट शुरू नहीं कर सकते: ऑफ़लाइन मैसेजिंग के लिए आपसी पसंदीदा आवश्यक है।"
           }
         }
       }
@@ -17916,6 +18906,12 @@
             "state": "translated",
             "value": "ব্যবহারকারী"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उपयोगकर्ता"
+          }
         }
       }
     },
@@ -18016,6 +19012,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বার্তা পাঠানো যায় না: ব্যক্তি ব্লক করা আছে।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संदेश नहीं भेज सकते: व्यक्ति ब्लॉक है।"
           }
         }
       }
@@ -18118,6 +19120,12 @@
             "state": "translated",
             "value": "%@-কে বার্তা পাঠানো যায় না: ব্যক্তি ব্লক করা আছে।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को संदेश नहीं भेज सकते: व्यक्ति ब्लॉक है।"
+          }
         }
       }
     },
@@ -18218,6 +19226,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@-কে বার্তা পাঠানো যায় না - পিয়ার মেশ বা নোস্টরে পৌঁছানো যাচ্ছে না।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को संदेश नहीं भेज सकते - पीयर मेश या नोस्ट्र पर पहुँच योग्य नहीं।"
           }
         }
       }
@@ -18320,6 +19334,12 @@
             "state": "translated",
             "value": "জিওহ্যাশ চ্যাটে %@ ব্লক করা হয়েছে"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जियोहैश चैट में %@ ब्लॉक किया गया"
+          }
         }
       }
     },
@@ -18420,6 +19440,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "জিওহ্যাশ চ্যাটে %@ আনব্লক করা হয়েছে"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जियोहैश चैट में %@ अनब्लॉक किया गया"
           }
         }
       }
@@ -18522,6 +19548,12 @@
             "state": "translated",
             "value": "পাঠানো যায় না: লোকেশন চ্যানেলে নেই"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भेज नहीं सकते: लोकेशन चैनल में नहीं हैं"
+          }
         }
       }
     },
@@ -18622,6 +19654,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "লোকেশন চ্যানেলে পাঠাতে ব্যর্থ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लोकेशन चैनल पर भेजना विफल"
           }
         }
       }
@@ -18724,6 +19762,12 @@
             "state": "translated",
             "value": "ডেভেলপমেন্ট বিল্ড: Tor বাইপাস সক্রিয়।"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डेवलपमेंट बिल्ड: Tor बायपास सक्षम।"
+          }
         }
       }
     },
@@ -18824,6 +19868,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor পুনরায় চালু হয়েছে। নেটওয়ার্ক রাউটিং পুনরুদ্ধার হয়েছে।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor पुनः आरंभ हो गया। नेटवर्क रूटिंग बहाल।"
           }
         }
       }
@@ -18926,6 +19976,12 @@
             "state": "translated",
             "value": "Tor সংযোগ ফিরিয়ে আনতে পুনরায় চালু হচ্ছে..."
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कनेक्टिविटी बहाल करने के लिए Tor पुनः आरंभ हो रहा है..."
+          }
         }
       }
     },
@@ -19026,6 +20082,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor চালু হয়েছে। IP গোপন রাখতে সব চ্যাট Tor দিয়ে যাচ্ছে।"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor शुरू हो गया। IP गोपनीयता के लिए सभी चैट Tor से रूट हो रहे हैं।"
           }
         }
       }
@@ -19128,6 +20190,12 @@
             "state": "translated",
             "value": "Tor চালু হচ্ছে..."
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor शुरू हो रहा है..."
+          }
         }
       }
     },
@@ -19228,6 +20296,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "যাচাই QR কোড"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापन QR कोड"
           }
         }
       }
@@ -19330,6 +20404,12 @@
             "state": "translated",
             "value": "আমাকে যাচাই করতে স্ক্যান করুন"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मुझे सत्यापित करने के लिए स्कैन करें"
+          }
         }
       }
     },
@@ -19430,6 +20510,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "QR অনুপলব্ধ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR उपलब्ध नहीं"
           }
         }
       }
@@ -19532,6 +20618,12 @@
             "state": "translated",
             "value": "যাচাই করতে QR বিষয়বস্তু পেস্ট করুন:"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापित करने के लिए QR सामग्री पेस्ट करें:"
+          }
         }
       }
     },
@@ -19632,6 +20724,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "বন্ধুর QR স্ক্যান করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मित्र का QR स्कैन करें"
           }
         }
       }
@@ -19734,6 +20832,12 @@
             "state": "translated",
             "value": "অবৈধ বা মেয়াদোত্তীর্ণ QR পেলোড"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अमान्य या समाप्त हुआ QR पेलोड"
+          }
         }
       }
     },
@@ -19834,6 +20938,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "মিলে যাওয়া পিয়ার খুঁজে পাওয়া যায়নি"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मिलता-जुलता पीयर नहीं मिला"
           }
         }
       }
@@ -19936,6 +21046,12 @@
             "state": "translated",
             "value": "%@-এর জন্য যাচাই অনুরোধ করা হয়েছে"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ के लिए सत्यापन अनुरोध किया गया"
+          }
         }
       }
     },
@@ -20036,6 +21152,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "যাচাই করুন"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापित करें"
           }
         }
       }
@@ -20138,6 +21260,12 @@
             "state": "translated",
             "value": "যাচাই"
           }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सत्यापन"
+          }
         }
       }
     },
@@ -20237,6 +21365,12 @@
           }
         },
         "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "hi": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -105,6 +105,12 @@
             "state": "translated",
             "value": "bitchat"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat"
+          }
         }
       }
     },
@@ -211,6 +217,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "बंद करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kapat"
           }
         }
       }
@@ -319,6 +331,12 @@
             "state": "translated",
             "value": "समाप्त"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BİTTİ"
+          }
         }
       }
     },
@@ -425,6 +443,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "नॉइज़ प्रोटोकॉल से निजी संदेश एन्क्रिप्ट किए जाते हैं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "özel mesajlar noise protokolü ile şifrelenir"
           }
         }
       }
@@ -533,6 +557,12 @@
             "state": "translated",
             "value": "एंड-टू-एंड एन्क्रिप्शन"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uçtan uca şifreleme"
+          }
         }
       }
     },
@@ -639,6 +669,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "संदेश साथियों के माध्यम से रिले होकर दूर तक पहुँचते हैं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesajlar eşler üzerinden aktarılarak uzağa ulaşır"
           }
         }
       }
@@ -747,6 +783,12 @@
             "state": "translated",
             "value": "विस्तारित दायरा"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "genişletilmiş menzil"
+          }
         }
       }
     },
@@ -853,6 +895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "जब आपके पसंदीदा लोग जुड़ें तो सूचना पाएं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favori kişileriniz katıldığında bildirim alın"
           }
         }
       }
@@ -961,6 +1009,12 @@
             "state": "translated",
             "value": "पसंदीदा"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favoriler"
+          }
         }
       }
     },
@@ -1067,6 +1121,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "विकेंद्रीकृत गुमनाम रिले के माध्यम से आसपास के क्षेत्रों के लोगों से चैट करने के लिए जियोहैश चैनल"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "merkeziyetsiz anonim röleler üzerinden yakın bölgelerdeki insanlarla sohbet etmek için geohash kanalları"
           }
         }
       }
@@ -1175,6 +1235,12 @@
             "state": "translated",
             "value": "स्थानीय चैनल"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yerel kanallar"
+          }
         }
       }
     },
@@ -1281,6 +1347,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "विशेष लोगों को सूचित करने के लिए @nickname उपयोग करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "belirli kişileri bildirmek için @nickname kullanın"
           }
         }
       }
@@ -1389,6 +1461,12 @@
             "state": "translated",
             "value": "मेंशन"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bahsetmeler"
+          }
         }
       }
     },
@@ -1495,6 +1573,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ब्लूटूथ लो एनर्जी से इंटरनेट बिना भी काम करता है"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth Low Energy kullanarak internet olmadan çalışır"
           }
         }
       }
@@ -1603,6 +1687,12 @@
             "state": "translated",
             "value": "ऑफलाइन संचार"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "çevrimdışı iletişim"
+          }
         }
       }
     },
@@ -1709,6 +1799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "विशेषताएँ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ÖZELLİKLER"
           }
         }
       }
@@ -1817,6 +1913,12 @@
             "state": "translated",
             "value": "• चैनल बदलने के लिए #mesh टैप करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• kanalı değiştirmek için #mesh'e dokunun"
+          }
         }
       }
     },
@@ -1923,6 +2025,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• चैट साफ़ करने के लिए तीन बार टैप करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• sohbeti temizlemek için sohbete üç kez dokunun"
           }
         }
       }
@@ -2031,6 +2139,12 @@
             "state": "translated",
             "value": "• कमांड के लिए / टाइप करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• komutlar için / yazın"
+          }
         }
       }
     },
@@ -2137,6 +2251,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• साइडबार खोलने के लिए लोगों वाले आइकन पर टैप करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• kenar çubuğunu açmak için insan simgesine dokunun"
           }
         }
       }
@@ -2245,6 +2365,12 @@
             "state": "translated",
             "value": "• अपना उपनाम टैप करके सेट करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• takma adınızı üzerine dokunarak ayarlayın"
+          }
         }
       }
     },
@@ -2351,6 +2477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• किसी पीयर का नाम टैप करके DM शुरू करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• bir eşin adına dokunarak DM başlatın"
           }
         }
       }
@@ -2459,6 +2591,12 @@
             "state": "translated",
             "value": "उपयोग कैसे करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NASIL KULLANILIR"
+          }
         }
       }
     },
@@ -2565,6 +2703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "नया पीयर आईडी नियमित रूप से बनाया जाता है"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yeni eş kimliği düzenli olarak oluşturulur"
           }
         }
       }
@@ -2673,6 +2817,12 @@
             "state": "translated",
             "value": "अस्थायी पहचान"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geçici kimlik"
+          }
         }
       }
     },
@@ -2779,6 +2929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "कोई सर्वर, खाते या डेटा संग्रह नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sunucu, hesap veya veri toplama yok"
           }
         }
       }
@@ -2887,6 +3043,12 @@
             "state": "translated",
             "value": "ट्रैकिंग नहीं"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "izleme yok"
+          }
         }
       }
     },
@@ -2993,6 +3155,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोगो पर तीन बार टैप करें और तुरंत सारा डेटा साफ़ करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "logoya üç kez dokunun, tüm veriler anında silinsin"
           }
         }
       }
@@ -3101,6 +3269,12 @@
             "state": "translated",
             "value": "पैनिक मोड"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "panik modu"
+          }
         }
       }
     },
@@ -3208,6 +3382,12 @@
             "state": "translated",
             "value": "गोपनीयता"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GİZLİLİK"
+          }
         }
       }
     },
@@ -3311,6 +3491,12 @@
           }
         },
         "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidegroupchat"
+          }
+        },
+        "tr": {
           "stringUnit": {
             "state": "translated",
             "value": "sidegroupchat"
@@ -3422,6 +3608,12 @@
             "state": "translated",
             "value": "निजी संदेश सुरक्षा का अभी पूरा ऑडिट नहीं हुआ है। यह चेतावनी हटने तक गंभीर स्थितियों में उपयोग न करें।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "özel mesaj güvenliği henüz tamamen denetlenmedi. bu uyarı kaybolana kadar kritik durumlarda kullanmayın."
+          }
         }
       }
     },
@@ -3528,6 +3720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "चेतावनी"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UYARI"
           }
         }
       }
@@ -3636,6 +3834,12 @@
             "state": "translated",
             "value": "रद्द करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iptal"
+          }
         }
       }
     },
@@ -3742,6 +3946,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "बंद करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kapat"
           }
         }
       }
@@ -3850,6 +4060,12 @@
             "state": "translated",
             "value": "कॉपी करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kopyala"
+          }
         }
       }
     },
@@ -3956,6 +4172,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ठीक है"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TAMAM"
           }
         }
       }
@@ -4064,6 +4286,12 @@
             "state": "translated",
             "value": "बंद"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kapalı"
+          }
         }
       }
     },
@@ -4170,6 +4398,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "चालू"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "açık"
           }
         }
       }
@@ -4278,6 +4512,12 @@
             "state": "translated",
             "value": "अज्ञात"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bilinmiyor"
+          }
         }
       }
     },
@@ -4384,6 +4624,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पसंदीदा में जोड़ें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorilere ekle"
           }
         }
       }
@@ -4492,6 +4738,12 @@
             "state": "translated",
             "value": "नोस्ट्र पर उपलब्ध"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr üzerinden kullanılabilir"
+          }
         }
       }
     },
@@ -4598,6 +4850,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "मुख्य चैट पर वापस"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ana sohbete dön"
           }
         }
       }
@@ -4706,6 +4964,12 @@
             "state": "translated",
             "value": "मेश से जुड़ा"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh üzerinden bağlı"
+          }
         }
       }
     },
@@ -4812,6 +5076,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्शन स्थिति: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme durumu: %@"
           }
         }
       }
@@ -4920,6 +5190,12 @@
             "state": "translated",
             "value": "लोकेशन चैनल"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum kanalları"
+          }
         }
       }
     },
@@ -5027,6 +5303,12 @@
             "state": "translated",
             "value": "इस स्थान के लोकेशन नोट"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu yer için konum notları"
+          }
         }
       }
     },
@@ -5133,6 +5415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "अपठित निजी चैट खोलें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "okunmamış özel sohbeti aç"
           }
         }
       }
@@ -5625,6 +5913,12 @@
             "state": "translated",
             "value": "%#@people@"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@people@"
+          }
         }
       }
     },
@@ -5731,6 +6025,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ के साथ निजी चैट"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile özel sohbet"
           }
         }
       }
@@ -5839,6 +6139,12 @@
             "state": "translated",
             "value": "मेश के माध्यम से पहुंच योग्य"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh üzerinden ulaşılabilir"
+          }
         }
       }
     },
@@ -5945,6 +6251,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पसंदीदा से हटाएँ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorilerden kaldır"
           }
         }
       }
@@ -6053,6 +6365,12 @@
             "state": "translated",
             "value": "संदेश भेजने के लिए संदेश लिखें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bir mesaj göndermek için metin girin"
+          }
         }
       }
     },
@@ -6159,6 +6477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "भेजने के लिए डबल टैप करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "göndermek için çift dokunun"
           }
         }
       }
@@ -6267,6 +6591,12 @@
             "state": "translated",
             "value": "संदेश भेजें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesaj gönder"
+          }
         }
       }
     },
@@ -6373,6 +6703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#%@ के लिए बुकमार्क टॉगल करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%@ için yer işaretini değiştir"
           }
         }
       }
@@ -6481,6 +6817,12 @@
             "state": "translated",
             "value": "पसंदीदा स्थिति बदलने के लिए डबल टैप करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favori durumunu değiştirmek için çift dokunun"
+          }
         }
       }
     },
@@ -6587,6 +6929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्शन फिंगरप्रिंट देखने के लिए टैप करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme parmak izini görmek için dokunun"
           }
         }
       }
@@ -6695,6 +7043,12 @@
             "state": "translated",
             "value": "ब्लॉक करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "engelle"
+          }
         }
       }
     },
@@ -6801,6 +7155,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "डायरेक्ट संदेश"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrudan mesaj"
           }
         }
       }
@@ -6909,6 +7269,12 @@
             "state": "translated",
             "value": "गले लगाएँ"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sarıl"
+          }
         }
       }
     },
@@ -7015,6 +7381,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "मेंशन करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bahset"
           }
         }
       }
@@ -7123,6 +7495,12 @@
             "state": "translated",
             "value": "थप्पड़ मारें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tokatla"
+          }
         }
       }
     },
@@ -7229,6 +7607,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "क्रियाएँ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eylemler"
           }
         }
       }
@@ -7337,6 +7721,12 @@
             "state": "translated",
             "value": "ब्लूटूथ बंद है। bitchat उपयोग करने के लिए सेटिंग्स में ब्लूटूथ चालू करें।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth kapalı. bitchat'i kullanmak için ayarlardan Bluetooth'u açın."
+          }
         }
       }
     },
@@ -7443,6 +7833,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "bitchat को पास के उपकरणों से जुड़ने के लिए ब्लूटूथ अनुमति चाहिए। कृपया सेटिंग्स में ब्लूटूथ एक्सेस सक्षम करें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bitchat'in yakın cihazlara bağlanması için Bluetooth izni gerekir. lütfen ayarlardan Bluetooth erişimini etkinleştirin."
           }
         }
       }
@@ -7551,6 +7947,12 @@
             "state": "translated",
             "value": "सेटिंग्स"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ayarlar"
+          }
         }
       }
     },
@@ -7657,6 +8059,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ब्लूटूथ आवश्यक"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth gerekli"
           }
         }
       }
@@ -7765,6 +8173,12 @@
             "state": "translated",
             "value": "यह डिवाइस ब्लूटूथ समर्थित नहीं है। bitchat चलाने के लिए ब्लूटूथ जरूरी है।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu cihaz Bluetooth'u desteklemiyor. bitchat'in çalışması için Bluetooth gerekli."
+          }
         }
       }
     },
@@ -7871,6 +8285,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन चैनलों के स्क्रीनशॉट आपकी लोकेशन प्रकट करेंगे। सार्वजनिक रूप से साझा करने से पहले सोचें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum kanallarının ekran görüntüleri konumunuzu ortaya çıkarır. paylaşmadan önce iki kez düşünün."
           }
         }
       }
@@ -7979,6 +8399,12 @@
             "state": "translated",
             "value": "ध्यान दें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dikkat"
+          }
         }
       }
     },
@@ -8085,6 +8511,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ब्लॉक करें या ब्लॉक पीयरों की सूची देखें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "engelle veya engellenen eşleri listele"
           }
         }
       }
@@ -8193,6 +8625,12 @@
             "state": "translated",
             "value": "चैट संदेश साफ़ करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sohbet mesajlarını temizle"
+          }
         }
       }
     },
@@ -8299,6 +8737,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पसंदीदा में जोड़ें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorilere ekle"
           }
         }
       }
@@ -8407,6 +8851,12 @@
             "state": "translated",
             "value": "किसी को गर्म आलिंगन भेजें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "birine sıcak bir sarılma gönder"
+          }
         }
       }
     },
@@ -8513,6 +8963,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "निजी संदेश भेजें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "özel mesaj gönder"
           }
         }
       }
@@ -8621,6 +9077,12 @@
             "state": "translated",
             "value": "किसी को ट्राउट से थप्पड़ मारें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "birine alabalıkla tokat at"
+          }
         }
       }
     },
@@ -8727,6 +9189,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "किसी पीयर को अनब्लॉक करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bir eşin engelini kaldır"
           }
         }
       }
@@ -8835,6 +9303,12 @@
             "state": "translated",
             "value": "पसंदीदा से हटाएँ"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "favorilerden çıkar"
+          }
         }
       }
     },
@@ -8941,6 +9415,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "कौन ऑनलाइन है देखें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kimler çevrimiçi gör"
           }
         }
       }
@@ -9049,6 +9529,12 @@
             "state": "translated",
             "value": "%2$d सदस्यों में से %1$d को पहुँचाया"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d üyeden %1$d kişiye ulaştı"
+          }
         }
       }
     },
@@ -9155,6 +9641,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ को पहुँचाया"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'a iletildi"
           }
         }
       }
@@ -9263,6 +9755,12 @@
             "state": "translated",
             "value": "विफल: %@"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "başarısız: %@"
+          }
         }
       }
     },
@@ -9369,6 +9867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ ने पढ़ा"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ okudu"
           }
         }
       }
@@ -9477,6 +9981,12 @@
             "state": "translated",
             "value": "उपयोगकर्ता ब्लॉक है"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kullanıcı engellendi"
+          }
         }
       }
     },
@@ -9583,6 +10093,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "खुद को संदेश नहीं भेज सकते"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kendine mesaj gönderemezsin"
           }
         }
       }
@@ -9691,6 +10207,12 @@
             "state": "translated",
             "value": "भेजने में त्रुटि"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gönderme hatası"
+          }
         }
       }
     },
@@ -9797,6 +10319,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "अज्ञात प्राप्तकर्ता"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bilinmeyen alıcı"
           }
         }
       }
@@ -9905,6 +10433,12 @@
             "state": "translated",
             "value": "पीयर पहुंच योग्य नहीं"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eşe ulaşılamıyor"
+          }
         }
       }
     },
@@ -10011,6 +10545,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोग"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KİŞİLER"
           }
         }
       }
@@ -10119,6 +10659,12 @@
             "state": "translated",
             "value": "सत्यापन: मेरा QR दिखाएँ या मित्र का स्कैन करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrulama: QR kodumu göster veya bir arkadaşını tara"
+          }
         }
       }
     },
@@ -10225,6 +10771,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "संदेश लिखें..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bir mesaj yazın..."
           }
         }
       }
@@ -10333,6 +10885,12 @@
             "state": "translated",
             "value": "उपनाम"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "takma ad"
+          }
         }
       }
     },
@@ -10439,6 +10997,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन सक्षम करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konumu etkinleştir"
           }
         }
       }
@@ -10547,6 +11111,12 @@
             "state": "translated",
             "value": "संदेश कॉपी करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesajı kopyala"
+          }
         }
       }
     },
@@ -10653,6 +11223,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "कम दिखाएँ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "daha az göster"
           }
         }
       }
@@ -10761,6 +11337,12 @@
             "state": "translated",
             "value": "और दिखाएँ"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "daha fazla göster"
+          }
         }
       }
     },
@@ -10867,6 +11449,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन उपलब्ध नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum kullanılamıyor"
           }
         }
       }
@@ -10975,6 +11563,12 @@
             "state": "translated",
             "value": "नोट्स"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notlar"
+          }
         }
       }
     },
@@ -11081,6 +11675,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "कैशु से भुगतान करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cashu ile öde"
           }
         }
       }
@@ -11189,6 +11789,12 @@
             "state": "translated",
             "value": "लाइटनिंग से भुगतान करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lightning ile öde"
+          }
         }
       }
     },
@@ -11295,6 +11901,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्शन स्थापित हो रहा है"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme kuruluyor"
           }
         }
       }
@@ -11403,6 +12015,12 @@
             "state": "translated",
             "value": "एन्क्रिप्शन विफल हुआ"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme başarısız"
+          }
         }
       }
     },
@@ -11509,6 +12127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्ट नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifrelenmedi"
           }
         }
       }
@@ -11617,6 +12241,12 @@
             "state": "translated",
             "value": "एन्क्रिप्टेड"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreli"
+          }
         }
       }
     },
@@ -11723,6 +12353,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्टेड और सत्यापित"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreli ve doğrulandı"
           }
         }
       }
@@ -11831,6 +12467,12 @@
             "state": "translated",
             "value": "एन्क्रिप्शन स्थापित हो रहा है..."
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme kuruluyor..."
+          }
         }
       }
     },
@@ -11937,6 +12579,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्शन विफल हुआ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreleme başarısız"
           }
         }
       }
@@ -12045,6 +12693,12 @@
             "state": "translated",
             "value": "एन्क्रिप्ट नहीं"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifrelenmedi"
+          }
         }
       }
     },
@@ -12151,6 +12805,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "एन्क्रिप्टेड"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreli"
           }
         }
       }
@@ -12259,6 +12919,12 @@
             "state": "translated",
             "value": "एन्क्रिप्टेड और सत्यापित"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şifreli ve doğrulandı"
+          }
         }
       }
     },
@@ -12365,6 +13031,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "सत्यापित के रूप में चिह्नित करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrulandı olarak işaretle"
           }
         }
       }
@@ -12473,6 +13145,12 @@
             "state": "translated",
             "value": "सत्यापन हटाएँ"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrulamayı kaldır"
+          }
         }
       }
     },
@@ -12579,6 +13257,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ सत्यापित नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ DOĞRULANMADI"
           }
         }
       }
@@ -12687,6 +13371,12 @@
             "state": "translated",
             "value": "✓ सत्यापित"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ DOĞRULANDI"
+          }
         }
       }
     },
@@ -12793,6 +13483,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "उपलब्ध नहीं - हैंडशेक जारी है"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kullanılamıyor - el sıkışma sürüyor"
           }
         }
       }
@@ -12901,6 +13597,12 @@
             "state": "translated",
             "value": "आपने इस व्यक्ति की पहचान सत्यापित की है।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu kişinin kimliğini doğruladınız."
+          }
         }
       }
     },
@@ -13007,6 +13709,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "इन फिंगरप्रिंट्स की तुलना %@ से सुरक्षित चैनल पर करें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu parmak izlerini %@ ile güvenli bir kanalda karşılaştırın."
           }
         }
       }
@@ -13115,6 +13823,12 @@
             "state": "translated",
             "value": "उनका फिंगरप्रिंट:"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onların parmak izi:"
+          }
         }
       }
     },
@@ -13221,6 +13935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "सुरक्षा सत्यापन"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "güvenlik doğrulaması"
           }
         }
       }
@@ -13329,6 +14049,12 @@
             "state": "translated",
             "value": "आपका फिंगरप्रिंट:"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sizin parmak iziniz:"
+          }
         }
       }
     },
@@ -13435,6 +14161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ब्लॉक करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "engelle"
           }
         }
       }
@@ -13543,6 +14275,12 @@
             "state": "translated",
             "value": "अनब्लॉक करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "engeli kaldır"
+          }
         }
       }
     },
@@ -13649,6 +14387,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "आसपास कोई नहीं..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yakında kimse yok..."
           }
         }
       }
@@ -13757,6 +14501,12 @@
             "state": "translated",
             "value": "जियोहैश में ब्लॉक"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash'te engellendi"
+          }
         }
       }
     },
@@ -13863,6 +14613,12 @@
           "stringUnit": {
             "state": "translated",
             "value": " (आप)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (sen)"
           }
         }
       }
@@ -13971,6 +14727,12 @@
             "state": "translated",
             "value": "सेटिंग्स खोलें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ayarları aç"
+          }
         }
       }
     },
@@ -14077,6 +14839,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन एक्सेस हटाएँ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum erişimini kaldır"
           }
         }
       }
@@ -14185,6 +14953,12 @@
             "state": "translated",
             "value": "लोकेशन अनुमति और मेरे जियोहैश प्राप्त करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum izni ve geohash'lerimi al"
+          }
         }
       }
     },
@@ -14291,6 +15065,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "टेलीपोर्ट"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ışınlan"
           }
         }
       }
@@ -14399,6 +15179,12 @@
             "state": "translated",
             "value": "बुकमार्क की गई"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yer imleri"
+          }
         }
       }
     },
@@ -14505,6 +15291,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "जियोहैश चैनलों से आसपास के लोगों से चैट करें। केवल मोटा जियोहैश साझा होता है, कभी सटीक GPS नहीं। आपका IP सारा ट्रैफ़िक Tor से रूट कर छिपा रहता है।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash kanallarıyla yakınınızdaki insanlarla sohbet edin. yalnızca kaba bir geohash paylaşılır, tam GPS asla değil. IP adresiniz tüm trafik Tor üzerinden yönlendirilerek gizlenir."
           }
         }
       }
@@ -14613,6 +15405,12 @@
             "state": "translated",
             "value": "अमान्य जियोहैश"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geçersiz geohash"
+          }
         }
       }
     },
@@ -14719,6 +15517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पास के चैनल खोजे जा रहे हैं…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yakındaki kanallar aranıyor…"
           }
         }
       }
@@ -14827,6 +15631,12 @@
             "state": "translated",
             "value": "मेश"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesh"
+          }
         }
       }
     },
@@ -14933,6 +15743,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन अनुमति अस्वीकृत। लोकेशन चैनल उपयोग करने के लिए सेटिंग्स में सक्षम करें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum izni reddedildi. konum kanallarını kullanmak için ayarlardan etkinleştirin."
           }
         }
       }
@@ -15425,6 +16241,12 @@
             "state": "translated",
             "value": "%1$@ [%2$#@people_count@]"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ [%2$#@people_count@]"
+          }
         }
       }
     },
@@ -15528,6 +16350,12 @@
           }
         },
         "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$@"
+          }
+        },
+        "tr": {
           "stringUnit": {
             "state": "translated",
             "value": "#%1$@ • %2$@"
@@ -15639,6 +16467,12 @@
             "state": "translated",
             "value": "%1$@ • %2$@"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • %2$@"
+          }
         }
       }
     },
@@ -15745,6 +16579,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "#लोकेशन चैनल"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#konum kanalları"
           }
         }
       }
@@ -15853,6 +16693,12 @@
             "state": "translated",
             "value": "लोकेशन चैनलों के लिए आपका IP छुपाता है। अनुशंसित: चालू रखें।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum kanalları için IP'nizi gizler. önerilen: açık."
+          }
         }
       }
     },
@@ -15959,6 +16805,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor रूटिंग"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor yönlendirmesi"
           }
         }
       }
@@ -16067,6 +16919,12 @@
             "state": "translated",
             "value": "ब्लॉक"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blok"
+          }
         }
       }
     },
@@ -16173,6 +17031,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "भवन"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bina"
           }
         }
       }
@@ -16281,6 +17145,12 @@
             "state": "translated",
             "value": "शहर"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "şehir"
+          }
         }
       }
     },
@@ -16387,6 +17257,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पड़ोस"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mahalle"
           }
         }
       }
@@ -16495,6 +17371,12 @@
             "state": "translated",
             "value": "प्रांत"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il"
+          }
         }
       }
     },
@@ -16601,6 +17483,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "क्षेत्र"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bölge"
           }
         }
       }
@@ -16709,6 +17597,12 @@
             "state": "translated",
             "value": "बंद करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kapat"
+          }
         }
       }
     },
@@ -16815,6 +17709,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "फिर प्रयास करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yeniden dene"
           }
         }
       }
@@ -16923,6 +17823,12 @@
             "state": "translated",
             "value": "इस स्थान के लिए अन्य आगंतुकों को मिलने वाले छोटे स्थायी नोट जोड़ें।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu konuma gelen diğer ziyaretçilerin bulması için kısa kalıcı notlar ekleyin."
+          }
         }
       }
     },
@@ -17029,6 +17935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "इस जगह के लिए पहला नोट आप जोड़ें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu yer için ilk notu sen ekle."
           }
         }
       }
@@ -17137,6 +18049,12 @@
             "state": "translated",
             "value": "अभी कोई नोट नहीं"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "henüz not yok"
+          }
         }
       }
     },
@@ -17244,6 +18162,12 @@
             "state": "translated",
             "value": "नोट भेजने में विफल। %@"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "not gönderilemedi. %@"
+          }
         }
       }
     },
@@ -17350,6 +18274,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "इस स्थान के पास कोई जियो रिले उपलब्ध नहीं। कुछ देर बाद फिर प्रयास करें।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu konuma yakın geo röle yok. birazdan yeniden deneyin."
           }
         }
       }
@@ -17842,6 +18772,12 @@
             "state": "translated",
             "value": "#%1$@ • %2$#@note_count@"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#%1$@ • %2$#@note_count@"
+          }
         }
       }
     },
@@ -17948,6 +18884,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "नोट लोड हो रहे हैं…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notlar yükleniyor…"
           }
         }
       }
@@ -18056,6 +18998,12 @@
             "state": "translated",
             "value": "हाल के नोट लोड हो रहे हैं…"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "son notlar yükleniyor…"
+          }
         }
       }
     },
@@ -18162,6 +19110,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "पास कोई जियो रिले नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yakında geo röle yok"
           }
         }
       }
@@ -18270,6 +19224,12 @@
             "state": "translated",
             "value": "इस स्थान के लिए नोट जोड़ें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bu yer için bir not ekleyin"
+          }
         }
       }
     },
@@ -18376,6 +19336,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "जियो रिले अनुपलब्ध; नोट रुके हैं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geo röleler kullanılamıyor; notlar durduruldu"
           }
         }
       }
@@ -18484,6 +19450,12 @@
             "state": "translated",
             "value": "नोट जियो रिले पर निर्भर हैं। कनेक्शन जांचें और फिर प्रयास करें।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notlar geo rölelere bağlıdır. bağlantıyı kontrol edip tekrar deneyin."
+          }
         }
       }
     },
@@ -18590,6 +19562,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "नए संदेश"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yeni mesajlar"
           }
         }
       }
@@ -18698,6 +19676,12 @@
             "state": "translated",
             "value": "%@ के साथ चैट शुरू नहीं कर सकते: व्यक्ति ब्लॉक है।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile sohbet başlatılamıyor: kişi engelli."
+          }
         }
       }
     },
@@ -18804,6 +19788,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ के साथ चैट शुरू नहीं कर सकते: ऑफ़लाइन मैसेजिंग के लिए आपसी पसंदीदा आवश्यक है।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile sohbet başlatılamıyor: çevrimdışı mesajlaşma için karşılıklı favori gerekiyor."
           }
         }
       }
@@ -18912,6 +19902,12 @@
             "state": "translated",
             "value": "उपयोगकर्ता"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kullanıcı"
+          }
         }
       }
     },
@@ -19018,6 +20014,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "संदेश नहीं भेज सकते: व्यक्ति ब्लॉक है।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mesaj gönderilemiyor: kişi engelli."
           }
         }
       }
@@ -19126,6 +20128,12 @@
             "state": "translated",
             "value": "%@ को संदेश नहीं भेज सकते: व्यक्ति ब्लॉक है।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'a mesaj gönderilemiyor: kişi engelli."
+          }
         }
       }
     },
@@ -19232,6 +20240,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ को संदेश नहीं भेज सकते - पीयर मेश या नोस्ट्र पर पहुँच योग्य नहीं।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'a mesaj gönderilemiyor - eş mesh veya Nostr üzerinden ulaşılamıyor."
           }
         }
       }
@@ -19340,6 +20354,12 @@
             "state": "translated",
             "value": "जियोहैश चैट में %@ ब्लॉक किया गया"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash sohbetlerinde %@ engellendi"
+          }
         }
       }
     },
@@ -19446,6 +20466,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "जियोहैश चैट में %@ अनब्लॉक किया गया"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geohash sohbetlerinde %@ engeli kaldırıldı"
           }
         }
       }
@@ -19554,6 +20580,12 @@
             "state": "translated",
             "value": "भेज नहीं सकते: लोकेशन चैनल में नहीं हैं"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gönderilemiyor: konum kanalında değilsiniz"
+          }
         }
       }
     },
@@ -19660,6 +20692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "लोकेशन चैनल पर भेजना विफल"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "konum kanalına gönderme başarısız"
           }
         }
       }
@@ -19768,6 +20806,12 @@
             "state": "translated",
             "value": "डेवलपमेंट बिल्ड: Tor बायपास सक्षम।"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geliştirme yapısı: Tor atlatması etkin."
+          }
         }
       }
     },
@@ -19874,6 +20918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor पुनः आरंभ हो गया। नेटवर्क रूटिंग बहाल।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor yeniden başlatıldı. ağ yönlendirmesi geri geldi."
           }
         }
       }
@@ -19982,6 +21032,12 @@
             "state": "translated",
             "value": "कनेक्टिविटी बहाल करने के लिए Tor पुनः आरंभ हो रहा है..."
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor bağlantıyı kurtarmak için yeniden başlatılıyor..."
+          }
         }
       }
     },
@@ -20088,6 +21144,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tor शुरू हो गया। IP गोपनीयता के लिए सभी चैट Tor से रूट हो रहे हैं।"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor başlatıldı. IP gizliliği için tüm sohbetler Tor üzerinden yönlendiriliyor."
           }
         }
       }
@@ -20196,6 +21258,12 @@
             "state": "translated",
             "value": "Tor शुरू हो रहा है..."
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tor başlatılıyor..."
+          }
         }
       }
     },
@@ -20302,6 +21370,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "सत्यापन QR कोड"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrulama QR kodu"
           }
         }
       }
@@ -20410,6 +21484,12 @@
             "state": "translated",
             "value": "मुझे सत्यापित करने के लिए स्कैन करें"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "beni doğrulamak için tara"
+          }
         }
       }
     },
@@ -20516,6 +21596,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "QR उपलब्ध नहीं"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR mevcut değil"
           }
         }
       }
@@ -20624,6 +21710,12 @@
             "state": "translated",
             "value": "सत्यापित करने के लिए QR सामग्री पेस्ट करें:"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrulamak için QR içeriğini yapıştırın:"
+          }
         }
       }
     },
@@ -20730,6 +21822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "मित्र का QR स्कैन करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bir arkadaşının QR'ını tara"
           }
         }
       }
@@ -20838,6 +21936,12 @@
             "state": "translated",
             "value": "अमान्य या समाप्त हुआ QR पेलोड"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geçersiz veya süresi dolmuş QR yükü"
+          }
         }
       }
     },
@@ -20944,6 +22048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "मिलता-जुलता पीयर नहीं मिला"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eş bulunamadı"
           }
         }
       }
@@ -21052,6 +22162,12 @@
             "state": "translated",
             "value": "%@ के लिए सत्यापन अनुरोध किया गया"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ için doğrulama istendi"
+          }
         }
       }
     },
@@ -21158,6 +22274,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "सत्यापित करें"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "doğrula"
           }
         }
       }
@@ -21266,6 +22388,12 @@
             "state": "translated",
             "value": "सत्यापन"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DOĞRULA"
+          }
         }
       }
     },
@@ -21371,6 +22499,12 @@
           }
         },
         "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "tr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"


### PR DESCRIPTION
## Summary
  - add Vietnamese, Filipino/Tagalog, Malay, Polish, Dutch, Swedish, Tamil, and
  Urdu strings to the localization catalog
  - align Bluetooth, Tor, and system prompts with region-specific terminology
  while preserving placeholders
  - validate `Localizable.xcstrings` formatting to ensure the expanded catalog
  stays parseable

  ## Testing
  - not run (please run `xcodebuild -project bitchat.xcodeproj -scheme bitchat
  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15'
  test`)
