### PR TITLE
Fix ghost peers and stale messages from gossip sync

### DIFF
--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -2415,7 +2415,20 @@ extension BLEService {
         if peerID == myPeerID {
             return
         }
-        
+
+        // Reject stale announces to prevent ghost peers from appearing
+        // Use same 15-minute window as gossip sync (900 seconds)
+        let maxAnnounceAgeSeconds: TimeInterval = 900
+        let nowMs = UInt64(Date().timeIntervalSince1970 * 1000)
+        let ageThresholdMs = UInt64(maxAnnounceAgeSeconds * 1000)
+        if nowMs >= ageThresholdMs {
+            let cutoffMs = nowMs - ageThresholdMs
+            if packet.timestamp < cutoffMs {
+                SecureLogger.debug("⏰ Ignoring stale announce from \(peerID.prefix(8))… (age: \(Double(nowMs - packet.timestamp) / 1000.0)s)", category: .session)
+                return
+            }
+        }
+
         // Suppress announce logs to reduce noise
 
         // Precompute signature verification outside barrier to reduce contention
@@ -2590,6 +2603,26 @@ extension BLEService {
         // This allows our own messages to be surfaced when they come back via
         // the sync path without re-processing regular relayed copies.
         if peerID == myPeerID && packet.ttl != 0 { return }
+
+        // Reject stale broadcast messages to prevent old messages from appearing
+        // Use same 15-minute window as gossip sync (900 seconds)
+        // Check if this is a broadcast message (recipient is all 0xFF or nil)
+        let isBroadcast: Bool = {
+            guard let r = packet.recipientID else { return true }
+            return r.count == 8 && r.allSatisfy { $0 == 0xFF }
+        }()
+        if isBroadcast {
+            let maxMessageAgeSeconds: TimeInterval = 900
+            let nowMs = UInt64(Date().timeIntervalSince1970 * 1000)
+            let ageThresholdMs = UInt64(maxMessageAgeSeconds * 1000)
+            if nowMs >= ageThresholdMs {
+                let cutoffMs = nowMs - ageThresholdMs
+                if packet.timestamp < cutoffMs {
+                    SecureLogger.debug("⏰ Ignoring stale broadcast message from \(peerID.prefix(8))… (age: \(Double(nowMs - packet.timestamp) / 1000.0)s)", category: .session)
+                    return
+                }
+            }
+        }
 
         var accepted = false
         var senderNickname: String = ""

--- a/bitchat/Sync/GossipSyncManager.swift
+++ b/bitchat/Sync/GossipSyncManager.swift
@@ -12,6 +12,7 @@ final class GossipSyncManager {
         var seenCapacity: Int = 1000          // max packets per sync (cap across types)
         var gcsMaxBytes: Int = 400           // filter size budget (128..1024)
         var gcsTargetFpr: Double = 0.01      // 1%
+        var maxMessageAgeSeconds: TimeInterval = 900  // 15 min - discard older messages
     }
 
     private let myPeerID: PeerID
@@ -36,7 +37,10 @@ final class GossipSyncManager {
         stop()
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + 30.0, repeating: 30.0, leeway: .seconds(1))
-        timer.setEventHandler { [weak self] in self?.sendRequestSync() }
+        timer.setEventHandler { [weak self] in
+            self?.cleanupExpiredMessages()
+            self?.sendRequestSync()
+        }
         timer.resume()
         periodicTimer = timer
     }
@@ -57,6 +61,18 @@ final class GossipSyncManager {
         }
     }
 
+    // Helper to check if a packet is within the age threshold
+    private func isPacketFresh(_ packet: BitchatPacket) -> Bool {
+        let nowMs = UInt64(Date().timeIntervalSince1970 * 1000)
+        let ageThresholdMs = UInt64(config.maxMessageAgeSeconds * 1000)
+
+        // If current time is less than threshold, accept all (handle clock issues gracefully)
+        guard nowMs >= ageThresholdMs else { return true }
+
+        let cutoffMs = nowMs - ageThresholdMs
+        return packet.timestamp >= cutoffMs
+    }
+
     private func _onPublicPacketSeen(_ packet: BitchatPacket) {
         let mt = MessageType(rawValue: packet.type)
         let isBroadcastRecipient: Bool = {
@@ -66,6 +82,9 @@ final class GossipSyncManager {
         let isBroadcastMessage = (mt == .message && isBroadcastRecipient)
         let isAnnounce = (mt == .announce)
         guard isBroadcastMessage || isAnnounce else { return }
+
+        // Reject expired packets to prevent ghost peers and old messages
+        guard isPacketFresh(packet) else { return }
 
         let idHex = PacketIdUtil.computeId(packet).hexEncodedString()
 
@@ -137,9 +156,10 @@ final class GossipSyncManager {
             return GCSFilter.contains(sortedValues: sorted, candidate: bucket)
         }
 
-        // 1) Announcements: send latest per peer if requester lacks them
+        // 1) Announcements: send latest per peer if requester lacks them (and not expired)
         for (_, pair) in latestAnnouncementByPeer {
             let (idHex, pkt) = pair
+            guard isPacketFresh(pkt) else { continue }
             let idBytes = Data(hexString: idHex) ?? Data()
             if !mightContain(idBytes) {
                 var toSend = pkt
@@ -148,9 +168,10 @@ final class GossipSyncManager {
             }
         }
 
-        // 2) Broadcast messages: send all missing
+        // 2) Broadcast messages: send all missing (and not expired)
         let toSendMsgs = messageOrder.compactMap { messages[$0] }
         for pkt in toSendMsgs {
+            guard isPacketFresh(pkt) else { continue }
             let idBytes = PacketIdUtil.computeId(pkt)
             if !mightContain(idBytes) {
                 var toSend = pkt
@@ -162,11 +183,19 @@ final class GossipSyncManager {
 
     // Build REQUEST_SYNC payload using current candidates and GCS params
     private func buildGcsPayload() -> Data {
-        // Collect candidates: latest announce per peer + broadcast messages
+        // Collect candidates: latest announce per peer + broadcast messages (only fresh)
         var candidates: [BitchatPacket] = []
         candidates.reserveCapacity(latestAnnouncementByPeer.count + messageOrder.count)
-        for (_, pair) in latestAnnouncementByPeer { candidates.append(pair.packet) }
-        for id in messageOrder { if let p = messages[id] { candidates.append(p) } }
+        for (_, pair) in latestAnnouncementByPeer {
+            if isPacketFresh(pair.packet) {
+                candidates.append(pair.packet)
+            }
+        }
+        for id in messageOrder {
+            if let p = messages[id], isPacketFresh(p) {
+                candidates.append(p)
+            }
+        }
         // Sort by timestamp desc
         candidates.sort { $0.timestamp > $1.timestamp }
 
@@ -182,6 +211,23 @@ final class GossipSyncManager {
         let params = GCSFilter.buildFilter(ids: ids, maxBytes: config.gcsMaxBytes, targetFpr: config.gcsTargetFpr)
         let req = RequestSyncPacket(p: params.p, m: params.m, data: params.data)
         return req.encode()
+    }
+
+    // Periodic cleanup of expired messages and announcements
+    private func cleanupExpiredMessages() {
+        // Remove expired announcements
+        latestAnnouncementByPeer = latestAnnouncementByPeer.filter { _, pair in
+            isPacketFresh(pair.packet)
+        }
+
+        // Remove expired messages
+        let expiredMessageIds = messages.compactMap { id, pkt in
+            isPacketFresh(pkt) ? nil : id
+        }
+        for id in expiredMessageIds {
+            messages.removeValue(forKey: id)
+            messageOrder.removeAll { $0 == id }
+        }
     }
 
     // Explicit removal hook for LEAVE/stale peer


### PR DESCRIPTION
## Problem

Ghost peers from yesterday appeared on app restart, then disappeared after 5 seconds. Restarting the app brought them back. Also seeing stale messages from yesterday appearing in the mesh timeline.

### Root Causes

**Vector 1: Gossip Sync Storage**
- `GossipSyncManager` stored packets indefinitely (capacity limit only, no time limit)
- Peers running 24+ hours accumulated day-old announces in storage
- When a peer restarts with empty gossip storage, it receives ALL stored messages from other peers (up to 1000 messages)

**Vector 2: Packet Processing**
- `handleAnnounce` and `handleMessage` had no timestamp validation
- They accepted packets from ANY timestamp, even from yesterday
- Even with gossip filtering, old announces could arrive via relayed paths or from peers running old code

### Why the 5-Second Disappearance?

`checkPeerConnectivity()` runs every 5 seconds and removes peers with `isConnected=false` and age > 21 seconds. Old relayed announces create disconnected ghost peers which get cleaned up 5 seconds later, but reappear on restart.

## Solution

Defense-in-depth approach with time-based filtering at multiple layers:

### GossipSyncManager Changes
- Added `maxMessageAgeSeconds: TimeInterval = 900` (15-minute window)
- Added `isPacketFresh()` helper to validate packet timestamps
- **Storage filtering**: `_onPublicPacketSeen` rejects expired packets at ingestion
- **Sync response filtering**: `_handleRequestSync` skips expired packets when responding
- **GCS payload filtering**: `buildGcsPayload` only includes fresh packets
- **Periodic cleanup**: `cleanupExpiredMessages()` runs every 30s to prune expired data

### BLEService Changes
- `handleAnnounce`: Rejects announces older than 15 minutes before processing
- `handleMessage`: Rejects broadcast messages older than 15 minutes before processing
- Both log rejected packets with age for visibility

## Testing

- ✅ All tests pass (23/23)
- ✅ Build succeeds
- ✅ Manual testing: Ghost peers no longer appear on app restart
- ✅ Logs show `⏰ Ignoring stale announce/broadcast` when old packets are rejected

## Impact

The 15-minute window is generous enough for legitimate network delays and queuing while preventing yesterday's ghost peers and messages from appearing. Even if a peer runs old code and sends ancient announces, this device will reject them at processing time.