### PR TITLE
fix: eliminate flaky FragmentationTests with proper async synchronization

### DIFF
--- a/bitchatTests/Fragmentation/FragmentationTests.swift
+++ b/bitchatTests/Fragmentation/FragmentationTests.swift
@@ -263,6 +263,13 @@ extension FragmentationTests {
                 group.addTask {
                     await withCheckedContinuation { continuation in
                         self.lock.lock()
+                        // Recheck count after acquiring lock to avoid race condition
+                        // where message arrives between initial check and continuation install
+                        if self._publicMessages.count >= count {
+                            self.lock.unlock()
+                            continuation.resume()
+                            return
+                        }
                         self.publicMessageContinuation = continuation
                         self.lock.unlock()
                     }
@@ -290,6 +297,13 @@ extension FragmentationTests {
                 group.addTask {
                     await withCheckedContinuation { continuation in
                         self.lock.lock()
+                        // Recheck count after acquiring lock to avoid race condition
+                        // where message arrives between initial check and continuation install
+                        if self._receivedMessages.count >= count {
+                            self.lock.unlock()
+                            continuation.resume()
+                            return
+                        }
                         self.receivedMessageContinuation = continuation
                         self.lock.unlock()
                     }


### PR DESCRIPTION
## Summary
- Fix intermittent failures in `reassemblyFromFragmentsDeliversPublicMessage` and `duplicateFragmentDoesNotBreakReassembly` tests
- Replace fire-and-forget Task blocks with sequential fragment sending
- Add thread-safe `CaptureDelegate` with continuation-based waiting instead of `sleep(0.5)`

## Root Cause
Tests used fire-and-forget `Task { sleep; handlePacket }` blocks followed by `sleep(0.5)` to wait for results. However, delegate callbacks go through `notifyUI()` which spawns another MainActor Task - the sleep didn't guarantee callback completion.

## Solution
- Thread-safe `CaptureDelegate` with `NSLock` for array access
- `waitForPublicMessages(count:timeout:)` using `CheckedContinuation` with timeout
- Sequential fragment sending with `try await Task.sleep()` between fragments

## Test plan
- [x] Run FragmentationTests 3+ times to verify no flakiness
- [x] Verify all 4 tests pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)