### PR TITLE
chore: pin swift-secp256k1 to exact version 0.21.1

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -924,8 +924,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/21-DOT-DEV/swift-secp256k1";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.21.1;
+				kind = exactVersion;
+				version = 0.21.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Change dependency requirement from upToNextMajorVersion to exactVersion to ensure consistent builds and prevent unexpected breaking changes. This change makes the Xcode project more similar to the [SPM manifest](https://github.com/permissionlesstech/bitchat/blob/aff700a15e1e5fcc7bb33844eb65046ca866e0ea/Package.swift#L21). 

<img width="800" height="305" alt="image" src="https://github.com/user-attachments/assets/8158f4af-e4cf-4564-8f6e-359ed8ae5a5e" />
