### PR TITLE
fix(security): reduce timestamp validation window to ±5 minutes [BCH-01-011]

### DIFF
--- a/bitchat/Utils/InputValidator.swift
+++ b/bitchat/Utils/InputValidator.swift
@@ -52,11 +52,13 @@ struct InputValidator {
     // MessageType/NoisePayloadType enums; keeping validator free of stale lists.
 
     /// Validates timestamp is reasonable (not too far in past or future)
+    /// BCH-01-011: Reduced from ±1 hour to ±5 minutes to limit replay attack window
     static func validateTimestamp(_ timestamp: Date) -> Bool {
         let now = Date()
-        let oneHourAgo = now.addingTimeInterval(-3600)
-        let oneHourFromNow = now.addingTimeInterval(3600)
-        return timestamp >= oneHourAgo && timestamp <= oneHourFromNow
+        // 5 minutes = 300 seconds (industry standard for replay protection)
+        let fiveMinutesAgo = now.addingTimeInterval(-300)
+        let fiveMinutesFromNow = now.addingTimeInterval(300)
+        return timestamp >= fiveMinutesAgo && timestamp <= fiveMinutesFromNow
     }
 
 }

--- a/bitchatTests/InputValidatorTests.swift
+++ b/bitchatTests/InputValidatorTests.swift
@@ -131,6 +131,7 @@ struct InputValidatorTests {
     }
 
     // MARK: - Timestamp Validation Tests
+    // BCH-01-011: Window reduced from ±1 hour to ±5 minutes
 
     @Test func currentTimestampIsValid() throws {
         let now = Date()
@@ -138,29 +139,46 @@ struct InputValidatorTests {
         #expect(result == true)
     }
 
-    @Test func timestampWithinOneHourIsValid() throws {
+    @Test func timestampWithinFiveMinutesIsValid() throws {
+        // 2 minutes ago should be valid (within 5-minute window)
+        let twoMinutesAgo = Date().addingTimeInterval(-2 * 60)
+        let result = InputValidator.validateTimestamp(twoMinutesAgo)
+        #expect(result == true)
+    }
+
+    @Test func timestampThirtyMinutesAgoIsInvalid() throws {
+        // BCH-01-011: 30 minutes is now outside the 5-minute window
         let thirtyMinutesAgo = Date().addingTimeInterval(-30 * 60)
         let result = InputValidator.validateTimestamp(thirtyMinutesAgo)
-        #expect(result == true)
-    }
-
-    @Test func timestampTwoHoursAgoIsInvalid() throws {
-        let twoHoursAgo = Date().addingTimeInterval(-2 * 3600)
-        let result = InputValidator.validateTimestamp(twoHoursAgo)
         #expect(result == false)
     }
 
-    @Test func timestampTwoHoursInFutureIsInvalid() throws {
-        let twoHoursFromNow = Date().addingTimeInterval(2 * 3600)
-        let result = InputValidator.validateTimestamp(twoHoursFromNow)
+    @Test func timestampTenMinutesAgoIsInvalid() throws {
+        // 10 minutes is outside the 5-minute window
+        let tenMinutesAgo = Date().addingTimeInterval(-10 * 60)
+        let result = InputValidator.validateTimestamp(tenMinutesAgo)
         #expect(result == false)
     }
 
-    @Test func timestampAtOneHourBoundaryIsValid() throws {
-        // Just slightly within the one-hour window
-        let almostOneHourAgo = Date().addingTimeInterval(-3599)
-        let result = InputValidator.validateTimestamp(almostOneHourAgo)
+    @Test func timestampTenMinutesInFutureIsInvalid() throws {
+        // 10 minutes in future is outside the 5-minute window
+        let tenMinutesFromNow = Date().addingTimeInterval(10 * 60)
+        let result = InputValidator.validateTimestamp(tenMinutesFromNow)
+        #expect(result == false)
+    }
+
+    @Test func timestampAtFiveMinuteBoundaryIsValid() throws {
+        // Just slightly within the five-minute window (299 seconds)
+        let almostFiveMinutesAgo = Date().addingTimeInterval(-299)
+        let result = InputValidator.validateTimestamp(almostFiveMinutesAgo)
         #expect(result == true)
+    }
+
+    @Test func timestampJustOutsideFiveMinuteWindowIsInvalid() throws {
+        // Just outside the five-minute window (301 seconds)
+        let justOverFiveMinutesAgo = Date().addingTimeInterval(-301)
+        let result = InputValidator.validateTimestamp(justOverFiveMinutesAgo)
+        #expect(result == false)
     }
 
     // MARK: - Edge Cases


### PR DESCRIPTION
## Summary

- **BCH-01-011**: Reduces timestamp validation window from ±1 hour to ±5 minutes
- Limits replay attack exposure by rejecting messages with stale or far-future timestamps
- 5-minute window is industry standard for replay protection while tolerating clock drift

## Changes

- `InputValidator.validateTimestamp` now uses 300-second (5 min) window instead of 3600-second (1 hour)
- Updated tests to verify boundary conditions for new 5-minute window

## Test plan

- [x] All 32 InputValidator tests pass
- [x] Full test suite (376 tests) passes
- [ ] Manual verification: messages with timestamps >5 minutes old are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)