### PR TITLE
Fix BLE queue usage and tighten actor isolation

### DIFF
--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -160,6 +160,7 @@ enum DeliveryStatus: Codable, Equatable, Hashable {
 
 // MARK: - Delegate Protocol
 
+@MainActor
 protocol BitchatDelegate: AnyObject {
     func didReceiveMessage(_ message: BitchatMessage)
     func didConnectToPeer(_ peerID: PeerID)
@@ -180,6 +181,7 @@ protocol BitchatDelegate: AnyObject {
 }
 
 // Provide default implementation to make it effectively optional
+@MainActor
 extension BitchatDelegate {
     func isFavorite(fingerprint: String) -> Bool {
         return false

--- a/bitchat/Services/NostrTransport.swift
+++ b/bitchat/Services/NostrTransport.swift
@@ -50,10 +50,11 @@ final class NostrTransport: Transport {
     
     // Nostr does not use Noise sessions here; return a cached placeholder to avoid reallocation
     private static var cachedNoiseService: NoiseEncryptionService?
+    private static let noiseServiceLock = NSLock()
     func getNoiseService() -> NoiseEncryptionService {
-        if let noiseService = Self.cachedNoiseService {
-            return noiseService
-        }
+        Self.noiseServiceLock.lock()
+        defer { Self.noiseServiceLock.unlock() }
+        if let noiseService = Self.cachedNoiseService { return noiseService }
         let noiseService = NoiseEncryptionService(keychain: keychain)
         Self.cachedNoiseService = noiseService
         return noiseService

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -91,6 +91,7 @@ import UIKit
 /// Manages the application state and business logic for BitChat.
 /// Acts as the primary coordinator between UI components and backend services,
 /// implementing the BitchatDelegate protocol to handle network events.
+@MainActor
 final class ChatViewModel: ObservableObject, BitchatDelegate {
     // Precompiled regexes and detectors reused across formatting
     private enum Regexes {
@@ -229,14 +230,13 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     private let networkResetGraceSeconds: TimeInterval = TransportConfig.networkResetGraceSeconds // avoid refiring on short drops/reconnects
     @Published var nickname: String = "" {
         didSet {
-            // Trim whitespace whenever nickname is set
             let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed != nickname {
                 nickname = trimmed
+                return
             }
-            // Update mesh service nickname if it's initialized
-            if meshService.myPeerID != "" {
-                meshService.setNickname(nickname)
+            if meshService.myPeerID != "", meshService.myNickname != trimmed {
+                meshService.setNickname(trimmed)
             }
         }
     }


### PR DESCRIPTION
## Summary
- route every CoreBluetooth operation through , assert queue affinity in debug builds, and keep  synchronous so LEAVE and cleanup finish before termination
- harden concurrency: mark / as , hop delegate callbacks back to the main actor, and rewrite  throttling to avoid non-Sendable captures; lock ’s cached 
- fix the crashy peer lookup by snapshotting  on its queue; trim the nickname setter/notification handlers to avoid duplicate announces and off-main access

## Testing
- Not run (sandbox blocked xcodebuild run); please build locally