### PR TITLE
BCH-01-010: Noise Protocol spec compliance improvements

### DIFF
--- a/bitchat/Noise/NoiseSession.swift
+++ b/bitchat/Noise/NoiseSession.swift
@@ -102,23 +102,23 @@ class NoiseSession {
             
             // Check if handshake is complete
             if handshake.isHandshakeComplete() {
-                // Get transport ciphers
-                let (send, receive) = try handshake.getTransportCiphers(useExtractedNonce: true)
+                // Get transport ciphers and handshake hash (hash captured before split clears state)
+                let (send, receive, hash) = try handshake.getTransportCiphers(useExtractedNonce: true)
                 sendCipher = send
                 receiveCipher = receive
-                
+
                 // Store remote static key
                 remoteStaticPublicKey = handshake.getRemoteStaticPublicKey()
-                
+
                 // Store handshake hash for channel binding
-                handshakeHash = handshake.getHandshakeHash()
-                
+                handshakeHash = hash
+
                 state = .established
                 handshakeState = nil // Clear handshake state
-                
+
                 SecureLogger.debug("NoiseSession[\(peerID)]: Handshake complete (no response needed), transitioning to established")
                 SecureLogger.info(.handshakeCompleted(peerID: peerID.id))
-                
+
                 return nil
             } else {
                 // Generate response
@@ -128,20 +128,20 @@ class NoiseSession {
                 
                 // Check if handshake is complete after writing
                 if handshake.isHandshakeComplete() {
-                    // Get transport ciphers
-                    let (send, receive) = try handshake.getTransportCiphers(useExtractedNonce: true)
+                    // Get transport ciphers and handshake hash (hash captured before split clears state)
+                    let (send, receive, hash) = try handshake.getTransportCiphers(useExtractedNonce: true)
                     sendCipher = send
                     receiveCipher = receive
-                    
+
                     // Store remote static key
                     remoteStaticPublicKey = handshake.getRemoteStaticPublicKey()
-                    
+
                     // Store handshake hash for channel binding
-                    handshakeHash = handshake.getHandshakeHash()
-                    
+                    handshakeHash = hash
+
                     state = .established
                     handshakeState = nil // Clear handshake state
-                    
+
                     SecureLogger.debug("NoiseSession[\(peerID)]: Handshake complete after writing response, transitioning to established")
                     SecureLogger.info(.handshakeCompleted(peerID: peerID.id))
                 }


### PR DESCRIPTION
## Summary
- Expands nonce from 4-byte to full 8-byte transmission per Noise spec (2^64 nonce space)
- Fixes potential integer overflow in replay window check using safe arithmetic
- Adds constant-time comparison functions for key validation (prevents timing side-channels)
- Adds `clearSensitiveData()` to `NoiseSymmetricState` to clear chaining key/hash after split
- Documents atomic nonce state updates in decryption

## Background
Cure53 security audit (BCH-01-010) identified that while the core XX handshake pattern is cryptographically correct, the implementation contained quality issues that reduced security margins and violated best practices for key hygiene and memory safety. This is an Info-severity finding focused on spec compliance and defense-in-depth.

## Changes Made

### 1. Full 8-byte nonce transmission
The implementation was transmitting only 4-byte nonces, limiting nonce space to 2^32 messages. Now uses full 8-byte nonces per Noise spec guidance.

### 2. Integer overflow fix
Changed replay window check from `receivedNonce + WINDOW_SIZE <= highest` to safe arithmetic that prevents overflow when receivedNonce is near UInt64.max.

### 3. Constant-time operations
Added `constantTimeCompare()` and `constantTimeIsZero()` functions for key validation, preventing timing side-channel attacks.

### 4. Symmetric state clearing
Added `clearSensitiveData()` method to `NoiseSymmetricState` that clears the chaining key and hash after the split operation, per Noise spec guidance.

### 5. Atomic nonce updates
Documented that nonce state updates (replay window marking + increment) are performed atomically after successful decryption only.

## Test plan
- [x] Build succeeds for macOS
- [x] All 374 existing tests pass
- [x] Noise handshake and encryption/decryption continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)