### PR TITLE
Fix BLEServiceTests local echo timing

### DIFF
--- a/bitchatTests/Mocks/MockBLEService.swift
+++ b/bitchatTests/Mocks/MockBLEService.swift
@@ -108,6 +108,11 @@ final class MockBLEService: NSObject {
     func getPeers() -> [PeerID: String] {
         return getPeerNicknames()
     }
+
+    /// Keep local echo synchronous so Swift Testing confirmations observe it deterministically.
+    private func deliverLocalEcho(_ message: BitchatMessage) {
+        delegate?.didReceiveMessage(message)
+    }
     
     func sendMessage(_ content: String, mentions: [String] = [], to recipientID: String? = nil, messageID: String? = nil, timestamp: Date? = nil) {
         let message = BitchatMessage(
@@ -137,10 +142,7 @@ final class MockBLEService: NSObject {
             sentMessages.append((message, packet))
             sentPackets.append(packet)
             
-            // Simulate local echo
-            DispatchQueue.main.async { [weak self] in
-                self?.delegate?.didReceiveMessage(message)
-            }
+            deliverLocalEcho(message)
             
             // Surface raw packet to tests that intercept/relay/encrypt
             packetDeliveryHandler?(packet)
@@ -190,10 +192,7 @@ final class MockBLEService: NSObject {
             sentMessages.append((message, packet))
             sentPackets.append(packet)
             
-            // Simulate local echo
-            DispatchQueue.main.async { [weak self] in
-                self?.delegate?.didReceiveMessage(message)
-            }
+            deliverLocalEcho(message)
             
             // Surface raw packet to tests that intercept/relay/encrypt
             packetDeliveryHandler?(packet)


### PR DESCRIPTION
## Summary
- make MockBLEService local echo synchronous in tests
- remove the main-queue race behind BLEServiceTests confirmation callbacks
- keep the behavior change scoped to the test harness

## Verification
- xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:bitchatTests_iOS/BLEServiceTests

This is separate from #1044 and addresses the unrelated BLEServiceTests GitHub Actions failure.