### PR TITLE
fix: route favorites through MessageRouter outbox

### DIFF
--- a/bitchat/Services/MessageRouter.swift
+++ b/bitchat/Services/MessageRouter.swift
@@ -6,6 +6,9 @@ import Foundation
 @MainActor
 final class MessageRouter {
     private let transports: [Transport]
+    // Used to stamp our own Nostr identity onto favorite notifications so the
+    // recipient can learn our npub. Optional so tests can omit it.
+    private let idBridge: NostrIdentityBridge?
 
     // Outbox entry with timestamp for TTL-based eviction
     private struct QueuedMessage {
@@ -25,8 +28,9 @@ final class MessageRouter {
     // get a delivery ack (e.g. peer on an old client that doesn't ack).
     private static let maxSendAttempts = 8
 
-    init(transports: [Transport]) {
+    init(transports: [Transport], idBridge: NostrIdentityBridge? = nil) {
         self.transports = transports
+        self.idBridge = idBridge
 
         // Observe favorites changes to learn Nostr mapping and flush queued messages
         NotificationCenter.default.addObserver(
@@ -65,6 +69,11 @@ final class MessageRouter {
     // MARK: - Message Sending
 
     func sendPrivate(_ content: String, to peerID: PeerID, recipientNickname: String, messageID: String) {
+        // Normalize to the short ID so the outbox is keyed consistently. Callers
+        // pass either a 16-hex short ID (active chat) or a 64-hex noise-key ID
+        // (e.g. favorite toggles); a peer reconnect flushes by short ID, so a
+        // mismatch would otherwise leave queued messages stranded.
+        let peerID = peerID.toShort()
         if let transport = connectedTransport(for: peerID) {
             // A live link is a strong delivery signal; trust it outright.
             SecureLogger.debug("Routing PM via \(type(of: transport)) (connected) to \(peerID.id.prefix(8))… id=\(messageID.prefix(8))…", category: .session)
@@ -129,16 +138,22 @@ final class MessageRouter {
     }
 
     func sendFavoriteNotification(to peerID: PeerID, isFavorite: Bool) {
-        if let transport = connectedTransport(for: peerID) {
-            transport.sendFavoriteNotification(to: peerID, isFavorite: isFavorite)
-        } else if let transport = reachableTransport(for: peerID) {
-            transport.sendFavoriteNotification(to: peerID, isFavorite: isFavorite)
+        // Route favorites through the outbox (same `[FAVORITED]:<npub>` payload the
+        // transports built internally) so they survive a Noise handshake delay or
+        // offline queuing instead of being dropped when the peer is momentarily
+        // unreachable. The recipient parses the prefix and never displays it.
+        var content = isFavorite ? "[FAVORITED]" : "[UNFAVORITED]"
+        if let npub = try? idBridge?.getCurrentNostrIdentity()?.npub {
+            content += ":" + npub
         }
+        sendPrivate(content, to: peerID, recipientNickname: "", messageID: UUID().uuidString)
     }
 
     // MARK: - Outbox Management
 
     func flushOutbox(for peerID: PeerID) {
+        // Match the short-ID keying used when enqueuing in sendPrivate.
+        let peerID = peerID.toShort()
         guard let queued = outbox[peerID], !queued.isEmpty else { return }
         SecureLogger.debug("Flushing outbox for \(peerID.id.prefix(8))… count=\(queued.count)", category: .session)
 

--- a/bitchat/ViewModels/ChatViewModelBootstrapper.swift
+++ b/bitchat/ViewModels/ChatViewModelBootstrapper.swift
@@ -28,7 +28,7 @@ struct ChatViewModelServiceBundle {
         )
         let nostrTransport = NostrTransport(keychain: keychain, idBridge: idBridge)
         nostrTransport.senderPeerID = meshService.myPeerID
-        let messageRouter = MessageRouter(transports: [meshService, nostrTransport])
+        let messageRouter = MessageRouter(transports: [meshService, nostrTransport], idBridge: idBridge)
 
         self.commandProcessor = commandProcessor
         self.messageRouter = messageRouter

--- a/bitchatTests/Services/MessageRouterTests.swift
+++ b/bitchatTests/Services/MessageRouterTests.swift
@@ -124,7 +124,7 @@ struct MessageRouterTests {
     }
 
     @Test @MainActor
-    func sendFavoriteNotification_usesConnectedOrReachable() async {
+    func sendFavoriteNotification_routesThroughOutboxAsPrivateMessage() async {
         let peerID = PeerID(str: "0000000000000004")
         let transport = MockTransport()
         transport.reachablePeers.insert(peerID)
@@ -132,6 +132,25 @@ struct MessageRouterTests {
         let router = MessageRouter(transports: [transport])
         router.sendFavoriteNotification(to: peerID, isFavorite: true)
 
-        #expect(transport.sentFavoriteNotifications.count == 1)
+        // Favorites now ride the outbox (sendPrivate) so they survive offline /
+        // handshake gaps; the recipient parses the `[FAVORITED]` prefix.
+        #expect(transport.sentPrivateMessages.count == 1)
+        #expect(transport.sentPrivateMessages.first?.content.hasPrefix("[FAVORITED]") == true)
+    }
+
+    @Test @MainActor
+    func sendFavoriteNotification_whileOffline_queuesAndFlushesOnReconnect() async {
+        let peerID = PeerID(str: "0000000000000009")
+        let transport = MockTransport()
+        // Peer is neither connected nor reachable: the favorite must be retained.
+        let router = MessageRouter(transports: [transport])
+        router.sendFavoriteNotification(to: peerID, isFavorite: false)
+        #expect(transport.sentPrivateMessages.isEmpty)
+
+        // Peer comes back: the queued favorite flushes.
+        transport.connectedPeers.insert(peerID)
+        router.flushOutbox(for: peerID)
+        #expect(transport.sentPrivateMessages.count == 1)
+        #expect(transport.sentPrivateMessages.first?.content.hasPrefix("[UNFAVORITED]") == true)
     }
 }


### PR DESCRIPTION
## Summary

The core of this PR — the offline message queue, flush-on-reconnect, and retain-until-ack — already landed on `main` via #1331 (`MessageRouter` outbox with `sendAttempts` bounding, `markDelivered`, and the `didConnectToPeer` flush). So I rebased on top of `main` and slimmed this down to the one piece #1331 does **not** cover yet: favorite notifications surviving offline / handshake gaps.

## Changes

- **Favorites through the outbox:** `MessageRouter.sendFavoriteNotification` now builds the `[FAVORITED]:<npub>` payload and routes it through `sendPrivate` (the outbox) instead of the transport's fire-and-forget path. A favorite toggled while the peer is fully offline used to be dropped — now it queues and flushes on reconnect. The receiver already parses the `[FAVORITED]` prefix from the PM content, so the wire format is unchanged.
- **Outbox key normalization:** `sendPrivate` / `flushOutbox` normalize to the short `PeerID`. Favorite toggles pass a 64-hex noise-key ID while a peer reconnect flushes by the 16-hex short ID — without normalizing, a queued favorite would never flush.
- `MessageRouter` gains an optional `NostrIdentityBridge` to stamp our npub on favorite notifications, wired through `ChatViewModelBootstrapper`.

## Dropped (superseded by #1331)

Kept `main`'s outbox design and layered on top instead of replacing it, so the following are gone:

- the `sentAt` + 30s resend-cooldown rework
- `Bool`-returning transport sends
- `confirmDelivery` / `resetSendState`
- the `didEstablishEncryptedSession` delegate
- routing `/me` emotes through the outbox — it caused a local double render (`sendPrivateMessage` echoes into `privateChats`, and the emote also adds a system confirmation), and offline emotes aren't worth that, so reverted to main's direct send

## Test plan

- [x] `swift test --package-path .` (XCTest suite green; the swift-testing parallel run has a pre-existing harness flake unrelated to this change)
- [x] `MessageRouterTests` updated for the outbox-routed behavior
- [x] New test: favorite toggled while offline queues and flushes on reconnect
- [x] iOS simulator build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
