### PR TITLE
Remove dormant wake attempt on Tor foreground restart

### DIFF
--- a/bitchat/ViewModels/Extensions/ChatViewModel+Tor.swift
+++ b/bitchat/ViewModels/Extensions/ChatViewModel+Tor.swift
@@ -24,7 +24,7 @@ extension ChatViewModel {
             }
         }
     }
-    
+
     @objc func handleTorWillRestart() {
         Task { @MainActor in
             self.torRestartPending = true


### PR DESCRIPTION
## Summary

- Eliminates 1-3+ second delay before "restarting tor" message appears on app foreground
- Removes dead code path that was never succeeding

## Background

When the app returns to foreground, it was attempting to "wake" Tor from dormant mode before falling back to a full restart. However, Arti's `arti_go_dormant()` and `arti_wake()` FFI functions are no-op stubs:

```rust
pub extern "C" fn arti_go_dormant() -> c_int {
    // Arti doesn't have explicit dormant mode yet, but we can note the intent
    update_summary("Dormant");
    0
}
```

The wake attempt would always fail (iOS suspends the Tokio runtime when backgrounded), causing a 2.5-12 second delay before the actual restart began.

## Changes

- Remove `wakeFromDormant()` function and its call in `ensureRunningOnForeground()`
- Simplify `goDormantOnBackground()` to just mark state as not ready (no FFI calls needed)
- Go straight to `restartArti()` on foreground

## Test plan

- [x] Background the app for 5+ seconds with Tor enabled
- [x] Foreground the app
- [x] Verify "tor restarting..." message appears immediately (no delay)
- [x] Verify Tor eventually becomes ready and Nostr reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)