### PR TITLE
Fix Swift 6 concurrency warnings

### DIFF
--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -53,9 +53,10 @@ struct BitchatApp: App {
                     // Inject live Noise service into VerificationService to avoid creating new BLE instances
                     VerificationService.shared.configure(with: chatViewModel.meshService.getNoiseService())
                     // Prewarm Nostr identity and QR to make first VERIFY sheet fast
+                    let nickname = chatViewModel.nickname
                     DispatchQueue.global(qos: .utility).async {
                         let npub = try? idBridge.getCurrentNostrIdentity()?.npub
-                        _ = VerificationService.shared.buildMyQRString(nickname: chatViewModel.nickname, npub: npub)
+                        _ = VerificationService.shared.buildMyQRString(nickname: nickname, npub: npub)
                     }
 
                     appDelegate.chatViewModel = chatViewModel


### PR DESCRIPTION
## Summary
- Fix main actor isolation warnings in Timer callbacks in ContentView
- Fix Sendable closure warning in BitchatApp

## Changes
- **ContentView.swift**: Wrap Timer callbacks in `Task { @MainActor in }` to properly access main actor-isolated properties (`updateAutocomplete`, `messages`)
- **BitchatApp.swift**: Capture `nickname` before entering background queue to avoid accessing main actor-isolated property from Sendable closure