### PR TITLE
fix: update georelays weekly workflow

### DIFF
--- a/.github/workflows/fetch_georelays.yml
+++ b/.github/workflows/fetch_georelays.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add app/src/main/assets/nostr_relays.csv
+          git add relays/online_relays_gps.csv
           git commit -m "Automated update of relay data - $(date -u)"
           git push
         env:


### PR DESCRIPTION
Restore the original script, which commits directly into `main` with the updated relay list.