### PR TITLE
Prune unused validation helpers

### DIFF
--- a/bitchat/Sync/PacketIdUtil.swift
+++ b/bitchat/Sync/PacketIdUtil.swift
@@ -14,8 +14,4 @@ enum PacketIdUtil {
         let digest = hasher.finalize()
         return Data(digest.prefix(16))
     }
-
-    static func computeIdHex(_ packet: BitchatPacket) -> String {
-        return computeId(packet).hexEncodedString()
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused validation helpers and constants from `InputValidator`
- simplify nickname sanitization to the only remaining use case
- drop the unused `PacketIdUtil.computeIdHex` helper

## Testing
- swift test *(fails on Linux because os.log is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc3b696288331af83c8381480e1fd