### PR TITLE
Prune unused helpers and add Linux logging stubs

### DIFF
--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -2149,19 +2149,6 @@ extension BLEService {
         }
     }
     
-    private func sendData(_ data: Data, to peripheral: CBPeripheral) {
-        // Fire-and-forget: Simple send without complex fallback logic
-        guard peripheral.state == .connected else { return }
-        
-        let peripheralUUID = peripheral.identifier.uuidString
-        guard let state = peripherals[peripheralUUID],
-              let characteristic = state.characteristic else { return }
-        
-        // Fire-and-forget principle: always use .withoutResponse for speed
-        // CoreBluetooth will handle fragmentation at L2CAP layer
-        writeOrEnqueue(data, to: peripheral, characteristic: characteristic)
-    }
-    
     // MARK: Fragmentation (Required for messages > BLE MTU)
     
     private func sendFragmentedPacket(_ packet: BitchatPacket, pad: Bool, maxChunk: Int? = nil, directedOnlyPeer: PeerID? = nil) {
@@ -2847,17 +2834,6 @@ extension BLEService {
     }
     
     // MARK: Helper Functions
-    
-    private func sendLeave() {
-        SecureLogger.debug("👋 Sending leave announcement", category: .session)
-        let packet = BitchatPacket(
-            type: MessageType.leave.rawValue,
-            ttl: messageTTL,
-            senderID: myPeerID,
-            payload: Data(myNickname.utf8)
-        )
-        broadcastPacket(packet)
-    }
     
     private func sendAnnounce(forceSend: Bool = false) {
         // Throttle announces to prevent flooding

--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -65,14 +65,11 @@ final class CommandProcessor {
         case "/unfav":
             if inGeoPublic || inGeoDM { return .error(message: "favorites are only for mesh peers in #mesh") }
             return handleFavorite(args, add: false)
-        //
-        case "/help", "/h":
-            return .error(message: "unknown command: \(cmd)")
         default:
             return .error(message: "unknown command: \(cmd)")
         }
     }
-    
+
     // MARK: - Command Handlers
     
     private func handleMessage(_ args: String) -> CommandResult {
@@ -311,19 +308,4 @@ final class CommandProcessor {
         }
     }
     
-    private func handleHelp() -> CommandResult {
-        let helpText = """
-        commands:
-        /msg @name - start private chat
-        /who - list who's online
-        /clear - clear messages
-        /hug @name - send a hug
-        /slap @name - slap with a trout
-        /fav @name - add to favorites
-        /unfav @name - remove from favorites
-        /block @name - block
-        /unblock @name - unblock
-        """
-        return .success(message: helpText)
-    }
 }

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -27,34 +27,6 @@ final class KeychainManager: KeychainManagerProtocol {
     private let service = BitchatApp.bundleID
     private let appGroup = "group.\(BitchatApp.bundleID)"
     
-    private func isSandboxed() -> Bool {
-        #if os(macOS)
-        // More robust sandbox detection using multiple methods
-        
-        // Method 1: Check environment variable (can be spoofed)
-        let environment = ProcessInfo.processInfo.environment
-        let hasEnvVar = environment["APP_SANDBOX_CONTAINER_ID"] != nil
-        
-        // Method 2: Check if we can access a path outside sandbox
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        let testPath = homeDir.appendingPathComponent("../../../tmp/bitchat_sandbox_test_\(UUID().uuidString)")
-        let canWriteOutsideSandbox = FileManager.default.createFile(atPath: testPath.path, contents: nil, attributes: nil)
-        if canWriteOutsideSandbox {
-            try? FileManager.default.removeItem(at: testPath)
-        }
-        
-        // Method 3: Check container path
-        let containerPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first?.path ?? ""
-        let hasContainerPath = containerPath.contains("/Containers/")
-        
-        // If any method indicates sandbox, we consider it sandboxed
-        return hasEnvVar || !canWriteOutsideSandbox || hasContainerPath
-        #else
-        // iOS is always sandboxed
-        return true
-        #endif
-    }
-    
     // MARK: - Identity Keys
     
     func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool {

--- a/localPackages/BitLogger/Sources/OSLog+Categories.swift
+++ b/localPackages/BitLogger/Sources/OSLog+Categories.swift
@@ -6,11 +6,13 @@
 // For more information, see <https://unlicense.org>
 //
 
+#if canImport(os.log)
 import os.log
+#endif
 
 public extension OSLog {
     private static let subsystem = "chat.bitchat"
-    
+
     static let noise        = OSLog(subsystem: subsystem, category: "noise")
     static let encryption   = OSLog(subsystem: subsystem, category: "encryption")
     static let keychain     = OSLog(subsystem: subsystem, category: "keychain")


### PR DESCRIPTION
## Summary
- add conditional OSLog stubs so BitLogger builds without the os.log module
- remove unused command, keychain, BLE, and chat view model helpers flagged as dead code
- drop Tor dynamic loader fallbacks and guard Network imports for non-Apple platforms

## Testing
- swift test *(fails: relies on Apple-only frameworks such as Combine/Network)*

------
https://chatgpt.com/codex/tasks/task_e_68efb1079ef88331ab0a3aaa9c8423f1