### PR TITLE
Don’t auto-register mock BLE services on creation

### DIFF
--- a/bitchatTests/EndToEnd/PrivateChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PrivateChatE2ETests.swift
@@ -41,6 +41,31 @@ final class PrivateChatE2ETests: XCTestCase {
     
     // MARK: - Basic Private Messaging Tests
     
+    func testSimplePrivateMessageShouldNotBeSentWithoutConnection() {
+        // Intentionally commented out to test
+        // simulateConnection(alice, bob)
+        
+        let expectation = XCTestExpectation(description: "Bob should not receive a private message")
+        expectation.isInverted = true
+        
+        bob.messageDeliveryHandler = { message in
+            if message.content == TestConstants.testMessage1 &&
+               message.isPrivate &&
+               message.sender == TestConstants.testNickname1 {
+                expectation.fulfill()
+            }
+        }
+        
+        // Alice sends private message to Bob
+        alice.sendPrivateMessage(
+            TestConstants.testMessage1,
+            to: TestConstants.testPeerID2,
+            recipientNickname: TestConstants.testNickname2
+        )
+        
+        wait(for: [expectation], timeout: TestConstants.shortTimeout)
+    }
+    
     func testSimplePrivateMessage() {
         simulateConnection(alice, bob)
         
@@ -280,7 +305,6 @@ final class PrivateChatE2ETests: XCTestCase {
         let service = MockBluetoothMeshService()
         service.myPeerID = peerID
         service.mockNickname = nickname
-        service._testRegister()
         return service
     }
     

--- a/bitchatTests/EndToEnd/PublicChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PublicChatE2ETests.swift
@@ -423,7 +423,6 @@ final class PublicChatE2ETests: XCTestCase {
         let service = MockBluetoothMeshService()
         service.myPeerID = peerID
         service.mockNickname = nickname
-        service._testRegister()
         return service
     }
     

--- a/bitchatTests/Integration/IntegrationTests.swift
+++ b/bitchatTests/Integration/IntegrationTests.swift
@@ -591,7 +591,6 @@ final class IntegrationTests: XCTestCase {
         let node = MockBluetoothMeshService()
         node.myPeerID = peerID
         node.mockNickname = name
-        node._testRegister()
         nodes[name] = node
         
         // Create Noise manager

--- a/bitchatTests/Mocks/MockBLEService.swift
+++ b/bitchatTests/Mocks/MockBLEService.swift
@@ -17,7 +17,6 @@ import CoreBluetooth
 ///   simulated connections between peers. Tests call `simulateConnectedPeer` /
 ///   `simulateDisconnectedPeer` to manage topology.
 /// - `resetTestBus()` clears global state and is called in test `setUp()`.
-/// - `_testRegister()` registers a node immediately on creation for deterministic routing.
 /// - `messageDeliveryHandler` and `packetDeliveryHandler` let tests observe messages/packets
 ///   as they flow, enabling scenarios like manual encryption/relay.
 /// - A thread-safe `seenMessageIDs` set prevents double-delivery races during flooding.
@@ -108,11 +107,6 @@ final class MockBLEService: NSObject {
     private static func disconnectPeers(_ a: String, _ b: String) {
         if var setA = adjacency[a] { setA.remove(b); adjacency[a] = setA }
         if var setB = adjacency[b] { setB.remove(a); adjacency[b] = setB }
-    }
-
-    /// Test-only: register this instance on the bus immediately.
-    func _testRegister() {
-        registerIfNeeded()
     }
 
     func startServices() {

--- a/bitchatTests/README.md
+++ b/bitchatTests/README.md
@@ -6,7 +6,7 @@ This test suite uses an in-memory networking harness to make end-to-end and inte
 
 - **File:** `bitchatTests/Mocks/MockBLEService.swift`
 - **Registry/Adjacency:** Global `registry` maps `peerID` to a `MockBLEService` instance; `adjacency` records simulated links between peers.
-- **Setup:** Call `MockBLEService.resetTestBus()` in `setUp()` to clear state between tests; use `_testRegister()` when creating a node to register immediately.
+- **Setup:** Call `MockBLEService.resetTestBus()` in `setUp()` to clear state between tests.
 - **Topology:** Use `simulateConnectedPeer(_:)` and `simulateDisconnectedPeer(_:)` to add/remove links. `connectFullMesh()` helpers in tests build larger topologies.
 - **Handlers:** Tests can observe data via `messageDeliveryHandler` (decoded `BitchatMessage`) and `packetDeliveryHandler` (raw `BitchatPacket`).
 - **De‑duplication:** A thread-safe `seenMessageIDs` prevents duplicate deliveries during flooding/relays.
@@ -35,8 +35,8 @@ This test suite uses an in-memory networking harness to make end-to-end and inte
 
 ## Quick Start
 
-- Create nodes with `_testRegister()` and connect them:
-  - `let svc = MockBLEService(); svc.myPeerID = "PEER1"; svc._testRegister()`
+- Create nodes and connect them:
+  - `let svc = MockBLEService(); svc.myPeerID = "PEER1"`
   - `svc.simulateConnectedPeer("PEER2")`
 - Observe messages:
   - `svc.messageDeliveryHandler = { msg in /* asserts */ }`


### PR DESCRIPTION
Automatically registering the services on creation makes all of them available even if they're not connected to each other because of the global state of the registry or because of [this logic in the mock](https://github.com/permissionlesstech/bitchat/blob/main/bitchatTests/Mocks/MockBLEService.swift#L232-L235) that delivers messages to anyone who's registered even if they're not connected.

---
In any case, that mock has other issues with the global "registry": it uses a simple string as a dictionary key which causes race condition which was uncovered when I tried to convert the tests to Swift Testing. Apparently XCTest is not running these tests in parallel.

Also, it looks like the mock service doesn't really conform to Transport and not really simulating real-life scenario. Ideally we should not have different logic on the test vs the real code because it could give false positives