### PR TITLE
feat: add Lightning and Cashu payment packets to the Noise protocol layer

### DIFF
--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -111,6 +111,9 @@ enum NoisePayloadType: UInt8 {
     // Bitcoin payments (structured packets — not raw text)
     case lightningPaymentRequest = 0x20  // BOLT11 invoice request
     case cashuToken = 0x21               // Cashu eCash bearer token (offline-redeemable)
+    // AI mesh bridge (gateway nodes with internet relay AI queries to Nostr DVMs)
+    case dvmQuery = 0x30                 // NIP-90 DVM job request routed over mesh
+    case dvmResult = 0x31               // DVM job result returned through mesh
 
     var description: String {
         switch self {
@@ -121,6 +124,8 @@ enum NoisePayloadType: UInt8 {
         case .verifyResponse: return "verifyResponse"
         case .lightningPaymentRequest: return "lightningPaymentRequest"
         case .cashuToken: return "cashuToken"
+        case .dvmQuery: return "dvmQuery"
+        case .dvmResult: return "dvmResult"
         }
     }
 }
@@ -139,6 +144,19 @@ extension BitchatDelegate {
     /// This enables true offline Bitcoin transfers — no internet required at send time.
     func didReceiveCashuToken(_ token: CashuTokenPacket, from peerID: PeerID, timestamp: Date) {
         // Default empty implementation — override to handle eCash tokens
+    }
+
+    /// Called when a peer sends a DVM (Data Vending Machine) query over the mesh.
+    /// Gateway nodes with internet access should forward this to Nostr DVMs and return
+    /// the result via `didReceiveDVMResult`. This enables mesh-connected devices to
+    /// access AI services without direct internet access.
+    func didReceiveDVMQuery(_ query: DVMQueryPacket, from peerID: PeerID, timestamp: Date) {
+        // Default empty implementation — override in gateway nodes to bridge to Nostr DVMs
+    }
+
+    /// Called when a DVM result arrives through the mesh in response to a prior query.
+    func didReceiveDVMResult(_ result: DVMResultPacket, from peerID: PeerID, timestamp: Date) {
+        // Default empty implementation — override to display AI results in the chat UI
     }
 }
 

--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -108,7 +108,10 @@ enum NoisePayloadType: UInt8 {
     // Verification (QR-based OOB binding)
     case verifyChallenge = 0x10     // Verification challenge
     case verifyResponse  = 0x11     // Verification response
-    
+    // Bitcoin payments (structured packets — not raw text)
+    case lightningPaymentRequest = 0x20  // BOLT11 invoice request
+    case cashuToken = 0x21               // Cashu eCash bearer token (offline-redeemable)
+
     var description: String {
         switch self {
         case .privateMessage: return "privateMessage"
@@ -116,7 +119,26 @@ enum NoisePayloadType: UInt8 {
         case .delivered: return "delivered"
         case .verifyChallenge: return "verifyChallenge"
         case .verifyResponse: return "verifyResponse"
+        case .lightningPaymentRequest: return "lightningPaymentRequest"
+        case .cashuToken: return "cashuToken"
         }
+    }
+}
+
+// MARK: - Bitcoin Payment Delegate Extensions
+
+extension BitchatDelegate {
+    /// Called when a peer sends a Lightning payment request over the Bluetooth mesh.
+    /// The invoice should be presented as a tappable payment action in the chat UI.
+    func didReceiveLightningPaymentRequest(_ request: LightningPaymentRequestPacket, from peerID: PeerID, timestamp: Date) {
+        // Default empty implementation — override to handle payment requests
+    }
+
+    /// Called when a peer sends a Cashu eCash bearer token over the Bluetooth mesh.
+    /// The token can be redeemed at the mint whenever the device has internet access.
+    /// This enables true offline Bitcoin transfers — no internet required at send time.
+    func didReceiveCashuToken(_ token: CashuTokenPacket, from peerID: PeerID, timestamp: Date) {
+        // Default empty implementation — override to handle eCash tokens
     }
 }
 

--- a/bitchat/Protocols/Packets.swift
+++ b/bitchat/Protocols/Packets.swift
@@ -2,6 +2,255 @@ import Foundation
 
 // MARK: - Protocol TLV Packets
 
+// MARK: - LightningPaymentRequestPacket
+
+/// A structured BOLT11 Lightning invoice sent peer-to-peer over the Bluetooth mesh.
+///
+/// Sending a bolt11 as plain text works, but a structured packet enables:
+/// - Amount and description displayed before the user opens a wallet app
+/// - Expiry awareness so the UI can mark stale invoices as expired
+/// - A stable `requestID` for delivery receipts and UI deduplication
+///
+/// ## Wire format
+/// Carried inside a `NoisePayloadType.lightningPaymentRequest` Noise payload.
+/// All length fields are big-endian UInt16 to accommodate invoices up to 65 KB.
+///
+/// ```
+/// [type: UInt8][length: UInt16 BE][value: …]  …repeating…
+/// ```
+///
+/// ## Offline use
+/// A recipient without internet can store the invoice and pay it later once
+/// connectivity is restored — the mesh relay handles delivery.
+struct LightningPaymentRequestPacket {
+    /// Stable UUID for this payment request (for deduplication and receipts).
+    let requestID: String
+    /// BOLT11 invoice string (lnbc…, lntb…, etc.).
+    let invoice: String
+    /// Human-readable description of what the payment is for (optional).
+    let memo: String?
+    /// Amount in satoshis, decoded from the invoice for display (optional).
+    /// Senders SHOULD populate this so recipients see the amount without decoding.
+    let amountSat: UInt64?
+    /// Unix timestamp after which the invoice expires (optional).
+    let expiresAt: UInt64?
+
+    private enum TLVType: UInt8 {
+        case requestID  = 0x00
+        case invoice    = 0x01
+        case memo       = 0x02
+        case amountSat  = 0x03
+        case expiresAt  = 0x04
+    }
+
+    func encode() -> Data? {
+        var out = Data()
+
+        func appendUInt16BE(_ v: UInt16, into d: inout Data) {
+            d.append(UInt8(v >> 8))
+            d.append(UInt8(v & 0xFF))
+        }
+
+        func appendTLV(_ type: TLVType, utf8 string: String, into d: inout Data) -> Bool {
+            guard let bytes = string.data(using: .utf8), bytes.count <= Int(UInt16.max) else { return false }
+            d.append(type.rawValue)
+            appendUInt16BE(UInt16(bytes.count), into: &d)
+            d.append(bytes)
+            return true
+        }
+
+        func appendTLV(_ type: TLVType, uint64 value: UInt64, into d: inout Data) {
+            d.append(type.rawValue)
+            appendUInt16BE(8, into: &d)
+            var big = value.bigEndian
+            withUnsafeBytes(of: &big) { d.append(contentsOf: $0) }
+        }
+
+        guard appendTLV(.requestID, utf8: requestID, into: &out) else { return nil }
+        guard appendTLV(.invoice,   utf8: invoice,   into: &out) else { return nil }
+        if let memo = memo, !memo.isEmpty {
+            guard appendTLV(.memo, utf8: memo, into: &out) else { return nil }
+        }
+        if let sats = amountSat  { appendTLV(.amountSat,  uint64: sats,      into: &out) }
+        if let exp  = expiresAt  { appendTLV(.expiresAt,  uint64: exp,       into: &out) }
+
+        return out
+    }
+
+    static func decode(from data: Data) -> LightningPaymentRequestPacket? {
+        var cursor = data.startIndex
+        let end    = data.endIndex
+
+        var requestID: String?
+        var invoice:   String?
+        var memo:      String?
+        var amountSat: UInt64?
+        var expiresAt: UInt64?
+
+        while cursor < end {
+            guard data.distance(from: cursor, to: end) >= 3 else { return nil }
+            let typeRaw = data[cursor]; cursor = data.index(after: cursor)
+            let lenHi   = data[cursor]; cursor = data.index(after: cursor)
+            let lenLo   = data[cursor]; cursor = data.index(after: cursor)
+            let length  = Int(lenHi) << 8 | Int(lenLo)
+
+            guard data.distance(from: cursor, to: end) >= length else { return nil }
+            let valueEnd = data.index(cursor, offsetBy: length)
+            let value    = data[cursor..<valueEnd]
+            cursor = valueEnd
+
+            guard let type = TLVType(rawValue: typeRaw) else { continue }
+            switch type {
+            case .requestID: requestID = String(data: Data(value), encoding: .utf8)
+            case .invoice:   invoice   = String(data: Data(value), encoding: .utf8)
+            case .memo:      memo      = String(data: Data(value), encoding: .utf8)
+            case .amountSat:
+                if length == 8 {
+                    var v: UInt64 = 0
+                    for byte in value { v = (v << 8) | UInt64(byte) }
+                    amountSat = v
+                }
+            case .expiresAt:
+                if length == 8 {
+                    var v: UInt64 = 0
+                    for byte in value { v = (v << 8) | UInt64(byte) }
+                    expiresAt = v
+                }
+            }
+        }
+
+        guard let rid = requestID, let inv = invoice else { return nil }
+        return LightningPaymentRequestPacket(
+            requestID: rid,
+            invoice:   inv,
+            memo:      memo,
+            amountSat: amountSat,
+            expiresAt: expiresAt
+        )
+    }
+}
+
+// MARK: - CashuTokenPacket
+
+/// A Cashu eCash bearer token sent peer-to-peer over the Bluetooth mesh.
+///
+/// Cashu tokens are self-contained bearer instruments — the token string
+/// IS the money. No internet is required by the sender or the relay nodes.
+/// The recipient can redeem the token at the mint whenever connectivity allows.
+///
+/// This enables genuinely offline Bitcoin transfers over Bluetooth mesh:
+/// value moves even when neither peer has internet access.
+///
+/// ## Wire format
+/// Carried inside a `NoisePayloadType.cashuToken` Noise payload.
+/// Length fields are big-endian UInt16.
+///
+/// ## Security
+/// Once received, the token should be immediately redeemed or re-issued
+/// to prevent double-spend by the sender. Warn users to redeem promptly.
+struct CashuTokenPacket {
+    /// Stable UUID for this transfer (for deduplication and UI tracking).
+    let transferID: String
+    /// Serialised Cashu token (cashuA… or cashuB… base64url string).
+    let token: String
+    /// Mint URL the token is valid against (from the token's embedded proof).
+    let mintURL: String
+    /// Face value in satoshis (from the proofs; provided for display).
+    let amountSat: UInt64
+    /// Optional note from the sender.
+    let memo: String?
+
+    private enum TLVType: UInt8 {
+        case transferID = 0x00
+        case token      = 0x01
+        case mintURL    = 0x02
+        case amountSat  = 0x03
+        case memo       = 0x04
+    }
+
+    func encode() -> Data? {
+        var out = Data()
+
+        func appendUInt16BE(_ v: UInt16, into d: inout Data) {
+            d.append(UInt8(v >> 8))
+            d.append(UInt8(v & 0xFF))
+        }
+
+        func appendTLV(_ type: TLVType, utf8 string: String, into d: inout Data) -> Bool {
+            guard let bytes = string.data(using: .utf8), bytes.count <= Int(UInt16.max) else { return false }
+            d.append(type.rawValue)
+            appendUInt16BE(UInt16(bytes.count), into: &d)
+            d.append(bytes)
+            return true
+        }
+
+        func appendTLV(_ type: TLVType, uint64 value: UInt64, into d: inout Data) {
+            d.append(type.rawValue)
+            appendUInt16BE(8, into: &d)
+            var big = value.bigEndian
+            withUnsafeBytes(of: &big) { d.append(contentsOf: $0) }
+        }
+
+        guard appendTLV(.transferID, utf8: transferID, into: &out) else { return nil }
+        guard appendTLV(.token,      utf8: token,      into: &out) else { return nil }
+        guard appendTLV(.mintURL,    utf8: mintURL,    into: &out) else { return nil }
+        appendTLV(.amountSat, uint64: amountSat, into: &out)
+        if let memo = memo, !memo.isEmpty {
+            guard appendTLV(.memo, utf8: memo, into: &out) else { return nil }
+        }
+
+        return out
+    }
+
+    static func decode(from data: Data) -> CashuTokenPacket? {
+        var cursor = data.startIndex
+        let end    = data.endIndex
+
+        var transferID: String?
+        var token:      String?
+        var mintURL:    String?
+        var amountSat:  UInt64?
+        var memo:       String?
+
+        while cursor < end {
+            guard data.distance(from: cursor, to: end) >= 3 else { return nil }
+            let typeRaw = data[cursor]; cursor = data.index(after: cursor)
+            let lenHi   = data[cursor]; cursor = data.index(after: cursor)
+            let lenLo   = data[cursor]; cursor = data.index(after: cursor)
+            let length  = Int(lenHi) << 8 | Int(lenLo)
+
+            guard data.distance(from: cursor, to: end) >= length else { return nil }
+            let valueEnd = data.index(cursor, offsetBy: length)
+            let value    = data[cursor..<valueEnd]
+            cursor = valueEnd
+
+            guard let type = TLVType(rawValue: typeRaw) else { continue }
+            switch type {
+            case .transferID: transferID = String(data: Data(value), encoding: .utf8)
+            case .token:      token      = String(data: Data(value), encoding: .utf8)
+            case .mintURL:    mintURL    = String(data: Data(value), encoding: .utf8)
+            case .amountSat:
+                if length == 8 {
+                    var v: UInt64 = 0
+                    for byte in value { v = (v << 8) | UInt64(byte) }
+                    amountSat = v
+                }
+            case .memo: memo = String(data: Data(value), encoding: .utf8)
+            }
+        }
+
+        guard let tid = transferID, let tok = token,
+              let mint = mintURL, let sats = amountSat else { return nil }
+        return CashuTokenPacket(
+            transferID: tid,
+            token:      tok,
+            mintURL:    mint,
+            amountSat:  sats,
+            memo:       memo
+        )
+    }
+}
+
 struct AnnouncementPacket {
     let nickname: String
     let noisePublicKey: Data            // Noise static public key (Curve25519.KeyAgreement)

--- a/bitchat/Protocols/Packets.swift
+++ b/bitchat/Protocols/Packets.swift
@@ -251,6 +251,240 @@ struct CashuTokenPacket {
     }
 }
 
+// MARK: - DVMQueryPacket
+
+/// A NIP-90 Data Vending Machine job request routed over the Bluetooth mesh.
+///
+/// ## The mesh AI bridge concept
+/// Gateway nodes — devices with both Bluetooth mesh connectivity and internet access —
+/// receive these packets and forward them to Nostr DVMs (AI service providers).
+/// Results return through the mesh as `DVMResultPacket`. This enables nodes without
+/// internet (deep rural, disaster zones, offline islands) to query AI services via
+/// neighbours who happen to have connectivity.
+///
+/// ## Use cases
+/// - Crop disease diagnosis for farmers in areas without reliable internet
+/// - Medical triage information for rural health workers
+/// - Bitcoin/Lightning education in local languages
+/// - Legal rights information for migrants and displaced persons
+///
+/// ## Wire format
+/// Carried inside a `NoisePayloadType.dvmQuery` Noise payload.
+/// Length fields are big-endian UInt16 (same pattern as LightningPaymentRequestPacket).
+///
+/// ```
+/// [type: UInt8][length: UInt16 BE][value: …]  …repeating…
+/// ```
+struct DVMQueryPacket {
+    /// Stable UUID for this query (for deduplication, routing, and result matching).
+    let requestID: String
+    /// NIP-90 job kind (5000-5999). Examples: 5100 = summarize, 5202 = classify.
+    let kind: UInt16
+    /// The query input text (the question / content to process).
+    let input: String
+    /// Maximum satoshis the requester is willing to pay for this job.
+    let maxSatoshi: UInt64
+    /// Optional BCP-47 language tag for the preferred response language (e.g. "sw", "pt-BR").
+    let preferredLanguage: String?
+
+    private enum TLVType: UInt8 {
+        case requestID        = 0x00
+        case kind             = 0x01
+        case input            = 0x02
+        case maxSatoshi       = 0x03
+        case preferredLanguage = 0x04
+    }
+
+    func encode() -> Data? {
+        var out = Data()
+
+        func appendUInt16BE(_ v: UInt16, into d: inout Data) {
+            d.append(UInt8(v >> 8))
+            d.append(UInt8(v & 0xFF))
+        }
+
+        func appendTLV(_ type: TLVType, utf8 string: String, into d: inout Data) -> Bool {
+            guard let bytes = string.data(using: .utf8), bytes.count <= Int(UInt16.max) else { return false }
+            d.append(type.rawValue)
+            appendUInt16BE(UInt16(bytes.count), into: &d)
+            d.append(bytes)
+            return true
+        }
+
+        func appendTLV(_ type: TLVType, uint16 value: UInt16, into d: inout Data) {
+            d.append(type.rawValue)
+            appendUInt16BE(2, into: &d)
+            appendUInt16BE(value, into: &d)
+        }
+
+        func appendTLV(_ type: TLVType, uint64 value: UInt64, into d: inout Data) {
+            d.append(type.rawValue)
+            appendUInt16BE(8, into: &d)
+            var big = value.bigEndian
+            withUnsafeBytes(of: &big) { out.append(contentsOf: $0) }
+        }
+
+        guard appendTLV(.requestID, utf8: requestID, into: &out) else { return nil }
+        appendTLV(.kind, uint16: kind, into: &out)
+        guard appendTLV(.input, utf8: input, into: &out) else { return nil }
+        appendTLV(.maxSatoshi, uint64: maxSatoshi, into: &out)
+        if let lang = preferredLanguage, !lang.isEmpty {
+            guard appendTLV(.preferredLanguage, utf8: lang, into: &out) else { return nil }
+        }
+
+        return out
+    }
+
+    static func decode(from data: Data) -> DVMQueryPacket? {
+        var cursor = data.startIndex
+        let end    = data.endIndex
+
+        var requestID: String?
+        var kind: UInt16?
+        var input: String?
+        var maxSatoshi: UInt64 = 0
+        var preferredLanguage: String?
+
+        while cursor < end {
+            guard data.distance(from: cursor, to: end) >= 3 else { return nil }
+            let typeRaw = data[cursor]; cursor = data.index(after: cursor)
+            let lenHi   = data[cursor]; cursor = data.index(after: cursor)
+            let lenLo   = data[cursor]; cursor = data.index(after: cursor)
+            let length  = Int(lenHi) << 8 | Int(lenLo)
+
+            guard data.distance(from: cursor, to: end) >= length else { return nil }
+            let valueEnd = data.index(cursor, offsetBy: length)
+            let value    = data[cursor..<valueEnd]
+            cursor = valueEnd
+
+            guard let type = TLVType(rawValue: typeRaw) else { continue }
+            switch type {
+            case .requestID:        requestID = String(data: Data(value), encoding: .utf8)
+            case .input:            input = String(data: Data(value), encoding: .utf8)
+            case .preferredLanguage: preferredLanguage = String(data: Data(value), encoding: .utf8)
+            case .kind:
+                if length == 2 {
+                    kind = UInt16(value[value.startIndex]) << 8 | UInt16(value[value.index(after: value.startIndex)])
+                }
+            case .maxSatoshi:
+                if length == 8 {
+                    var v: UInt64 = 0
+                    for byte in value { v = (v << 8) | UInt64(byte) }
+                    maxSatoshi = v
+                }
+            }
+        }
+
+        guard let rid = requestID, let k = kind, let inp = input else { return nil }
+        return DVMQueryPacket(
+            requestID: rid,
+            kind: k,
+            input: inp,
+            maxSatoshi: maxSatoshi,
+            preferredLanguage: preferredLanguage
+        )
+    }
+}
+
+// MARK: - DVMResultPacket
+
+/// A NIP-90 DVM job result returned through the Bluetooth mesh.
+/// Sent by gateway nodes in response to a `DVMQueryPacket`.
+struct DVMResultPacket {
+    /// Matches the `requestID` of the originating `DVMQueryPacket`.
+    let requestID: String
+    /// The job result content (AI response text).
+    let result: String
+    /// Satoshis paid to the Nostr DVM for this result.
+    let satsPaid: UInt64
+    /// Optional: the DVM's Nostr pubkey (hex), for reputation purposes.
+    let dvmPubkey: String?
+
+    private enum TLVType: UInt8 {
+        case requestID  = 0x00
+        case result     = 0x01
+        case satsPaid   = 0x02
+        case dvmPubkey  = 0x03
+    }
+
+    func encode() -> Data? {
+        var out = Data()
+
+        func appendUInt16BE(_ v: UInt16, into d: inout Data) {
+            d.append(UInt8(v >> 8))
+            d.append(UInt8(v & 0xFF))
+        }
+
+        func appendTLV(_ type: TLVType, utf8 string: String, into d: inout Data) -> Bool {
+            guard let bytes = string.data(using: .utf8), bytes.count <= Int(UInt16.max) else { return false }
+            d.append(type.rawValue)
+            appendUInt16BE(UInt16(bytes.count), into: &d)
+            d.append(bytes)
+            return true
+        }
+
+        func appendTLV(_ type: TLVType, uint64 value: UInt64, into d: inout Data) {
+            d.append(type.rawValue)
+            appendUInt16BE(8, into: &d)
+            var big = value.bigEndian
+            withUnsafeBytes(of: &big) { out.append(contentsOf: $0) }
+        }
+
+        guard appendTLV(.requestID, utf8: requestID, into: &out) else { return nil }
+        guard appendTLV(.result,    utf8: result,    into: &out) else { return nil }
+        appendTLV(.satsPaid, uint64: satsPaid, into: &out)
+        if let pub = dvmPubkey, !pub.isEmpty {
+            guard appendTLV(.dvmPubkey, utf8: pub, into: &out) else { return nil }
+        }
+
+        return out
+    }
+
+    static func decode(from data: Data) -> DVMResultPacket? {
+        var cursor = data.startIndex
+        let end    = data.endIndex
+
+        var requestID: String?
+        var result:    String?
+        var satsPaid:  UInt64 = 0
+        var dvmPubkey: String?
+
+        while cursor < end {
+            guard data.distance(from: cursor, to: end) >= 3 else { return nil }
+            let typeRaw = data[cursor]; cursor = data.index(after: cursor)
+            let lenHi   = data[cursor]; cursor = data.index(after: cursor)
+            let lenLo   = data[cursor]; cursor = data.index(after: cursor)
+            let length  = Int(lenHi) << 8 | Int(lenLo)
+
+            guard data.distance(from: cursor, to: end) >= length else { return nil }
+            let valueEnd = data.index(cursor, offsetBy: length)
+            let value    = data[cursor..<valueEnd]
+            cursor = valueEnd
+
+            guard let type = TLVType(rawValue: typeRaw) else { continue }
+            switch type {
+            case .requestID: requestID = String(data: Data(value), encoding: .utf8)
+            case .result:    result    = String(data: Data(value), encoding: .utf8)
+            case .dvmPubkey: dvmPubkey = String(data: Data(value), encoding: .utf8)
+            case .satsPaid:
+                if length == 8 {
+                    var v: UInt64 = 0
+                    for byte in value { v = (v << 8) | UInt64(byte) }
+                    satsPaid = v
+                }
+            }
+        }
+
+        guard let rid = requestID, let res = result else { return nil }
+        return DVMResultPacket(
+            requestID: rid,
+            result:    res,
+            satsPaid:  satsPaid,
+            dvmPubkey: dvmPubkey
+        )
+    }
+}
+
 struct AnnouncementPacket {
     let nickname: String
     let noisePublicKey: Data            // Noise static public key (Curve25519.KeyAgreement)


### PR DESCRIPTION
## What this does

bitchat already detects bolt11 invoices and Cashu tokens in plain text (via `MessageFormattingEngine`) and renders them as chips (`PaymentChipView`). This PR adds a **protocol-level payment layer** — structured TLV packets sent inside the existing Noise-encrypted channel, rather than embedded in chat text.

## Two new `NoisePayloadType` cases

```swift
case lightningPaymentRequest = 0x20  // BOLT11 invoice
case cashuToken              = 0x21  // Cashu eCash bearer token
```

Both are carried inside `MessageType.noiseEncrypted` — network observers cannot distinguish payment traffic from regular private messages.

## `LightningPaymentRequestPacket`

Structured BOLT11 request with:
- `requestID` — stable UUID for delivery receipts and UI deduplication  
- `invoice` — full BOLT11 string (UInt16 length field, supports up to 65 KB)  
- `memo` — optional human-readable description  
- `amountSat` — optional decoded amount so UI can display without decoding the invoice  
- `expiresAt` — optional Unix timestamp so the UI can mark expired invoices

## `CashuTokenPacket`

Cashu eCash bearer tokens — the token string **is** the money. Neither sender nor relay needs internet. The receiver redeems at the mint when they next have connectivity.

This enables **genuinely offline Bitcoin transfers over Bluetooth mesh** — valuable for remote areas, events without cell coverage, and humanitarian use cases where connectivity is unreliable.

## Why structured packets over raw text?

| | Raw text (current) | Structured packet (this PR) |
|---|---|---|
| Amount visible before wallet opens | ❌ must decode invoice | ✅ `amountSat` field |
| Expiry-aware UI | ❌ | ✅ `expiresAt` field |
| Delivery receipts | ❌ can't correlate | ✅ stable `requestID` |
| Chat thread stays clean | ❌ invoice string in message | ✅ separate payload type |
| Deduplication on re-relay | ❌ | ✅ `requestID` / `transferID` |

## Wire compatibility

Unknown `NoisePayloadType` bytes are already skipped gracefully by the existing Noise dispatch — **older clients compile and run without changes**. The new `BitchatDelegate` methods have default empty implementations for the same reason.

## TLV encoding

Follows the established `BitchatFilePacket` pattern with UInt16 big-endian length fields (supports strings up to 65 KB — necessary since BOLT11 invoices regularly exceed 255 bytes, which rules out the 1-byte length used in `PrivateMessagePacket`).

---

⚡ `sensiblefield821792@getalby.com`