### PR TITLE
SwiftTesting: Enable in GitHubActions + peer uuids

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -24,4 +24,4 @@ jobs:
         run: swift build
 
       - name: Run Tests
-        run: swift test --parallel --disable-swift-testing  # so it only runs xctests: https://github.com/swiftlang/swift-package-manager/issues/8529#issuecomment-2815711345
+        run: swift test --parallel

--- a/bitchatTests/EndToEnd/PrivateChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PrivateChatE2ETests.swift
@@ -8,6 +8,7 @@
 
 import Testing
 import CryptoKit
+import struct Foundation.UUID
 @testable import bitchat
 
 // TODO: Remove once MockBLEService is refactored to fix race condition
@@ -20,12 +21,10 @@ struct PrivateChatE2ETests {
     private let mockKeychain: MockKeychain
     
     init() {
-        MockBLEService.resetTestBus()
-
-        // Create services with unique peer IDs to avoid collision with other test suites
-        alice = MockBLEService(peerID: "PRIV_ALICE_", nickname: TestConstants.testNickname1)
-        bob = MockBLEService(peerID: "PRIV_BOB___", nickname: TestConstants.testNickname2)
-        charlie = MockBLEService(peerID: "PRIV_CHARLE", nickname: TestConstants.testNickname3)
+        // Create services with unique peer IDs to avoid any collision
+        alice = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname1)
+        bob = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname2)
+        charlie = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname3)
         mockKeychain = MockKeychain()
     }
     

--- a/bitchatTests/EndToEnd/PublicChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PublicChatE2ETests.swift
@@ -7,6 +7,7 @@
 //
 
 import Testing
+import struct Foundation.UUID
 @testable import bitchat
 
 @Suite(.serialized)
@@ -20,13 +21,11 @@ struct PublicChatE2ETests {
     private var receivedMessages: [String: [BitchatMessage]] = [:]
     
     init() {
-        MockBLEService.resetTestBus()
-
-        // Create mock services with unique peer IDs to avoid collision with other test suites
-        alice = MockBLEService(peerID: "PUB_ALICE__", nickname: TestConstants.testNickname1)
-        bob = MockBLEService(peerID: "PUB_BOB____", nickname: TestConstants.testNickname2)
-        charlie = MockBLEService(peerID: "PUB_CHARLIE", nickname: TestConstants.testNickname3)
-        david = MockBLEService(peerID: "PUB_DAVID__", nickname: TestConstants.testNickname4)
+        // Create mock services with unique peer IDs to avoid any collision
+        alice = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname1)
+        bob = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname2)
+        charlie = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname3)
+        david = MockBLEService(peerID: PeerID(str: UUID().uuidString), nickname: TestConstants.testNickname4)
     }
     
     // MARK: - Basic Broadcasting Tests


### PR DESCRIPTION
Using UUIDs for peer ID's would help us have unique ids across any test of the same or other test files