### PR TITLE
Fix hidden source of deadlocks

### DIFF
--- a/localPackages/BitLogger/Sources/SecureLogger.swift
+++ b/localPackages/BitLogger/Sources/SecureLogger.swift
@@ -276,7 +276,7 @@ private extension SecureLogger {
         }
         
         // Cache the result
-        cacheQueue.async(flags: .barrier) {
+        cacheQueue.sync {
             sanitizationCache.setObject(sanitized as NSString, forKey: key)
         }
         


### PR DESCRIPTION
Finally found the root cause of deadlocks - and it's a one-liner PR.
---

# Problem

`NoiseSession` has a private queue that it uses as a locking mechanism. It uses `sync(flags: .barrier)` which blocks the current queue, but inside `processHandshakeMessage` there's a logger: `SecureLogger.info(.handshakeCompleted(peerID: peerID.id))` which internally uses `cacheQueue.async(flags: .barrier)` - and they kind of wait on each other to finish their "exclusive write"'s -> deadlock.

# Solutions

We can either use regular `async` or `sync` (which also works with barrier flag), but gpt suggested that the safest option was a simple `sync`, followed by `async`. Given that we're just writing a simple string into an NSCache of 100 objects - it shouldn't be too big of a deal.

# Test / Verification

Below is a sample unit test that would give 100% reproducible deadlock - the number of tests should be equal or more than the number of cores on your machine (mine has 10). With `.async(flags: .barrier)` we get the deadlock and with a regular `.sync` (same as `.async` and even `.sync(flags: .barrier)`) - the deadlock is gone and even when I doubled the number of tests in parallel.

```
import Testing
import Foundation
@testable import bitchat

struct DeadlockSimulationTests {
    
    private let mockKeychain = MockKeychain()
    private let alice: NoiseSession
    private let bob: NoiseSession
    
    init() {
        alice = NoiseSession(peerID: PeerID(str: UUID().uuidString), role: .initiator, keychain: mockKeychain, localStaticKey: .init())
        bob = NoiseSession(peerID: PeerID(str: UUID().uuidString), role: .responder, keychain: mockKeychain, localStaticKey: .init())
    }
    
    @Test func test_1() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_2() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_3() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_4() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_5() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_6() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_7() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_8() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_9() throws {
        try alice.handshake(with: bob)
    }
    
    @Test func test_10() throws {
        try alice.handshake(with: bob)
    }
}

extension NoiseSession {
    func handshake(with responder: NoiseSession) throws {
        let msg1 = try startHandshake()
        let msg2 = try responder.processHandshakeMessage(msg1)!
        let msg3 = try processHandshakeMessage(msg2)!
        _ = try responder.processHandshakeMessage(msg3)
    }
}

```