### PR TITLE
fix(build): exclude allowBluetoothHFP on iOS Simulator

### DIFF
--- a/bitchat/Features/voice/VoiceRecorder.swift
+++ b/bitchat/Features/voice/VoiceRecorder.swift
@@ -58,11 +58,20 @@ final class VoiceRecorder: NSObject, AVAudioRecorderDelegate {
             guard session.recordPermission == .granted else {
                 throw RecorderError.microphoneAccessDenied
             }
+            #if targetEnvironment(simulator)
+            // allowBluetoothHFP is not available on iOS Simulator
+            try session.setCategory(
+                .playAndRecord,
+                mode: .default,
+                options: [.defaultToSpeaker, .allowBluetoothA2DP]
+            )
+            #else
             try session.setCategory(
                 .playAndRecord,
                 mode: .default,
                 options: [.defaultToSpeaker, .allowBluetoothA2DP, .allowBluetoothHFP]
             )
+            #endif
             try session.setActive(true, options: .notifyOthersOnDeactivation)
             #endif
             #if os(macOS)


### PR DESCRIPTION
## Summary

Fix iOS Simulator build failure caused by `allowBluetoothHFP` not being available on simulator.

**Changes:**
- Add `#if targetEnvironment(simulator)` conditional compilation
- Exclude `allowBluetoothHFP` option when building for iOS Simulator
- Keep `allowBluetoothHFP` for device builds to maintain Bluetooth HFP support

## Test plan

- [x] Build succeeds on iOS Simulator
- [ ] Voice recording works on iOS Simulator
- [ ] Voice recording with Bluetooth HFP works on physical device