### PR TITLE
Update payload in message sending to include nickname

### DIFF
--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -500,7 +500,7 @@ final class BLEService: NSObject {
             senderID: myPeerIDData,
             recipientID: nil,
             timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
-            payload: Data(),
+            payload: Data(myNickname.utf8),
             signature: nil,
             ttl: messageTTL
         )


### PR DESCRIPTION
## Fix: iOS LEAVE Packet Empty Payload Causing Android Rejection

### Problem

iOS was sending LEAVE packets with an empty payload when stopping services (stopServices() method), which caused Android's SecurityManager.validatePacket() to reject these packets. This resulted in peers remaining in "connected" state indefinitely on Android devices.

### Root Cause

Android's SecurityManager validates all packets and rejects those with empty payloads:

SecurityManager.kt line 54-57:
```kotlin
if (packet.payload.isEmpty()) {
    Log.d(TAG, "Dropping packet with empty payload")
    return false
}
```

iOS stopServices() method was creating LEAVE packets with empty payload:

BLEService.swift line 498-506 (BEFORE FIX):
```swift
let leavePacket = BitchatPacket(
    type: MessageType.leave.rawValue,
    senderID: myPeerIDData,
    recipientID: nil,
    timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
    payload: Data(),  // EMPTY PAYLOAD - REJECTED BY ANDROID
    signature: nil,
    ttl: messageTTL
)
```

### Solution

Updated the stopServices() method in BLEService.swift to include the user's nickname in the LEAVE packet payload, matching the behavior of the sendLeave() method and Android's sendLeaveAnnouncement() implementation.

### Changes

File: bitchat-ios/bitchat/Services/BLE/BLEService.swift
Line 503: Changed from payload: Data() to payload: Data(myNickname.utf8)

### Testing

Expected Behavior:
- LEAVE packets now include nickname payload
- Android SecurityManager accepts the packets
- Peers are properly removed from connected state on Android
- No more "Dropping packet with empty payload" logs

Test Steps:
1. Start iOS app and connect to Android device via BLE
2. Stop iOS services or close the app
3. Verify Android logs show proper LEAVE packet processing
4. Confirm peer is removed from Android's connected peers list

### Impact

This fix ensures proper disconnection handling between iOS and Android devices, preventing ghost connections where Android thinks iOS peer is still connected after leaving.

Related Code References:
- iOS sendLeave(): Already correctly includes nickname (line 1391)
- Android sendLeaveAnnouncement(): Already correctly includes nickname (line 957)
- iOS stopServices(): Now fixed to include nickname (line 503)