### PR TITLE
fix(ui): move location notes button from #mesh to location channels

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1436,6 +1436,9 @@ struct ContentView: View {
                 LocationChannelManager.shared.endLiveRefresh()
             }
             .onChange(of: locationManager.availableChannels) { channels in
+                // Only auto-update notesGeohash if sheet is not already open
+                // (user may have selected a specific channel's geohash)
+                guard !showLocationNotes else { return }
                 if let current = channels.first(where: { $0.level == .building })?.geohash,
                     notesGeohash != current {
                     notesGeohash = current


### PR DESCRIPTION
## Summary

Fixes #904

The "Add a note for others to find" feature posts permanent notes to Nostr (internet), not mesh. This creates potential privacy concerns when housed under #mesh, as users might accidentally link their location to their nym.

**Changes:**
- Move the location notes button from #mesh tab to location channels (#geohash)
- Simplify the geohash lookup - use the current channel's geohash directly
- Consolidate the notes and bookmark buttons in the location channel view

## Test plan

- [ ] Verify notes button no longer appears in #mesh
- [ ] Verify notes button appears in location channels (e.g., #u281)
- [ ] Verify clicking notes opens the location notes sheet with correct geohash
- [ ] Verify bookmark button still works alongside notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)