### PR TITLE
Fix READ receipt status not updating to blue checks

### DIFF
--- a/bitchat/ViewModels/Extensions/ChatViewModel+PrivateChat.swift
+++ b/bitchat/ViewModels/Extensions/ChatViewModel+PrivateChat.swift
@@ -740,15 +740,11 @@ extension ChatViewModel {
         
         if isViewing {
             // Mark read immediately if viewing
-            // Use router to send read receipt
+            // Use the incoming peerID directly - it has the established Noise session.
+            // Don't use PeerID(hexData: noiseKey) as that creates a 64-hex ID without a session.
+            // Use meshService directly (not messageRouter) so it queues if peer disconnects.
             let receipt = ReadReceipt(originalMessageID: message.id, readerID: meshService.myPeerID, readerNickname: nickname)
-            if let key = noiseKey {
-                 // Send via router to stable key if available (preferred for persistence/Nostr fallback)
-                 messageRouter.sendReadReceipt(receipt, to: PeerID(hexData: key))
-            } else {
-                 // Fallback to mesh direct
-                 meshService.sendReadReceipt(receipt, to: peerID)
-            }
+            meshService.sendReadReceipt(receipt, to: peerID)
             sentReadReceipts.insert(message.id)
         } else {
             // Notify


### PR DESCRIPTION
## Summary
- Fix READ receipts not updating message status from delivered (green ✓✓) to read (blue ✓✓) after the first message
- Add `findMessageIndex` helper to handle peer ID format mismatch between short (16-hex) and long (64-hex) noise key formats
- Prevent race condition where late-arriving DELIVERED acks overwrite READ status
- Use incoming peerID directly for sending READ receipts instead of creating new ID from noise key

## Root Causes Fixed
1. **Peer ID format mismatch**: Messages stored under one format (64-hex noise key), but receipts arriving with different format (16-hex ephemeral ID)
2. **Race condition**: DELIVERED acks arriving after READ receipts were downgrading `.read` back to `.delivered`
3. **Wrong peer ID for receipts**: `handlePrivateMessage` was creating a new 64-hex peer ID from noise key, but Noise session was established with 16-hex ephemeral ID

## Test plan
- [x] Send multiple private messages via BLE
- [x] Verify all messages show blue double checks after recipient reads them
- [x] Verify status doesn't flip back to green after showing blue

🤖 Generated with [Claude Code](https://claude.ai/code)