### PR TITLE
Move GeoRelay fetch work off the main actor

### DIFF
--- a/bitchat/Nostr/GeoRelayDirectory.swift
+++ b/bitchat/Nostr/GeoRelayDirectory.swift
@@ -18,7 +18,7 @@ struct GeoRelayDirectoryDependencies {
     var retryInitialSeconds: TimeInterval
     var retryMaxSeconds: TimeInterval
     var awaitTorReady: @Sendable () async -> Bool
-    var fetchData: @Sendable (URLRequest) async throws -> Data
+    var makeFetchData: @MainActor @Sendable () -> (@Sendable (URLRequest) async throws -> Data)
     var readData: (URL) -> Data?
     var writeData: (Data, URL) throws -> Void
     var cacheURL: () -> URL?
@@ -50,9 +50,12 @@ private extension GeoRelayDirectoryDependencies {
             retryInitialSeconds: TransportConfig.geoRelayRetryInitialSeconds,
             retryMaxSeconds: TransportConfig.geoRelayRetryMaxSeconds,
             awaitTorReady: { await TorManager.shared.awaitReady() },
-            fetchData: { request in
-                let (data, _) = try await TorURLSession.shared.session.data(for: request)
-                return data
+            makeFetchData: {
+                let session = TorURLSession.shared.session
+                return { request in
+                    let (data, _) = try await session.data(for: request)
+                    return data
+                }
             },
             readData: { try? Data(contentsOf: $0) },
             writeData: { data, url in
@@ -220,7 +223,7 @@ final class GeoRelayDirectory {
             timeoutInterval: 15
         )
         let awaitTorReady = dependencies.awaitTorReady
-        let fetchData = dependencies.fetchData
+        let fetchData = dependencies.makeFetchData()
 
         Task { [weak self] in
             guard let self else { return }

--- a/bitchatTests/Nostr/GeoRelayDirectoryTests.swift
+++ b/bitchatTests/Nostr/GeoRelayDirectoryTests.swift
@@ -146,12 +146,16 @@ final class GeoRelayDirectoryTests: XCTestCase {
     }
 
     func test_prefetchIfNeeded_runsRemoteFetchOffMainThread() async {
+        var factoryThreadFlags: [Bool] = []
         let threadRecorder = MainThreadRecorder()
         let harness = makeHarness(
             fetchCSV: """
             relay url,lat,lon
             background.example,8,9
             """,
+            fetchFactoryObserver: {
+                factoryThreadFlags.append(isExecutingOnMainThread())
+            },
             fetchObserver: {
                 await threadRecorder.record(isExecutingOnMainThread())
             }
@@ -164,6 +168,7 @@ final class GeoRelayDirectoryTests: XCTestCase {
             directory.entries == [GeoRelayDirectory.Entry(host: "background.example", lat: 8, lon: 9)]
         }
         XCTAssertTrue(refreshed)
+        XCTAssertEqual(factoryThreadFlags, [true])
         let recordedValues = await threadRecorder.recordedValues()
         XCTAssertEqual(recordedValues, [false])
     }
@@ -238,6 +243,7 @@ final class GeoRelayDirectoryTests: XCTestCase {
         workingDirectoryCSV: String? = nil,
         fetchCSV: String? = nil,
         fetchResults: [Result<Data, Error>] = [],
+        fetchFactoryObserver: (@MainActor @Sendable () -> Void)? = nil,
         fetchObserver: (@Sendable () async -> Void)? = nil,
         autoStart: Bool = false,
         activeNotificationName: Notification.Name? = nil
@@ -278,9 +284,12 @@ final class GeoRelayDirectoryTests: XCTestCase {
             retryInitialSeconds: 5,
             retryMaxSeconds: 40,
             awaitTorReady: { true },
-            fetchData: { request in
-                await fetchObserver?()
-                return try await fetcher.fetch(request)
+            makeFetchData: {
+                fetchFactoryObserver?()
+                return { request in
+                    await fetchObserver?()
+                    return try await fetcher.fetch(request)
+                }
             },
             readData: { url in
                 fileStore.dataByURL[url]


### PR DESCRIPTION
## Summary
- run GeoRelayDirectory remote fetch work off-main and hop back only for state mutation
- keep Tor readiness, response decode, and CSV parsing off the UI actor
- add a regression test proving the injected fetch closure no longer executes on the main thread

## Testing
- swift test
- xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17" test