### PR TITLE
Remove security warning from AppInfo view

### DIFF
--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -86,10 +86,6 @@ struct AppInfoView: View {
             ]
         }
 
-        enum Warning {
-            static let title: LocalizedStringKey = "app_info.warning.title"
-            static let message: LocalizedStringKey = "app_info.warning.message"
-        }
     }
     
     var body: some View {
@@ -192,24 +188,6 @@ struct AppInfoView: View {
 
                 FeatureRow(info: Strings.Privacy.panic)
             }
-
-            // Warning
-            VStack(alignment: .leading, spacing: 6) {
-                SectionHeader(Strings.Warning.title)
-                    .foregroundColor(Color.red)
-                
-                Text(Strings.Warning.message)
-                    .font(.bitchatSystem(size: 14, design: .monospaced))
-                    .foregroundColor(Color.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(.top, 6)
-            .padding(.bottom, 16)
-            .padding(.horizontal)
-            .background(Color.red.opacity(0.1))
-            .cornerRadius(8)
-            
-            .padding(.top)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- Removes the red security warning section from the AppInfo view
- Deletes the Warning strings enum and associated UI components

## Test plan
- [x] Open the app info view and verify the warning section is no longer displayed
- [x] Verify no build errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)