### PR TITLE
Fix test suite peer ID collisions

### DIFF
--- a/bitchatTests/EndToEnd/PublicChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PublicChatE2ETests.swift
@@ -21,12 +21,12 @@ struct PublicChatE2ETests {
     
     init() {
         MockBLEService.resetTestBus()
-        
-        // Create mock services
-        alice = MockBLEService(peerID: TestConstants.testPeerID1, nickname: TestConstants.testNickname1)
-        bob = MockBLEService(peerID: TestConstants.testPeerID2, nickname: TestConstants.testNickname2)
-        charlie = MockBLEService(peerID: TestConstants.testPeerID3, nickname: TestConstants.testNickname3)
-        david = MockBLEService(peerID: TestConstants.testPeerID4, nickname: TestConstants.testNickname4)
+
+        // Create mock services with unique peer IDs to avoid collision with other test suites
+        alice = MockBLEService(peerID: "PUB_ALICE__", nickname: TestConstants.testNickname1)
+        bob = MockBLEService(peerID: "PUB_BOB____", nickname: TestConstants.testNickname2)
+        charlie = MockBLEService(peerID: "PUB_CHARLIE", nickname: TestConstants.testNickname3)
+        david = MockBLEService(peerID: "PUB_DAVID__", nickname: TestConstants.testNickname4)
     }
     
     // MARK: - Basic Broadcasting Tests


### PR DESCRIPTION
## Summary

- Use unique peer IDs for each test suite to prevent global registry collisions when Swift Testing runs suites in parallel
- PrivateChatE2ETests uses `PRIV_*` prefix
- PublicChatE2ETests uses `PUB_*` prefix  
- Update all peer ID references to use actual instance IDs instead of TestConstants

## Problem

When Swift Testing runs test suites in parallel, both `PrivateChatE2ETests` and `PublicChatE2ETests` were creating mock services with the same peer IDs (e.g., `PEER1234`, `PEER5678`). This caused registry contamination in the global `MockBLEService.registry`, leading to messages being delivered to the wrong suite's instances.

## Solution

Each suite now uses unique peer ID prefixes, ensuring no collisions even when running in parallel.

## Test Results

All 23 tests now pass consistently.