### PR TITLE
Add new relay URL to NostrRelayManager

### DIFF
--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -33,7 +33,8 @@ final class NostrRelayManager: ObservableObject {
         "wss://nos.lol",
         "wss://relay.primal.net",
         "wss://offchain.pub",
-        "wss://nostr21.com"
+        "wss://nostr21.com",
+        "wss://sendit.nosflare.com"
         // For local testing, you can add: "ws://localhost:8080"
     ]
     private static let defaultRelaySet = Set(defaultRelays)


### PR DESCRIPTION
Add the blaster relay so that outgoing messages in geohash channels for teleported users are sent to bridged bitchat clients. Perhaps, also add as a blaster for all geohash channels that leverage the GPS-related relays with some regex pattern to ensure all locations use the `wss://sendit.nosflare.com` blaster relay when `relays/online_relays_gps.csv` is used.