### PR TITLE
[vuln] Fix announce trust anchoring

### DIFF
--- a/bitchat/Identity/IdentityModels.swift
+++ b/bitchat/Identity/IdentityModels.swift
@@ -139,23 +139,65 @@ enum TrustLevel: String, Codable {
 /// Storage is optional and controlled by user privacy settings.
 struct IdentityCache: Codable {
     // Fingerprint -> Social mapping
-    var socialIdentities: [String: SocialIdentity] = [:]
+    var socialIdentities: [String: SocialIdentity]
     
     // Nickname -> [Fingerprints] reverse index
     // Multiple fingerprints can claim same nickname
-    var nicknameIndex: [String: Set<String>] = [:]
+    var nicknameIndex: [String: Set<String>]
     
     // Verified fingerprints (cryptographic proof)
-    var verifiedFingerprints: Set<String> = []
+    var verifiedFingerprints: Set<String>
+
+    // Stable cryptographic identities, including trusted public signing keys.
+    var cryptographicIdentities: [String: CryptographicIdentity]
     
     // Last interaction timestamps (privacy: optional)
-    var lastInteractions: [String: Date] = [:] 
+    var lastInteractions: [String: Date]
     
     // Blocked Nostr pubkeys (lowercased hex) for geohash chats
-    var blockedNostrPubkeys: Set<String> = []
+    var blockedNostrPubkeys: Set<String>
     
     // Schema version for future migrations
-    var version: Int = 1
+    var version: Int
+
+    init(
+        socialIdentities: [String: SocialIdentity] = [:],
+        nicknameIndex: [String: Set<String>] = [:],
+        verifiedFingerprints: Set<String> = [],
+        cryptographicIdentities: [String: CryptographicIdentity] = [:],
+        lastInteractions: [String: Date] = [:],
+        blockedNostrPubkeys: Set<String> = [],
+        version: Int = 2
+    ) {
+        self.socialIdentities = socialIdentities
+        self.nicknameIndex = nicknameIndex
+        self.verifiedFingerprints = verifiedFingerprints
+        self.cryptographicIdentities = cryptographicIdentities
+        self.lastInteractions = lastInteractions
+        self.blockedNostrPubkeys = blockedNostrPubkeys
+        self.version = version
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case socialIdentities
+        case nicknameIndex
+        case verifiedFingerprints
+        case cryptographicIdentities
+        case lastInteractions
+        case blockedNostrPubkeys
+        case version
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.socialIdentities = try container.decodeIfPresent([String: SocialIdentity].self, forKey: .socialIdentities) ?? [:]
+        self.nicknameIndex = try container.decodeIfPresent([String: Set<String>].self, forKey: .nicknameIndex) ?? [:]
+        self.verifiedFingerprints = try container.decodeIfPresent(Set<String>.self, forKey: .verifiedFingerprints) ?? []
+        self.cryptographicIdentities = try container.decodeIfPresent([String: CryptographicIdentity].self, forKey: .cryptographicIdentities) ?? [:]
+        self.lastInteractions = try container.decodeIfPresent([String: Date].self, forKey: .lastInteractions) ?? [:]
+        self.blockedNostrPubkeys = try container.decodeIfPresent(Set<String>.self, forKey: .blockedNostrPubkeys) ?? []
+        self.version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+    }
 }
 
 //

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -503,7 +503,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     func setVerified(fingerprint: String, verified: Bool) {
         SecureLogger.info("Fingerprint \(verified ? "verified" : "unverified"): \(fingerprint)", category: .security)
         
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             if verified {
                 self.cache.verifiedFingerprints.insert(fingerprint)
             } else {

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -103,6 +103,7 @@ protocol SecureIdentityStateManagerProtocol {
     
     // MARK: Cryptographic Identities
     func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?)
+    func clearSigningPublicKey(for fingerprint: String)
     func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity]
     func updateSocialIdentity(_ identity: SocialIdentity)
     
@@ -316,6 +317,22 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                 }
             }
 
+            self.saveIdentityCache()
+        }
+    }
+
+    func clearSigningPublicKey(for fingerprint: String) {
+        queue.sync(flags: .barrier) {
+            guard var identity = self.cryptographicIdentities[fingerprint] else { return }
+            guard identity.signingPublicKey != nil else { return }
+            identity = CryptographicIdentity(
+                fingerprint: identity.fingerprint,
+                publicKey: identity.publicKey,
+                signingPublicKey: nil,
+                firstSeen: identity.firstSeen,
+                lastHandshake: identity.lastHandshake
+            )
+            self.cryptographicIdentities[fingerprint] = identity
             self.saveIdentityCache()
         }
     }

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -145,7 +145,6 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     
     // In-memory state
     private var ephemeralSessions: [PeerID: EphemeralIdentity] = [:]
-    private var cryptographicIdentities: [String: CryptographicIdentity] = [:]
     private var cache: IdentityCache = IdentityCache()
     
     // Thread safety
@@ -261,7 +260,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String? = nil) {
         queue.async(flags: .barrier) {
             let now = Date()
-            if var existing = self.cryptographicIdentities[fingerprint] {
+            if var existing = self.cache.cryptographicIdentities[fingerprint] {
                 // Update keys if changed
                 if existing.publicKey != noisePublicKey {
                     existing = CryptographicIdentity(
@@ -271,7 +270,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                         firstSeen: existing.firstSeen,
                         lastHandshake: now
                     )
-                    self.cryptographicIdentities[fingerprint] = existing
+                    self.cache.cryptographicIdentities[fingerprint] = existing
                 } else {
                     // Update signing key and lastHandshake
                     existing.signingPublicKey = signingPublicKey ?? existing.signingPublicKey
@@ -282,7 +281,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                         firstSeen: existing.firstSeen,
                         lastHandshake: now
                     )
-                    self.cryptographicIdentities[fingerprint] = updated
+                    self.cache.cryptographicIdentities[fingerprint] = updated
                 }
                 // Persist updated state (already assigned in branches above)
             } else {
@@ -294,7 +293,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                     firstSeen: now,
                     lastHandshake: now
                 )
-                self.cryptographicIdentities[fingerprint] = entry
+                self.cache.cryptographicIdentities[fingerprint] = entry
             }
 
             // Optionally persist claimed nickname into social identity
@@ -323,7 +322,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
 
     func clearSigningPublicKey(for fingerprint: String) {
         queue.sync(flags: .barrier) {
-            guard var identity = self.cryptographicIdentities[fingerprint] else { return }
+            guard var identity = self.cache.cryptographicIdentities[fingerprint] else { return }
             guard identity.signingPublicKey != nil else { return }
             identity = CryptographicIdentity(
                 fingerprint: identity.fingerprint,
@@ -332,7 +331,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                 firstSeen: identity.firstSeen,
                 lastHandshake: identity.lastHandshake
             )
-            self.cryptographicIdentities[fingerprint] = identity
+            self.cache.cryptographicIdentities[fingerprint] = identity
             self.saveIdentityCache()
         }
     }
@@ -342,7 +341,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
         queue.sync {
             // Defensive: ensure hex and correct length
             guard peerID.isShort else { return [] }
-            return cryptographicIdentities.values.filter { $0.fingerprint.hasPrefix(peerID.id) }
+            return cache.cryptographicIdentities.values.filter { $0.fingerprint.hasPrefix(peerID.id) }
         }
     }
     
@@ -501,7 +500,6 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
         queue.async(flags: .barrier) {
             self.cache = IdentityCache()
             self.ephemeralSessions.removeAll()
-            self.cryptographicIdentities.removeAll()
             
             // Delete from keychain
             let deleted = self.keychain.deleteIdentityKey(forKey: self.cacheKey)

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -670,12 +670,6 @@ final class BLEService: NSObject {
             return peers[peerID]?.noisePublicKey?.sha256Fingerprint()
         }
     }
-
-    func getSigningPublicKey(for peerID: PeerID) -> Data? {
-        collectionsQueue.sync {
-            peers[peerID]?.signingPublicKey
-        }
-    }
     
     func getNoiseSessionState(for peerID: PeerID) -> LazyHandshakeState {
         if noiseService.hasEstablishedSession(with: peerID) {
@@ -1146,45 +1140,8 @@ final class BLEService: NSObject {
     private func handleFileTransfer(_ packet: BitchatPacket, from peerID: PeerID) {
         if peerID == myPeerID && packet.ttl != 0 { return }
 
-        var accepted = false
-        var senderNickname = ""
-
         let peersSnapshot = collectionsQueue.sync { peers }
-
-        if peerID == myPeerID {
-            accepted = true
-            senderNickname = myNickname
-        } else if let info = peersSnapshot[peerID], info.isVerifiedNickname {
-            accepted = true
-            senderNickname = info.nickname
-            let hasCollision = peersSnapshot.values.contains { $0.isConnected && $0.nickname == info.nickname && $0.peerID != peerID } || (myNickname == info.nickname)
-            if hasCollision {
-                senderNickname += "#" + String(peerID.id.prefix(4))
-            }
-        } else if let info = peersSnapshot[peerID], info.isConnected {
-            accepted = true
-            senderNickname = info.nickname.isEmpty ? "anon" + String(peerID.id.prefix(4)) : info.nickname
-            let hasCollision = peersSnapshot.values.contains { $0.isConnected && $0.nickname == info.nickname && $0.peerID != peerID } || (myNickname == info.nickname)
-            if hasCollision {
-                senderNickname += "#" + String(peerID.id.prefix(4))
-            }
-        } else if let signature = packet.signature, let packetData = packet.toBinaryDataForSigning() {
-            let candidates = identityManager.getCryptoIdentitiesByPeerIDPrefix(peerID)
-            for candidate in candidates {
-                if let signingKey = candidate.signingPublicKey,
-                   noiseService.verifySignature(signature, for: packetData, publicKey: signingKey) {
-                    accepted = true
-                    if let social = identityManager.getSocialIdentity(for: candidate.fingerprint) {
-                        senderNickname = social.localPetname ?? social.claimedNickname
-                    } else {
-                        senderNickname = "anon" + String(peerID.id.prefix(4))
-                    }
-                    break
-                }
-            }
-        }
-
-        guard accepted else {
+        guard let senderNickname = authenticatedPublicSender(for: packet, from: peerID, peersSnapshot: peersSnapshot) else {
             SecureLogger.warning("🚫 Dropping file transfer from unverified or unknown peer \(peerID.id.prefix(8))…", category: .security)
             return
         }
@@ -1261,6 +1218,63 @@ final class BLEService: NSObject {
         notifyUI { [weak self] in
             self?.delegate?.didReceiveMessage(message)
         }
+    }
+
+    private func collisionAdjustedNickname(for peerID: PeerID, nickname: String, peersSnapshot: [PeerID: PeerInfo]) -> String {
+        guard !nickname.isEmpty else {
+            return "anon" + String(peerID.id.prefix(4))
+        }
+
+        let hasCollision =
+            peersSnapshot.values.contains { $0.isConnected && $0.nickname == nickname && $0.peerID != peerID }
+            || (myNickname == nickname)
+        if hasCollision {
+            return nickname + "#" + String(peerID.id.prefix(4))
+        }
+        return nickname
+    }
+
+    private func authenticatedPublicSender(for packet: BitchatPacket, from peerID: PeerID, peersSnapshot: [PeerID: PeerInfo]) -> String? {
+        if peerID == myPeerID {
+            return myNickname
+        }
+
+        guard let signature = packet.signature, let packetData = packet.toBinaryDataForSigning() else {
+            return nil
+        }
+
+        if let info = peersSnapshot[peerID],
+           info.isVerifiedNickname,
+           let signingKey = info.signingPublicKey,
+           noiseService.verifySignature(signature, for: packetData, publicKey: signingKey) {
+            return collisionAdjustedNickname(for: peerID, nickname: info.nickname, peersSnapshot: peersSnapshot)
+        }
+
+        let expectedNoiseKey = peersSnapshot[peerID]?.noisePublicKey
+        let candidates = identityManager.getCryptoIdentitiesByPeerIDPrefix(peerID)
+        for candidate in candidates {
+            guard identityManager.isVerified(fingerprint: candidate.fingerprint),
+                  let signingKey = candidate.signingPublicKey else {
+                continue
+            }
+            if let expectedNoiseKey, candidate.publicKey != expectedNoiseKey {
+                continue
+            }
+            guard noiseService.verifySignature(signature, for: packetData, publicKey: signingKey) else {
+                continue
+            }
+
+            if let info = peersSnapshot[peerID], info.noisePublicKey == candidate.publicKey {
+                return collisionAdjustedNickname(for: peerID, nickname: info.nickname, peersSnapshot: peersSnapshot)
+            }
+
+            if let social = identityManager.getSocialIdentity(for: candidate.fingerprint) {
+                return social.localPetname ?? social.claimedNickname
+            }
+            return "anon" + String(peerID.id.prefix(4))
+        }
+
+        return nil
     }
     
     func sendFavoriteNotification(to peerID: PeerID, isFavorite: Bool) {
@@ -3932,9 +3946,7 @@ extension BLEService {
                     nickname: announcement.nickname,
                     isConnected: isDirectAnnounce || hasPeripheralConnection || hasCentralSubscription,
                     noisePublicKey: announcement.noisePublicKey,
-                    // Keep the observed signing key in memory for later user verification,
-                    // but only mark it trusted after an authenticated announce.
-                    signingPublicKey: announcement.signingPublicKey,
+                    signingPublicKey: verified ? announcement.signingPublicKey : existing.signingPublicKey,
                     isVerifiedNickname: existing.isVerifiedNickname || verified,
                     lastSeen: Date()
                 )
@@ -3945,8 +3957,7 @@ extension BLEService {
                     nickname: announcement.nickname,
                     isConnected: isDirectAnnounce || hasPeripheralConnection || hasCentralSubscription,
                     noisePublicKey: announcement.noisePublicKey,
-                    // First-contact announces remain discoverable but untrusted.
-                    signingPublicKey: announcement.signingPublicKey,
+                    signingPublicKey: verified ? announcement.signingPublicKey : nil,
                     isVerifiedNickname: verified,
                     lastSeen: Date()
                 )
@@ -4067,47 +4078,10 @@ extension BLEService {
             }
         }
 
-        var accepted = false
-        var senderNickname: String = ""
         // Snapshot peers to avoid concurrent mutation while iterating during nickname collision checks.
         let peersSnapshot = collectionsQueue.sync { peers }
 
-        // If the packet is from ourselves (e.g., recovered via sync TTL==0), accept immediately
-        if peerID == myPeerID {
-            accepted = true
-            senderNickname = myNickname
-        }
-        else if let info = peersSnapshot[peerID], info.isVerifiedNickname {
-            // Known verified peer path
-            accepted = true
-            senderNickname = info.nickname
-            // Handle nickname collisions
-            let hasCollision = peersSnapshot.values.contains { $0.isConnected && $0.nickname == info.nickname && $0.peerID != peerID } || (myNickname == info.nickname)
-            if hasCollision {
-                senderNickname += "#" + String(peerID.id.prefix(4))
-            }
-        } else {
-            // Fallback: verify signature using persisted signing key for this peerID's fingerprint prefix
-            if let signature = packet.signature, let packetData = packet.toBinaryDataForSigning() {
-                // Find candidate identities by peerID prefix (16 hex)
-                let candidates = identityManager.getCryptoIdentitiesByPeerIDPrefix(peerID)
-                for candidate in candidates {
-                    if let signingKey = candidate.signingPublicKey,
-                       noiseService.verifySignature(signature, for: packetData, publicKey: signingKey) {
-                        accepted = true
-                        // Prefer persisted social petname or claimed nickname
-                        if let social = identityManager.getSocialIdentity(for: candidate.fingerprint) {
-                            senderNickname = social.localPetname ?? social.claimedNickname
-                        } else {
-                            senderNickname = "anon" + String(peerID.id.prefix(4))
-                        }
-                        break
-                    }
-                }
-            }
-        }
-
-        guard accepted else {
+        guard let senderNickname = authenticatedPublicSender(for: packet, from: peerID, peersSnapshot: peersSnapshot) else {
             SecureLogger.warning("🚫 Dropping public message from unverified or unknown peer \(peerID.id.prefix(8))…", category: .security)
             return
         }

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -689,6 +689,16 @@ final class BLEService: NSObject {
         return noiseService
     }
 
+    func clearTrustedPublicIdentity(for peerID: PeerID) {
+        let shortID = peerID.toShort()
+        collectionsQueue.sync(flags: .barrier) {
+            guard var peer = peers[shortID] else { return }
+            peer.signingPublicKey = nil
+            peer.isVerifiedNickname = false
+            peers[shortID] = peer
+        }
+    }
+
     func getCurrentBluetoothState() -> CBManagerState {
         return centralManager?.state ?? .unknown
     }
@@ -1237,7 +1247,8 @@ final class BLEService: NSObject {
     private func hasTrustedSigningIdentity(_ info: PeerInfo?) -> Bool {
         guard let info,
               info.isVerifiedNickname,
-              let noisePublicKey = info.noisePublicKey else {
+              let noisePublicKey = info.noisePublicKey,
+              info.signingPublicKey != nil else {
             return false
         }
         return identityManager.isVerified(fingerprint: noisePublicKey.sha256Fingerprint())

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -642,7 +642,7 @@ final class BLEService: NSObject {
             if info.isConnected { return true }
             guard meshAttached else { return false }
             // Apply reachability retention window
-            let isVerified = info.isVerifiedNickname
+            let isVerified = hasTrustedSigningIdentity(info)
             let retention: TimeInterval = isVerified ? TransportConfig.bleReachabilityRetentionVerifiedSeconds : TransportConfig.bleReachabilityRetentionUnverifiedSeconds
             return Date().timeIntervalSince(info.lastSeen) <= retention
         }
@@ -1234,6 +1234,15 @@ final class BLEService: NSObject {
         return nickname
     }
 
+    private func hasTrustedSigningIdentity(_ info: PeerInfo?) -> Bool {
+        guard let info,
+              info.isVerifiedNickname,
+              let noisePublicKey = info.noisePublicKey else {
+            return false
+        }
+        return identityManager.isVerified(fingerprint: noisePublicKey.sha256Fingerprint())
+    }
+
     private func authenticatedPublicSender(for packet: BitchatPacket, from peerID: PeerID, peersSnapshot: [PeerID: PeerInfo]) -> String? {
         if peerID == myPeerID {
             return myNickname
@@ -1244,7 +1253,7 @@ final class BLEService: NSObject {
         }
 
         if let info = peersSnapshot[peerID],
-           info.isVerifiedNickname,
+           hasTrustedSigningIdentity(info),
            let signingKey = info.signingPublicKey,
            noiseService.verifySignature(signature, for: packetData, publicKey: signingKey) {
             return collisionAdjustedNickname(for: peerID, nickname: info.nickname, peersSnapshot: peersSnapshot)
@@ -3885,7 +3894,7 @@ extension BLEService {
             identityManager.isVerified(fingerprint: $0.fingerprint)
         }
         let trustedSigningKey =
-            ((existingPeerForVerify?.isVerifiedNickname == true) ? existingPeerForVerify?.signingPublicKey : nil)
+            (hasTrustedSigningIdentity(existingPeerForVerify) ? existingPeerForVerify?.signingPublicKey : nil)
             ?? persistedTrustedIdentity?.signingPublicKey
         let hasTrustedIdentity = trustedSigningKey != nil
         var verifiedAnnounce = false
@@ -3896,7 +3905,7 @@ extension BLEService {
             }
         }
         if let existingKey = existingPeerForVerify?.noisePublicKey,
-           existingPeerForVerify?.isVerifiedNickname == true,
+           hasTrustedSigningIdentity(existingPeerForVerify),
            existingKey != announcement.noisePublicKey {
             SecureLogger.warning("⚠️ Announce key mismatch for \(peerID.id.prefix(8))… — keeping unverified", category: .security)
             verifiedAnnounce = false
@@ -4386,7 +4395,7 @@ extension BLEService {
         collectionsQueue.sync(flags: .barrier) {
             for (peerID, peer) in peers {
                 let age = now.timeIntervalSince(peer.lastSeen)
-                let retention: TimeInterval = peer.isVerifiedNickname ? TransportConfig.bleReachabilityRetentionVerifiedSeconds : TransportConfig.bleReachabilityRetentionUnverifiedSeconds
+                let retention: TimeInterval = hasTrustedSigningIdentity(peer) ? TransportConfig.bleReachabilityRetentionVerifiedSeconds : TransportConfig.bleReachabilityRetentionUnverifiedSeconds
                 if peer.isConnected && age > TransportConfig.blePeerInactivityTimeoutSeconds {
                     // Check if we still have an active BLE connection to this peer
                     let state = cachedLinkStates[peerID] ?? (hasPeripheral: false, hasCentral: false)

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -670,6 +670,12 @@ final class BLEService: NSObject {
             return peers[peerID]?.noisePublicKey?.sha256Fingerprint()
         }
     }
+
+    func getSigningPublicKey(for peerID: PeerID) -> Data? {
+        collectionsQueue.sync {
+            peers[peerID]?.signingPublicKey
+        }
+    }
     
     func getNoiseSessionState(for peerID: PeerID) -> LazyHandshakeState {
         if noiseService.hasEstablishedSession(with: peerID) {
@@ -3855,16 +3861,29 @@ extension BLEService {
 
         // Suppress announce logs to reduce noise
 
-        // Precompute signature verification outside barrier to reduce contention
+        // Precompute signature verification outside barrier to reduce contention.
+        // Announce signatures are only trusted once we already have a verified binding
+        // for this peer's signing key, either in memory or in persisted identity state.
         let existingPeerForVerify = collectionsQueue.sync { peers[peerID] }
+        let persistedTrustedIdentity = identityManager.getCryptoIdentitiesByPeerIDPrefix(peerID).first {
+            $0.publicKey == announcement.noisePublicKey &&
+            $0.signingPublicKey != nil &&
+            identityManager.isVerified(fingerprint: $0.fingerprint)
+        }
+        let trustedSigningKey =
+            ((existingPeerForVerify?.isVerifiedNickname == true) ? existingPeerForVerify?.signingPublicKey : nil)
+            ?? persistedTrustedIdentity?.signingPublicKey
+        let hasTrustedIdentity = trustedSigningKey != nil
         var verifiedAnnounce = false
-        if packet.signature != nil {
-            verifiedAnnounce = noiseService.verifyPacketSignature(packet, publicKey: announcement.signingPublicKey)
+        if let trustedSigningKey, packet.signature != nil {
+            verifiedAnnounce = noiseService.verifyPacketSignature(packet, publicKey: trustedSigningKey)
             if !verifiedAnnounce {
                 SecureLogger.warning("⚠️ Signature verification for announce failed \(peerID.id.prefix(8))", category: .security)
             }
         }
-        if let existingKey = existingPeerForVerify?.noisePublicKey, existingKey != announcement.noisePublicKey {
+        if let existingKey = existingPeerForVerify?.noisePublicKey,
+           existingPeerForVerify?.isVerifiedNickname == true,
+           existingKey != announcement.noisePublicKey {
             SecureLogger.warning("⚠️ Announce key mismatch for \(peerID.id.prefix(8))… — keeping unverified", category: .security)
             verifiedAnnounce = false
         }
@@ -3896,9 +3915,9 @@ extension BLEService {
             // Use precomputed verification result
             let verified = verifiedAnnounce
 
-            // Require verified announce; ignore otherwise (no backward compatibility)
-            if !verified {
-                SecureLogger.warning("❌ Ignoring unverified announce from \(peerID.id.prefix(8))…", category: .security)
+            // Never let an unauthenticated announce replace a previously trusted identity.
+            if hasTrustedIdentity && !verified {
+                SecureLogger.warning("❌ Ignoring unverified announce update from trusted peer \(peerID.id.prefix(8))…", category: .security)
                 // Reset flags to prevent post-barrier code from acting on unverified announces
                 isNewPeer = false
                 isReconnectedPeer = false
@@ -3913,8 +3932,10 @@ extension BLEService {
                     nickname: announcement.nickname,
                     isConnected: isDirectAnnounce || hasPeripheralConnection || hasCentralSubscription,
                     noisePublicKey: announcement.noisePublicKey,
+                    // Keep the observed signing key in memory for later user verification,
+                    // but only mark it trusted after an authenticated announce.
                     signingPublicKey: announcement.signingPublicKey,
-                    isVerifiedNickname: true,
+                    isVerifiedNickname: existing.isVerifiedNickname || verified,
                     lastSeen: Date()
                 )
             } else {
@@ -3924,8 +3945,9 @@ extension BLEService {
                     nickname: announcement.nickname,
                     isConnected: isDirectAnnounce || hasPeripheralConnection || hasCentralSubscription,
                     noisePublicKey: announcement.noisePublicKey,
+                    // First-contact announces remain discoverable but untrusted.
                     signingPublicKey: announcement.signingPublicKey,
-                    isVerifiedNickname: true,
+                    isVerifiedNickname: verified,
                     lastSeen: Date()
                 )
             }
@@ -3954,13 +3976,16 @@ extension BLEService {
             meshTopology.updateNeighbors(for: peerID.routingData, neighbors: neighbors)
         }
 
-        // Persist cryptographic identity and signing key for robust offline verification
-        identityManager.upsertCryptographicIdentity(
-            fingerprint: announcement.noisePublicKey.sha256Fingerprint(),
-            noisePublicKey: announcement.noisePublicKey,
-            signingPublicKey: announcement.signingPublicKey,
-            claimedNickname: announcement.nickname
-        )
+        if verifiedAnnounce {
+            // Persist cryptographic identity only after the announce was authenticated
+            // against an already trusted signing key.
+            identityManager.upsertCryptographicIdentity(
+                fingerprint: announcement.noisePublicKey.sha256Fingerprint(),
+                noisePublicKey: announcement.noisePublicKey,
+                signingPublicKey: announcement.signingPublicKey,
+                claimedNickname: announcement.nickname
+            )
+        }
 
         // Notify UI on main thread
         notifyUI { [weak self] in

--- a/bitchat/Services/Transport.swift
+++ b/bitchat/Services/Transport.swift
@@ -42,6 +42,7 @@ protocol Transport: AnyObject {
     func getNoiseSessionState(for peerID: PeerID) -> LazyHandshakeState
     func triggerHandshake(with peerID: PeerID)
     func getNoiseService() -> NoiseEncryptionService
+    func clearTrustedPublicIdentity(for peerID: PeerID)
 
     // Messaging
     func sendMessage(_ content: String, mentions: [String])
@@ -70,6 +71,7 @@ extension Transport {
     func sendFileBroadcast(_ packet: BitchatFilePacket, transferId: String) {}
     func sendFilePrivate(_ packet: BitchatFilePacket, to peerID: PeerID, transferId: String) {}
     func cancelTransfer(_ transferId: String) {}
+    func clearTrustedPublicIdentity(for peerID: PeerID) {}
 
     func sendMessage(_ content: String, mentions: [String], messageID: String, timestamp: Date) {
         sendMessage(content, mentions: mentions)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2821,6 +2821,29 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
             return .noiseSecured
         }
     }
+
+    @MainActor
+    func hasVerifiedPublicIdentity(for peerID: PeerID) -> Bool {
+        let shortPeerID = peerID.toShort()
+
+        let noisePublicKey: Data
+        if let peer = unifiedPeerService.getPeer(by: shortPeerID) {
+            noisePublicKey = peer.noisePublicKey
+        } else if let key = peerID.noiseKey {
+            noisePublicKey = key
+        } else {
+            return false
+        }
+
+        let fingerprint = noisePublicKey.sha256Fingerprint()
+        guard identityManager.isVerified(fingerprint: fingerprint) else { return false }
+
+        return identityManager.getCryptoIdentitiesByPeerIDPrefix(PeerID(publicKey: noisePublicKey)).contains {
+            $0.fingerprint == fingerprint &&
+            $0.publicKey == noisePublicKey &&
+            $0.signingPublicKey != nil
+        }
+    }
     
     /// Helper to resolve nickname for a peer ID through various sources
     @MainActor

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2887,8 +2887,10 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
     @MainActor
     func verifyFingerprint(for peerID: PeerID) {
         guard let fingerprint = getFingerprint(for: peerID) else { return }
-        let signingPublicKey = (meshService as? BLEService)?.getSigningPublicKey(for: peerID)
-        persistVerifiedIdentity(for: peerID, signingPublicKey: signingPublicKey)
+        // Manual fingerprint verification only authenticates the Noise identity.
+        // The public-message signing key is only trusted when it is verified OOB,
+        // such as via the QR verification flow.
+        persistVerifiedIdentity(for: peerID, signingPublicKey: nil)
         
         // Update secure storage with verified status
         identityManager.setVerified(fingerprint: fingerprint, verified: true)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2913,6 +2913,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
         // Manual fingerprint verification only authenticates the Noise identity.
         // The public-message signing key is only trusted when it is verified OOB,
         // such as via the QR verification flow.
+        meshService.clearTrustedPublicIdentity(for: peerID)
         identityManager.clearSigningPublicKey(for: fingerprint)
         persistVerifiedIdentity(for: peerID, signingPublicKey: nil)
         
@@ -2930,6 +2931,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
     @MainActor
     func unverifyFingerprint(for peerID: PeerID) {
         guard let fingerprint = getFingerprint(for: peerID) else { return }
+        meshService.clearTrustedPublicIdentity(for: peerID)
         identityManager.setVerified(fingerprint: fingerprint, verified: false)
         saveIdentityState()
         verifiedFingerprints.remove(fingerprint)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2913,6 +2913,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
         // Manual fingerprint verification only authenticates the Noise identity.
         // The public-message signing key is only trusted when it is verified OOB,
         // such as via the QR verification flow.
+        identityManager.clearSigningPublicKey(for: fingerprint)
         persistVerifiedIdentity(for: peerID, signingPublicKey: nil)
         
         // Update secure storage with verified status

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2873,8 +2873,22 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
     }
     
     @MainActor
+    private func persistVerifiedIdentity(for peerID: PeerID, signingPublicKey: Data?) {
+        guard let peer = unifiedPeerService.getPeer(by: peerID) else { return }
+        let claimedNickname = peer.nickname.isEmpty ? nil : peer.nickname
+        identityManager.upsertCryptographicIdentity(
+            fingerprint: peer.noisePublicKey.sha256Fingerprint(),
+            noisePublicKey: peer.noisePublicKey,
+            signingPublicKey: signingPublicKey,
+            claimedNickname: claimedNickname
+        )
+    }
+
+    @MainActor
     func verifyFingerprint(for peerID: PeerID) {
         guard let fingerprint = getFingerprint(for: peerID) else { return }
+        let signingPublicKey = (meshService as? BLEService)?.getSigningPublicKey(for: peerID)
+        persistVerifiedIdentity(for: peerID, signingPublicKey: signingPublicKey)
         
         // Update secure storage with verified status
         identityManager.setVerified(fingerprint: fingerprint, verified: true)
@@ -3144,6 +3158,8 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, CommandContextProv
                     if let fp = getFingerprint(for: peerID) {
                         let short = fp.prefix(8)
                         SecureLogger.info("🔐 Marking verified fingerprint: \(short)", category: .security)
+                        let signingPublicKey = Data(hexString: pending.signKeyHex)
+                        persistVerifiedIdentity(for: peerID, signingPublicKey: signingPublicKey)
                         identityManager.setVerified(fingerprint: fp, verified: true)
                         saveIdentityState()
                         verifiedFingerprints.insert(fp)

--- a/bitchat/Views/FingerprintView.swift
+++ b/bitchat/Views/FingerprintView.swift
@@ -30,7 +30,18 @@ struct FingerprintView: View {
         static let copy: LocalizedStringKey = "common.copy"
         static let verifiedBadge: LocalizedStringKey = "fingerprint.badge.verified"
         static let notVerifiedBadge: LocalizedStringKey = "fingerprint.badge.not_verified"
-        static let verifiedMessage: LocalizedStringKey = "fingerprint.message.verified"
+        static let verifiedFingerprintMessage = String(
+            localized: "fingerprint.message.fingerprint_verified",
+            defaultValue: "you have verified this peer's fingerprint."
+        )
+        static let verifiedPublicIdentityMessage = String(
+            localized: "fingerprint.message.public_identity_verified",
+            defaultValue: "signed public posts from this peer are authenticated."
+        )
+        static let publicIdentityPendingMessage = String(
+            localized: "fingerprint.message.public_identity_pending",
+            defaultValue: "signed public posts stay untrusted until QR verification confirms this peer's signing key."
+        )
         static func verifyHint(_ nickname: String) -> String {
             String(
                 format: String(localized: "fingerprint.message.verify_hint", comment: "Instruction to compare fingerprints with a named peer"),
@@ -38,8 +49,14 @@ struct FingerprintView: View {
                 nickname
             )
         }
-        static let markVerified: LocalizedStringKey = "fingerprint.action.mark_verified"
-        static let removeVerification: LocalizedStringKey = "fingerprint.action.remove_verification"
+        static let markVerified = String(
+            localized: "fingerprint.action.mark_fingerprint_verified",
+            defaultValue: "mark fingerprint verified"
+        )
+        static let removeVerification = String(
+            localized: "fingerprint.action.remove_fingerprint_verification",
+            defaultValue: "remove fingerprint verification"
+        )
         static func unknownPeer() -> String {
             String(localized: "common.unknown", comment: "Label for an unknown peer")
         }
@@ -173,6 +190,7 @@ struct FingerprintView: View {
                 // Verification status
                 if encryptionStatus == .noiseSecured || encryptionStatus == .noiseVerified {
                     let isVerified = encryptionStatus == .noiseVerified
+                    let hasVerifiedPublicIdentity = viewModel.hasVerifiedPublicIdentity(for: statusPeerID)
                     
                     VStack(spacing: 12) {
                         Text(isVerified ? Strings.verifiedBadge : Strings.notVerifiedBadge)
@@ -182,7 +200,10 @@ struct FingerprintView: View {
                         
                         Group {
                             if isVerified {
-                                Text(Strings.verifiedMessage)
+                                VStack(spacing: 6) {
+                                    Text(Strings.verifiedFingerprintMessage)
+                                    Text(hasVerifiedPublicIdentity ? Strings.verifiedPublicIdentityMessage : Strings.publicIdentityPendingMessage)
+                                }
                             } else {
                                 Text(Strings.verifyHint(peerNickname))
                             }

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -226,6 +226,49 @@ struct BLEServiceCoreTests {
     }
 
     @Test
+    func manualFingerprintVerification_clearsActiveSessionPublicIdentityTrust() async throws {
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let peerID = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let fingerprint = signer.getStaticPublicKeyData().sha256Fingerprint()
+        let identityManager = TrackingIdentityManager()
+        identityManager.seedVerifiedIdentity(
+            noisePublicKey: signer.getStaticPublicKeyData(),
+            signingPublicKey: signer.getSigningPublicKeyData(),
+            claimedNickname: "Alice"
+        )
+
+        let ble = makeService(identityManager: identityManager)
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let announce = try makeSignedAnnouncementPacket(signer: signer, nickname: "Alice")
+        ble._test_handlePacket(announce.packet, fromPeerID: peerID, preseedPeer: false)
+        _ = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == peerID && $0.nickname == "Alice" }) },
+            timeout: TestConstants.defaultTimeout
+        )
+
+        identityManager.setVerified(fingerprint: fingerprint, verified: false)
+        ble.clearTrustedPublicIdentity(for: peerID)
+        identityManager.clearSigningPublicKey(for: fingerprint)
+        identityManager.setVerified(fingerprint: fingerprint, verified: true)
+
+        let signedPublicPacket = try makeSignedPublicPacket(
+            content: "post-manual-verify",
+            sender: peerID,
+            signer: signer,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacket(signedPublicPacket, fromPeerID: peerID, preseedPeer: false)
+
+        let acceptedAfterManualVerify = await TestHelpers.waitUntil(
+            { delegate.publicMessagesSnapshot().contains(where: { $0.content == "post-manual-verify" && $0.senderPeerID == peerID }) },
+            timeout: TestConstants.shortTimeout
+        )
+        #expect(!acceptedAfterManualVerify)
+    }
+
+    @Test
     func spoofedAnnounce_cannotOverwriteTrustedPeerIdentity() async throws {
         let trustedSigner = NoiseEncryptionService(keychain: MockKeychain())
         let trustedPeerID = PeerID(publicKey: trustedSigner.getStaticPublicKeyData())

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -472,6 +472,12 @@ private final class TrackingIdentityManager: SecureIdentityStateManagerProtocol 
         upsertedFingerprints.append(fingerprint)
     }
 
+    func clearSigningPublicKey(for fingerprint: String) {
+        guard var identity = identities[fingerprint] else { return }
+        identity.signingPublicKey = nil
+        identities[fingerprint] = identity
+    }
+
     func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity] {
         identities.values.filter { $0.fingerprint.hasPrefix(peerID.id) }
     }

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -91,16 +91,123 @@ struct BLEServiceCoreTests {
         _ = await TestHelpers.waitUntil({ !ble.currentPeerSnapshots().isEmpty }, timeout: 0.3)
         #expect(ble.currentPeerSnapshots().isEmpty)
     }
+
+    @Test
+    func firstContactSignedAnnounce_isDiscoverableButNotTrusted() async throws {
+        let identityManager = TrackingIdentityManager()
+        let ble = makeService(identityManager: identityManager)
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let announce = try makeSignedAnnouncementPacket(signer: signer, nickname: "Mallory")
+
+        ble._test_handlePacket(announce.packet, fromPeerID: announce.peerID, preseedPeer: false)
+
+        let sawPeer = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == announce.peerID && $0.nickname == "Mallory" }) },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(sawPeer)
+        #expect(identityManager.upsertedFingerprints.isEmpty)
+
+        let forgedMessage = makePublicPacket(
+            content: "forged",
+            sender: announce.peerID,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacket(forgedMessage, fromPeerID: announce.peerID, preseedPeer: false)
+
+        let acceptedUnsignedMessage = await TestHelpers.waitUntil(
+            { !delegate.publicMessagesSnapshot().isEmpty },
+            timeout: TestConstants.shortTimeout
+        )
+        #expect(!acceptedUnsignedMessage)
+    }
+
+    @Test
+    func persistedVerifiedIdentity_canAuthenticateReturningAnnounce() async throws {
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let peerID = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let identityManager = TrackingIdentityManager()
+        identityManager.seedVerifiedIdentity(
+            noisePublicKey: signer.getStaticPublicKeyData(),
+            signingPublicKey: signer.getSigningPublicKeyData(),
+            claimedNickname: "Alice"
+        )
+
+        let ble = makeService(identityManager: identityManager)
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let announce = try makeSignedAnnouncementPacket(signer: signer, nickname: "Alice")
+        ble._test_handlePacket(announce.packet, fromPeerID: peerID, preseedPeer: false)
+
+        let acceptedAnnounce = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == peerID && $0.nickname == "Alice" }) },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(acceptedAnnounce)
+        #expect(identityManager.upsertedFingerprints == [signer.getStaticPublicKeyData().sha256Fingerprint()])
+
+        let publicPacket = makePublicPacket(
+            content: "trusted",
+            sender: peerID,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacket(publicPacket, fromPeerID: peerID, preseedPeer: false)
+
+        let acceptedUnsignedMessage = await TestHelpers.waitUntil(
+            { delegate.publicMessagesSnapshot().contains(where: { $0.content == "trusted" && $0.senderPeerID == peerID }) },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(acceptedUnsignedMessage)
+    }
+
+    @Test
+    func spoofedAnnounce_cannotOverwriteTrustedPeerIdentity() async throws {
+        let trustedSigner = NoiseEncryptionService(keychain: MockKeychain())
+        let trustedPeerID = PeerID(publicKey: trustedSigner.getStaticPublicKeyData())
+        let identityManager = TrackingIdentityManager()
+        identityManager.seedVerifiedIdentity(
+            noisePublicKey: trustedSigner.getStaticPublicKeyData(),
+            signingPublicKey: trustedSigner.getSigningPublicKeyData(),
+            claimedNickname: "Alice"
+        )
+
+        let ble = makeService(identityManager: identityManager)
+        let legitimateAnnounce = try makeSignedAnnouncementPacket(signer: trustedSigner, nickname: "Alice")
+        ble._test_handlePacket(legitimateAnnounce.packet, fromPeerID: trustedPeerID, preseedPeer: false)
+        _ = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == trustedPeerID && $0.nickname == "Alice" }) },
+            timeout: TestConstants.defaultTimeout
+        )
+
+        let attacker = NoiseEncryptionService(keychain: MockKeychain())
+        let spoofed = try makeSignedAnnouncementPacket(
+            signer: attacker,
+            nickname: "Mallory",
+            announcedNoisePublicKey: trustedSigner.getStaticPublicKeyData(),
+            announcedSigningPublicKey: attacker.getSigningPublicKeyData()
+        )
+
+        ble._test_handlePacket(spoofed.packet, fromPeerID: trustedPeerID, preseedPeer: false)
+        try await sleep(TestConstants.shortTimeout)
+
+        let peer = ble.currentPeerSnapshots().first(where: { $0.peerID == trustedPeerID })
+        #expect(peer?.nickname == "Alice")
+        #expect(identityManager.upsertedFingerprints == [trustedSigner.getStaticPublicKeyData().sha256Fingerprint()])
+    }
 }
 
-private func makeService() -> BLEService {
+private func makeService(identityManager: SecureIdentityStateManagerProtocol? = nil) -> BLEService {
     let keychain = MockKeychain()
-    let identityManager = MockIdentityManager(keychain)
+    let resolvedIdentityManager = identityManager ?? MockIdentityManager(keychain)
     let idBridge = NostrIdentityBridge(keychain: MockKeychainHelper())
     return BLEService(
         keychain: keychain,
         idBridge: idBridge,
-        identityManager: identityManager,
+        identityManager: resolvedIdentityManager,
         initializeBluetoothManagers: false
     )
 }
@@ -115,6 +222,36 @@ private func makePublicPacket(content: String, sender: PeerID, timestamp: UInt64
         signature: nil,
         ttl: 3
     )
+}
+
+private func makeSignedAnnouncementPacket(
+    signer: NoiseEncryptionService,
+    nickname: String,
+    announcedNoisePublicKey: Data? = nil,
+    announcedSigningPublicKey: Data? = nil
+) throws -> (peerID: PeerID, packet: BitchatPacket) {
+    let noisePublicKey = announcedNoisePublicKey ?? signer.getStaticPublicKeyData()
+    let signingPublicKey = announcedSigningPublicKey ?? signer.getSigningPublicKeyData()
+    let peerID = PeerID(publicKey: noisePublicKey)
+
+    let announcement = AnnouncementPacket(
+        nickname: nickname,
+        noisePublicKey: noisePublicKey,
+        signingPublicKey: signingPublicKey,
+        directNeighbors: nil
+    )
+    let payload = try #require(announcement.encode(), "Failed to encode announcement")
+    let packet = BitchatPacket(
+        type: MessageType.announce.rawValue,
+        senderID: try #require(Data(hexString: peerID.id), "Failed to encode sender ID"),
+        recipientID: nil,
+        timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
+        payload: payload,
+        signature: nil,
+        ttl: TransportConfig.messageTTLDefault
+    )
+
+    return (peerID: peerID, packet: try #require(signer.signPacket(packet), "Failed to sign announcement"))
 }
 
 private final class PublicCaptureDelegate: BitchatDelegate {
@@ -149,5 +286,116 @@ private final class PublicCaptureDelegate: BitchatDelegate {
         lock.lock()
         defer { lock.unlock() }
         return publicMessages
+    }
+}
+
+private final class TrackingIdentityManager: SecureIdentityStateManagerProtocol {
+    private var identities: [String: CryptographicIdentity] = [:]
+    private var socialIdentities: [String: SocialIdentity] = [:]
+    private var verifiedFingerprints: Set<String> = []
+    private var blockedFingerprints: Set<String> = []
+    private var blockedNostrPubkeys: Set<String> = []
+
+    private(set) var upsertedFingerprints: [String] = []
+
+    func seedVerifiedIdentity(noisePublicKey: Data, signingPublicKey: Data, claimedNickname: String) {
+        let fingerprint = noisePublicKey.sha256Fingerprint()
+        identities[fingerprint] = CryptographicIdentity(
+            fingerprint: fingerprint,
+            publicKey: noisePublicKey,
+            signingPublicKey: signingPublicKey,
+            firstSeen: Date(),
+            lastHandshake: Date()
+        )
+        socialIdentities[fingerprint] = SocialIdentity(
+            fingerprint: fingerprint,
+            localPetname: nil,
+            claimedNickname: claimedNickname,
+            trustLevel: .verified,
+            isFavorite: false,
+            isBlocked: false,
+            notes: nil
+        )
+        verifiedFingerprints.insert(fingerprint)
+    }
+
+    func forceSave() {}
+
+    func getSocialIdentity(for fingerprint: String) -> SocialIdentity? {
+        socialIdentities[fingerprint]
+    }
+
+    func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?) {
+        identities[fingerprint] = CryptographicIdentity(
+            fingerprint: fingerprint,
+            publicKey: noisePublicKey,
+            signingPublicKey: signingPublicKey,
+            firstSeen: identities[fingerprint]?.firstSeen ?? Date(),
+            lastHandshake: Date()
+        )
+        if let claimedNickname {
+            socialIdentities[fingerprint] = SocialIdentity(
+                fingerprint: fingerprint,
+                localPetname: socialIdentities[fingerprint]?.localPetname,
+                claimedNickname: claimedNickname,
+                trustLevel: verifiedFingerprints.contains(fingerprint) ? .verified : .unknown,
+                isFavorite: false,
+                isBlocked: false,
+                notes: nil
+            )
+        }
+        upsertedFingerprints.append(fingerprint)
+    }
+
+    func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity] {
+        identities.values.filter { $0.fingerprint.hasPrefix(peerID.id) }
+    }
+
+    func updateSocialIdentity(_ identity: SocialIdentity) {
+        socialIdentities[identity.fingerprint] = identity
+    }
+
+    func getFavorites() -> Set<String> { Set() }
+    func setFavorite(_ fingerprint: String, isFavorite: Bool) {}
+    func isFavorite(fingerprint: String) -> Bool { false }
+
+    func isBlocked(fingerprint: String) -> Bool { blockedFingerprints.contains(fingerprint) }
+    func setBlocked(_ fingerprint: String, isBlocked: Bool) {
+        if isBlocked {
+            blockedFingerprints.insert(fingerprint)
+        } else {
+            blockedFingerprints.remove(fingerprint)
+        }
+    }
+
+    func isNostrBlocked(pubkeyHexLowercased: String) -> Bool { blockedNostrPubkeys.contains(pubkeyHexLowercased) }
+    func setNostrBlocked(_ pubkeyHexLowercased: String, isBlocked: Bool) {
+        if isBlocked {
+            blockedNostrPubkeys.insert(pubkeyHexLowercased)
+        } else {
+            blockedNostrPubkeys.remove(pubkeyHexLowercased)
+        }
+    }
+    func getBlockedNostrPubkeys() -> Set<String> { blockedNostrPubkeys }
+
+    func registerEphemeralSession(peerID: PeerID, handshakeState: HandshakeState) {}
+    func updateHandshakeState(peerID: PeerID, state: HandshakeState) {}
+    func clearAllIdentityData() {}
+    func removeEphemeralSession(peerID: PeerID) {}
+
+    func setVerified(fingerprint: String, verified: Bool) {
+        if verified {
+            verifiedFingerprints.insert(fingerprint)
+        } else {
+            verifiedFingerprints.remove(fingerprint)
+        }
+    }
+
+    func isVerified(fingerprint: String) -> Bool {
+        verifiedFingerprints.contains(fingerprint)
+    }
+
+    func getVerifiedFingerprints() -> Set<String> {
+        verifiedFingerprints
     }
 }

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -186,6 +186,46 @@ struct BLEServiceCoreTests {
     }
 
     @Test
+    func revokedVerifiedIdentity_rejectsActiveSessionPublicMessages() async throws {
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let peerID = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let fingerprint = signer.getStaticPublicKeyData().sha256Fingerprint()
+        let identityManager = TrackingIdentityManager()
+        identityManager.seedVerifiedIdentity(
+            noisePublicKey: signer.getStaticPublicKeyData(),
+            signingPublicKey: signer.getSigningPublicKeyData(),
+            claimedNickname: "Alice"
+        )
+
+        let ble = makeService(identityManager: identityManager)
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let announce = try makeSignedAnnouncementPacket(signer: signer, nickname: "Alice")
+        ble._test_handlePacket(announce.packet, fromPeerID: peerID, preseedPeer: false)
+        _ = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == peerID && $0.nickname == "Alice" }) },
+            timeout: TestConstants.defaultTimeout
+        )
+
+        identityManager.setVerified(fingerprint: fingerprint, verified: false)
+
+        let signedPublicPacket = try makeSignedPublicPacket(
+            content: "post-revoke",
+            sender: peerID,
+            signer: signer,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacket(signedPublicPacket, fromPeerID: peerID, preseedPeer: false)
+
+        let acceptedAfterRevocation = await TestHelpers.waitUntil(
+            { delegate.publicMessagesSnapshot().contains(where: { $0.content == "post-revoke" && $0.senderPeerID == peerID }) },
+            timeout: TestConstants.shortTimeout
+        )
+        #expect(!acceptedAfterRevocation)
+    }
+
+    @Test
     func spoofedAnnounce_cannotOverwriteTrustedPeerIdentity() async throws {
         let trustedSigner = NoiseEncryptionService(keychain: MockKeychain())
         let trustedPeerID = PeerID(publicKey: trustedSigner.getStaticPublicKeyData())

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -13,23 +13,30 @@ import CoreBluetooth
 struct BLEServiceCoreTests {
 
     @Test
-    func duplicatePacket_isDeduped() async {
-        let ble = makeService()
+    func duplicatePacket_isDeduped() async throws {
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let sender = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let identityManager = TrackingIdentityManager()
+        identityManager.seedVerifiedIdentity(
+            noisePublicKey: signer.getStaticPublicKeyData(),
+            signingPublicKey: signer.getSigningPublicKeyData(),
+            claimedNickname: "HelloPeer"
+        )
+        let ble = makeService(identityManager: identityManager)
         let delegate = PublicCaptureDelegate()
         ble.delegate = delegate
 
-        let sender = PeerID(str: "1122334455667788")
         let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
-        let packet = makePublicPacket(content: "Hello", sender: sender, timestamp: timestamp)
+        let packet = try makeSignedPublicPacket(content: "Hello", sender: sender, signer: signer, timestamp: timestamp)
 
-        ble._test_handlePacket(packet, fromPeerID: sender)
+        ble._test_handlePacket(packet, fromPeerID: sender, preseedPeer: false)
         let receivedFirst = await TestHelpers.waitUntil(
             { delegate.publicMessagesSnapshot().count == 1 },
             timeout: TestConstants.defaultTimeout
         )
         #expect(receivedFirst)
 
-        ble._test_handlePacket(packet, fromPeerID: sender)
+        ble._test_handlePacket(packet, fromPeerID: sender, preseedPeer: false)
         let receivedDuplicate = await TestHelpers.waitUntil(
             { delegate.publicMessagesSnapshot().count > 1 },
             timeout: TestConstants.shortTimeout
@@ -150,18 +157,32 @@ struct BLEServiceCoreTests {
         #expect(acceptedAnnounce)
         #expect(identityManager.upsertedFingerprints == [signer.getStaticPublicKeyData().sha256Fingerprint()])
 
-        let publicPacket = makePublicPacket(
+        let unsignedPublicPacket = makePublicPacket(
             content: "trusted",
             sender: peerID,
             timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
         )
-        ble._test_handlePacket(publicPacket, fromPeerID: peerID, preseedPeer: false)
+        ble._test_handlePacket(unsignedPublicPacket, fromPeerID: peerID, preseedPeer: false)
 
         let acceptedUnsignedMessage = await TestHelpers.waitUntil(
             { delegate.publicMessagesSnapshot().contains(where: { $0.content == "trusted" && $0.senderPeerID == peerID }) },
+            timeout: TestConstants.shortTimeout
+        )
+        #expect(!acceptedUnsignedMessage)
+
+        let signedPublicPacket = try makeSignedPublicPacket(
+            content: "trusted",
+            sender: peerID,
+            signer: signer,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacket(signedPublicPacket, fromPeerID: peerID, preseedPeer: false)
+
+        let acceptedSignedMessage = await TestHelpers.waitUntil(
+            { delegate.publicMessagesSnapshot().contains(where: { $0.content == "trusted" && $0.senderPeerID == peerID }) },
             timeout: TestConstants.defaultTimeout
         )
-        #expect(acceptedUnsignedMessage)
+        #expect(acceptedSignedMessage)
     }
 
     @Test
@@ -198,6 +219,49 @@ struct BLEServiceCoreTests {
         #expect(peer?.nickname == "Alice")
         #expect(identityManager.upsertedFingerprints == [trustedSigner.getStaticPublicKeyData().sha256Fingerprint()])
     }
+
+    @Test
+    func unverifiedConnectedPeer_fileTransferIsRejected() async throws {
+        let ble = makeService()
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let announce = try makeSignedAnnouncementPacket(signer: signer, nickname: "Mallory")
+        ble._test_handlePacket(announce.packet, fromPeerID: announce.peerID, preseedPeer: false)
+
+        let sawPeer = await TestHelpers.waitUntil(
+            { ble.currentPeerSnapshots().contains(where: { $0.peerID == announce.peerID }) },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(sawPeer)
+
+        let payload = try #require(
+            BitchatFilePacket(
+                fileName: "spam.bin",
+                fileSize: nil,
+                mimeType: MimeType.octetStream.mimeString,
+                content: Data([0x01, 0x02, 0x03, 0x04])
+            ).encode(),
+            "Failed to encode file payload"
+        )
+        let packet = BitchatPacket(
+            type: MessageType.fileTransfer.rawValue,
+            senderID: try #require(Data(hexString: announce.peerID.id), "Failed to encode sender ID"),
+            recipientID: nil,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
+            payload: payload,
+            signature: nil,
+            ttl: TransportConfig.messageTTLDefault
+        )
+        ble._test_handlePacket(packet, fromPeerID: announce.peerID, preseedPeer: false)
+
+        let delivered = await TestHelpers.waitUntil(
+            { !delegate.receivedMessagesSnapshot().isEmpty },
+            timeout: TestConstants.shortTimeout
+        )
+        #expect(!delivered)
+    }
 }
 
 private func makeService(identityManager: SecureIdentityStateManagerProtocol? = nil) -> BLEService {
@@ -222,6 +286,16 @@ private func makePublicPacket(content: String, sender: PeerID, timestamp: UInt64
         signature: nil,
         ttl: 3
     )
+}
+
+private func makeSignedPublicPacket(
+    content: String,
+    sender: PeerID,
+    signer: NoiseEncryptionService,
+    timestamp: UInt64
+) throws -> BitchatPacket {
+    let packet = makePublicPacket(content: content, sender: sender, timestamp: timestamp)
+    return try #require(signer.signPacket(packet), "Failed to sign public packet")
 }
 
 private func makeSignedAnnouncementPacket(
@@ -257,6 +331,7 @@ private func makeSignedAnnouncementPacket(
 private final class PublicCaptureDelegate: BitchatDelegate {
     private let lock = NSLock()
     private(set) var publicMessages: [BitchatMessage] = []
+    private(set) var receivedMessages: [BitchatMessage] = []
 
     func didReceivePublicMessage(from peerID: PeerID, nickname: String, content: String, timestamp: Date, messageID: String?) {
         let message = BitchatMessage(
@@ -276,7 +351,11 @@ private final class PublicCaptureDelegate: BitchatDelegate {
         lock.unlock()
     }
 
-    func didReceiveMessage(_ message: BitchatMessage) {}
+    func didReceiveMessage(_ message: BitchatMessage) {
+        lock.lock()
+        receivedMessages.append(message)
+        lock.unlock()
+    }
     func didConnectToPeer(_ peerID: PeerID) {}
     func didDisconnectFromPeer(_ peerID: PeerID) {}
     func didUpdatePeerList(_ peers: [PeerID]) {}
@@ -286,6 +365,12 @@ private final class PublicCaptureDelegate: BitchatDelegate {
         lock.lock()
         defer { lock.unlock() }
         return publicMessages
+    }
+
+    func receivedMessagesSnapshot() -> [BitchatMessage] {
+        lock.lock()
+        defer { lock.unlock() }
+        return receivedMessages
     }
 }
 

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -15,6 +15,12 @@ import Foundation
 /// Creates a ChatViewModel with mock dependencies for testing
 @MainActor
 private func makeTestableViewModel() -> (viewModel: ChatViewModel, transport: MockTransport) {
+    let (viewModel, transport, _) = makeTestableViewModelWithIdentityManager()
+    return (viewModel, transport)
+}
+
+@MainActor
+private func makeTestableViewModelWithIdentityManager() -> (viewModel: ChatViewModel, transport: MockTransport, identityManager: MockIdentityManager) {
     let keychain = MockKeychain()
     let keychainHelper = MockKeychainHelper()
     let idBridge = NostrIdentityBridge(keychain: keychainHelper)
@@ -28,7 +34,7 @@ private func makeTestableViewModel() -> (viewModel: ChatViewModel, transport: Mo
         transport: transport
     )
 
-    return (viewModel, transport)
+    return (viewModel, transport, identityManager)
 }
 
 // MARK: - Initialization Tests
@@ -273,6 +279,42 @@ struct ChatViewModelPeerTests {
         transport.connectedPeers.insert(peerID)
 
         #expect(transport.isPeerConnected(peerID))
+    }
+}
+
+struct ChatViewModelVerificationTests {
+
+    @Test @MainActor
+    func verifyFingerprint_persistsNoiseIdentityWithoutSigningKey() async {
+        let (viewModel, transport, identityManager) = makeTestableViewModelWithIdentityManager()
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let peerID = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let fingerprint = signer.getStaticPublicKeyData().sha256Fingerprint()
+
+        transport.peerFingerprints[peerID] = fingerprint
+        transport.updatePeerSnapshots([
+            TransportPeerSnapshot(
+                peerID: peerID,
+                nickname: "Alice",
+                isConnected: true,
+                noisePublicKey: signer.getStaticPublicKeyData(),
+                lastSeen: Date()
+            )
+        ])
+
+        let hasPeer = await TestHelpers.waitUntil(
+            { viewModel.getPeer(byID: peerID) != nil },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(hasPeer)
+
+        viewModel.verifyFingerprint(for: peerID)
+
+        let persisted = identityManager.lastUpsertedIdentity
+        #expect(persisted?.fingerprint == fingerprint)
+        #expect(persisted?.noisePublicKey == signer.getStaticPublicKeyData())
+        #expect(persisted?.signingPublicKey == nil)
+        #expect(persisted?.claimedNickname == "Alice")
     }
 }
 

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -352,6 +352,7 @@ struct ChatViewModelVerificationTests {
         #expect(identityManager.lastClearedSigningKeyFingerprint == fingerprint)
         #expect(identityManager.signingPublicKey(for: fingerprint) == nil)
         #expect(identityManager.lastUpsertedIdentity?.signingPublicKey == nil)
+        #expect(transport.clearedTrustedPublicIdentities == [peerID])
     }
 }
 

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -316,6 +316,43 @@ struct ChatViewModelVerificationTests {
         #expect(persisted?.signingPublicKey == nil)
         #expect(persisted?.claimedNickname == "Alice")
     }
+
+    @Test @MainActor
+    func verifyFingerprint_clearsPreviouslyStoredSigningKey() async {
+        let (viewModel, transport, identityManager) = makeTestableViewModelWithIdentityManager()
+        let signer = NoiseEncryptionService(keychain: MockKeychain())
+        let staleSigningKey = Data(repeating: 0xAA, count: 32)
+        let peerID = PeerID(publicKey: signer.getStaticPublicKeyData())
+        let fingerprint = signer.getStaticPublicKeyData().sha256Fingerprint()
+
+        identityManager.seedCryptographicIdentity(
+            fingerprint: fingerprint,
+            noisePublicKey: signer.getStaticPublicKeyData(),
+            signingPublicKey: staleSigningKey
+        )
+        transport.peerFingerprints[peerID] = fingerprint
+        transport.updatePeerSnapshots([
+            TransportPeerSnapshot(
+                peerID: peerID,
+                nickname: "Alice",
+                isConnected: true,
+                noisePublicKey: signer.getStaticPublicKeyData(),
+                lastSeen: Date()
+            )
+        ])
+
+        let hasPeer = await TestHelpers.waitUntil(
+            { viewModel.getPeer(byID: peerID) != nil },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(hasPeer)
+
+        viewModel.verifyFingerprint(for: peerID)
+
+        #expect(identityManager.lastClearedSigningKeyFingerprint == fingerprint)
+        #expect(identityManager.signingPublicKey(for: fingerprint) == nil)
+        #expect(identityManager.lastUpsertedIdentity?.signingPublicKey == nil)
+    }
 }
 
 // MARK: - Deduplication Integration Tests

--- a/bitchatTests/Mocks/MockIdentityManager.swift
+++ b/bitchatTests/Mocks/MockIdentityManager.swift
@@ -14,6 +14,7 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
     private var blockedFingerprints: Set<String> = []
     private var blockedNostrPubkeys: Set<String> = []
     private var socialIdentities: [String: SocialIdentity] = [:]
+    private(set) var lastUpsertedIdentity: (fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?)?
     
     init(_ keychain: KeychainManagerProtocol) {
         self.keychain = keychain
@@ -29,7 +30,9 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
         socialIdentities[fingerprint]
     }
     
-    func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?) {}
+    func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?) {
+        lastUpsertedIdentity = (fingerprint, noisePublicKey, signingPublicKey, claimedNickname)
+    }
     
     func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity] {
         []

--- a/bitchatTests/Mocks/MockIdentityManager.swift
+++ b/bitchatTests/Mocks/MockIdentityManager.swift
@@ -14,7 +14,9 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
     private var blockedFingerprints: Set<String> = []
     private var blockedNostrPubkeys: Set<String> = []
     private var socialIdentities: [String: SocialIdentity] = [:]
+    private var cryptographicIdentities: [String: CryptographicIdentity] = [:]
     private(set) var lastUpsertedIdentity: (fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?)?
+    private(set) var lastClearedSigningKeyFingerprint: String?
     
     init(_ keychain: KeychainManagerProtocol) {
         self.keychain = keychain
@@ -31,11 +33,40 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
     }
     
     func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?) {
+        let existingSigningKey = cryptographicIdentities[fingerprint]?.signingPublicKey
+        cryptographicIdentities[fingerprint] = CryptographicIdentity(
+            fingerprint: fingerprint,
+            publicKey: noisePublicKey,
+            signingPublicKey: signingPublicKey ?? existingSigningKey,
+            firstSeen: cryptographicIdentities[fingerprint]?.firstSeen ?? Date(),
+            lastHandshake: Date()
+        )
         lastUpsertedIdentity = (fingerprint, noisePublicKey, signingPublicKey, claimedNickname)
+    }
+
+    func clearSigningPublicKey(for fingerprint: String) {
+        lastClearedSigningKeyFingerprint = fingerprint
+        guard var identity = cryptographicIdentities[fingerprint] else { return }
+        identity.signingPublicKey = nil
+        cryptographicIdentities[fingerprint] = identity
     }
     
     func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity] {
-        []
+        cryptographicIdentities.values.filter { $0.fingerprint.hasPrefix(peerID.id) }
+    }
+
+    func seedCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?) {
+        cryptographicIdentities[fingerprint] = CryptographicIdentity(
+            fingerprint: fingerprint,
+            publicKey: noisePublicKey,
+            signingPublicKey: signingPublicKey,
+            firstSeen: Date(),
+            lastHandshake: Date()
+        )
+    }
+
+    func signingPublicKey(for fingerprint: String) -> Data? {
+        cryptographicIdentities[fingerprint]?.signingPublicKey
     }
     
     func updateSocialIdentity(_ identity: SocialIdentity) {

--- a/bitchatTests/Mocks/MockTransport.swift
+++ b/bitchatTests/Mocks/MockTransport.swift
@@ -40,6 +40,7 @@ final class MockTransport: Transport {
     private(set) var cancelledTransfers: [String] = []
     private(set) var sentVerifyChallenges: [(peerID: PeerID, noiseKeyHex: String, nonceA: Data)] = []
     private(set) var sentVerifyResponses: [(peerID: PeerID, noiseKeyHex: String, nonceA: Data)] = []
+    private(set) var clearedTrustedPublicIdentities: [PeerID] = []
     private(set) var startServicesCallCount = 0
     private(set) var stopServicesCallCount = 0
     private(set) var emergencyDisconnectCallCount = 0
@@ -111,6 +112,10 @@ final class MockTransport: Transport {
         NoiseEncryptionService(keychain: mockKeychain)
     }
 
+    func clearTrustedPublicIdentity(for peerID: PeerID) {
+        clearedTrustedPublicIdentities.append(peerID)
+    }
+
     // MARK: - Messaging
 
     func sendMessage(_ content: String, mentions: [String]) {
@@ -175,6 +180,7 @@ final class MockTransport: Transport {
         cancelledTransfers.removeAll()
         sentVerifyChallenges.removeAll()
         sentVerifyResponses.removeAll()
+        clearedTrustedPublicIdentities.removeAll()
         startServicesCallCount = 0
         stopServicesCallCount = 0
         emergencyDisconnectCallCount = 0

--- a/bitchatTests/Services/SecureIdentityStateManagerTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerTests.swift
@@ -128,6 +128,33 @@ final class SecureIdentityStateManagerTests: XCTestCase {
         XCTAssertTrue(reloaded.isFavorite(fingerprint: fingerprint))
     }
 
+    func test_forceSave_persistsCryptographicIdentityAcrossReinit() async {
+        let keychain = MockKeychain()
+        let manager = SecureIdentityStateManager(keychain)
+        let noisePublicKey = Data(repeating: 0x11, count: 32)
+        let signingPublicKey = Data(repeating: 0x22, count: 32)
+        let fingerprint = noisePublicKey.sha256Fingerprint()
+        let peerID = PeerID(publicKey: noisePublicKey)
+
+        manager.upsertCryptographicIdentity(
+            fingerprint: fingerprint,
+            noisePublicKey: noisePublicKey,
+            signingPublicKey: signingPublicKey,
+            claimedNickname: "Alice"
+        )
+        let inserted = await waitUntil {
+            manager.getCryptoIdentitiesByPeerIDPrefix(peerID).first?.signingPublicKey == signingPublicKey
+        }
+        XCTAssertTrue(inserted)
+        manager.forceSave()
+
+        let reloaded = SecureIdentityStateManager(keychain)
+        let reloadedIdentity = reloaded.getCryptoIdentitiesByPeerIDPrefix(peerID).first
+        XCTAssertEqual(reloadedIdentity?.fingerprint, fingerprint)
+        XCTAssertEqual(reloadedIdentity?.publicKey, noisePublicKey)
+        XCTAssertEqual(reloadedIdentity?.signingPublicKey, signingPublicKey)
+    }
+
     func test_updateSocialIdentity_reindexesClaimedNickname() async {
         let manager = SecureIdentityStateManager(MockKeychain())
         let fingerprint = String(repeating: "34", count: 32)

--- a/bitchatTests/Services/UnifiedPeerServiceTests.swift
+++ b/bitchatTests/Services/UnifiedPeerServiceTests.swift
@@ -55,6 +55,7 @@ private final class TestIdentityManager: SecureIdentityStateManagerProtocol {
     }
 
     func upsertCryptographicIdentity(fingerprint: String, noisePublicKey: Data, signingPublicKey: Data?, claimedNickname: String?) {}
+    func clearSigningPublicKey(for fingerprint: String) {}
 
     func getCryptoIdentitiesByPeerIDPrefix(_ peerID: PeerID) -> [CryptographicIdentity] {
         []


### PR DESCRIPTION
## Summary
This PR fixes the BLE identity-spoofing path by removing unauthenticated signing-key trust, requiring a trusted signing key for public content, revoking that trust immediately when a user removes verification, clearing stale stored signing keys during manual fingerprint verification, clearing the active session's in-memory public signing-key trust during manual verification, and persisting cryptographic identities so returning peers can be authenticated consistently across app restarts.

## Why this was a security problem
The original flow had several related trust failures:
- announce packets could introduce an attacker-controlled signing key before any trusted binding existed
- manual fingerprint verification could persist or preserve a signing key even though the user had only verified the Noise fingerprint, not the public-message signing key
- once a peer was treated as trusted in memory, public messages and file transfers were accepted without enforcing a valid packet signature, and that in-memory trust could outlive later verification removal or manual re-verification
- the code also treated cryptographic identities as if they were durable trusted state even though they were not actually persisted, which made the returning-peer trust path inconsistent

That meant a nearby attacker could poison the public-identity trust anchor ahead of verification, inject unsigned public content under a trusted peer identity, survive manual re-verification inside the same live session, or rely on mismatched runtime-vs-persisted trust behavior after restart.

## Fix
- keep first-contact announces discoverable, but do not retain or trust the advertised signing key unless the announce authenticates against an already trusted signing key
- make manual `Mark Verified` persist only the verified Noise identity; it no longer anchors a public-message signing key
- explicitly clear any previously stored signing key when the user manually verifies a fingerprint, so older poisoned state does not survive re-verification
- explicitly clear the active session's in-memory trusted signing key when a user manually verifies or removes verification, so public identity trust is not silently retained across trust-state changes
- keep QR verification as the OOB path that can safely persist the signing key, since the QR payload carries that key through the verified challenge/response flow
- require a valid packet signature from a trusted signing key for public messages and file transfers, including already-known in-memory peers
- persist cryptographic identities in the encrypted identity cache so the returning-peer authentication path is actually durable and consistent with the runtime trust model
- re-check persisted verification state before trusting active-session signing keys, so removing verification revokes public trust immediately without requiring reconnect or restart
- clarify the fingerprint screen so it distinguishes fingerprint verification from trusted public signing-key verification

## User impact
- spoofed first-contact announces no longer seed a trusted signing key
- unsigned public messages and file transfers from trusted-looking peers are rejected
- removing verification now revokes public signed-content trust immediately for the active session
- manual fingerprint verification no longer preserves either stored or in-memory public signing-key trust
- returning peers can still be authenticated after restart because the trusted cryptographic identity is now actually persisted
- manual fingerprint verification still marks the Noise identity verified, but public-message authentication now depends on a signing key that was actually verified out of band
- QR-verified peers continue to work for authenticated public identity and content

## Validation
- `swift test --filter BLEServiceCoreTests`
- `swift test --filter ChatViewModelVerificationTests`
- `swift test --filter SecureIdentityStateManagerTests`
- `swift test --filter ProtocolContractTests`
- `swift test --filter VerificationServiceTests`
