### PR TITLE
Serialize fragment assembly on BLE message queue

### DIFF
--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -2200,6 +2200,16 @@ extension BLEService {
     }
     
     private func handleFragment(_ packet: BitchatPacket, from peerID: PeerID) {
+        if DispatchQueue.getSpecific(key: messageQueueKey) != nil {
+            _handleFragment(packet, from: peerID)
+        } else {
+            messageQueue.async(flags: .barrier) { [weak self] in
+                self?._handleFragment(packet, from: peerID)
+            }
+        }
+    }
+
+    private func _handleFragment(_ packet: BitchatPacket, from peerID: PeerID) {
         // Don't process our own fragments
         if peerID == myPeerID {
             return


### PR DESCRIPTION
## Summary
- ensure fragment intake always runs on the BLE message queue, using a barrier dispatch when invoked from other queues
- keep the pre-existing fragment logic intact in a private helper so shared state (incoming fragments, metadata) is mutated safely

## Testing
- xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' build
