### PR TITLE
[codex] Improve chat reliability and keyboard autoscroll

### DIFF
--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -450,8 +450,7 @@ final class BLEService: NSObject {
             return
         }
         // Pre-mark our own broadcast as processed to avoid handling relayed self copy
-        let senderHex = signedPacket.senderID.hexEncodedString()
-        let dedupID = "\(senderHex)-\(signedPacket.timestamp)-\(signedPacket.type)"
+        let dedupID = makeMessageID(for: signedPacket)
         messageDeduplicator.markProcessed(dedupID)
         if let messageID {
             selfBroadcastMessageIDs[dedupID] = (id: messageID, timestamp: sendDate)
@@ -673,9 +672,10 @@ final class BLEService: NSObject {
     }
     
     func getNoiseSessionState(for peerID: PeerID) -> LazyHandshakeState {
-        if noiseService.hasEstablishedSession(with: peerID) {
+        let sessionPeerID = peerID.toShort()
+        if noiseService.hasEstablishedSession(with: sessionPeerID) {
             return .established
-        } else if noiseService.hasSession(with: peerID) {
+        } else if noiseService.hasSession(with: sessionPeerID) {
             return .handshaking
         } else {
             return .none
@@ -683,7 +683,7 @@ final class BLEService: NSObject {
     }
     
     func triggerHandshake(with peerID: PeerID) {
-        initiateNoiseHandshake(with: peerID)
+        initiateNoiseHandshake(with: peerID.toShort())
     }
     
     func getNoiseService() -> NoiseEncryptionService {
@@ -754,9 +754,7 @@ final class BLEService: NSObject {
                 return
             }
 
-            let senderHex = packet.senderID.hexEncodedString()
-            let dedupID = "\(senderHex)-\(packet.timestamp)-\(packet.type)"
-            self.messageDeduplicator.markProcessed(dedupID)
+            self.messageDeduplicator.markProcessed(self.makeMessageID(for: packet))
 
             SecureLogger.debug("📁 Broadcasting file transfer payload bytes=\(payload.count)", category: .session)
             self.broadcastPacket(packet, transferId: transferId)
@@ -804,15 +802,20 @@ final class BLEService: NSObject {
         // Create typed payload: [type byte] + [message ID]
         var payload = Data([NoisePayloadType.readReceipt.rawValue])
         payload.append(contentsOf: receipt.originalMessageID.utf8)
+        let sessionPeerID = peerID.toShort()
 
-        if noiseService.hasEstablishedSession(with: peerID) {
-            SecureLogger.debug("📤 Sending READ receipt for message \(receipt.originalMessageID) to \(peerID)", category: .session)
+        if noiseService.hasEstablishedSession(with: sessionPeerID) {
+            SecureLogger.debug("📤 Sending READ receipt for message \(receipt.originalMessageID) to \(sessionPeerID)", category: .session)
             do {
-                let encrypted = try noiseService.encrypt(payload, for: peerID)
+                let encrypted = try noiseService.encrypt(payload, for: sessionPeerID)
+                guard let recipientData = routingData(for: sessionPeerID) else {
+                    SecureLogger.error("Invalid recipient peer ID for read receipt: \(peerID)", category: .session)
+                    return
+                }
                 let packet = BitchatPacket(
                     type: MessageType.noiseEncrypted.rawValue,
                     senderID: myPeerIDData,
-                    recipientID: Data(hexString: peerID.id),
+                    recipientID: recipientData,
                     timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                     payload: encrypted,
                     signature: nil,
@@ -826,10 +829,10 @@ final class BLEService: NSObject {
             // Queue for after handshake and initiate if needed
             collectionsQueue.async(flags: .barrier) { [weak self] in
                 guard let self = self else { return }
-                self.pendingNoisePayloadsAfterHandshake[peerID, default: []].append(payload)
+                self.pendingNoisePayloadsAfterHandshake[sessionPeerID, default: []].append(payload)
             }
-            if !noiseService.hasSession(with: peerID) { initiateNoiseHandshake(with: peerID) }
-            SecureLogger.debug("🕒 Queued READ receipt for \(peerID) until handshake completes", category: .session)
+            if !noiseService.hasSession(with: sessionPeerID) { initiateNoiseHandshake(with: sessionPeerID) }
+            SecureLogger.debug("🕒 Queued READ receipt for \(sessionPeerID) until handshake completes", category: .session)
         }
     }
     
@@ -1186,7 +1189,7 @@ final class BLEService: NSObject {
 
         // Skip directed packets that are not intended for us
         if let recipient = packet.recipientID {
-            if PeerID(hexData: recipient) != myPeerID && !recipient.allSatisfy({ $0 == 0xFF }) {
+            if !isRecipientAddressedToMe(recipient) && !recipient.allSatisfy({ $0 == 0xFF }) {
                 return
             }
         }
@@ -1233,7 +1236,7 @@ final class BLEService: NSObject {
             return
         }
 
-        let isPrivateMessage = PeerID(hexData: packet.recipientID) == myPeerID
+        let isPrivateMessage = isRecipientAddressedToMe(packet.recipientID)
 
         if isPrivateMessage {
             updatePeerLastSeen(peerID)
@@ -1282,14 +1285,19 @@ final class BLEService: NSObject {
         // Create typed payload: [type byte] + [message ID]
         var payload = Data([NoisePayloadType.delivered.rawValue])
         payload.append(contentsOf: messageID.utf8)
+        let sessionPeerID = peerID.toShort()
 
-        if noiseService.hasEstablishedSession(with: peerID) {
+        if noiseService.hasEstablishedSession(with: sessionPeerID) {
             do {
-                let encrypted = try noiseService.encrypt(payload, for: peerID)
+                let encrypted = try noiseService.encrypt(payload, for: sessionPeerID)
+                guard let recipientData = routingData(for: sessionPeerID) else {
+                    SecureLogger.error("Invalid recipient peer ID for delivery ACK: \(peerID)", category: .session)
+                    return
+                }
                 let packet = BitchatPacket(
                     type: MessageType.noiseEncrypted.rawValue,
                     senderID: myPeerIDData,
-                    recipientID: Data(hexString: peerID.id),
+                    recipientID: recipientData,
                     timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                     payload: encrypted,
                     signature: nil,
@@ -1303,10 +1311,10 @@ final class BLEService: NSObject {
             // Queue for after handshake and initiate if needed
             collectionsQueue.async(flags: .barrier) { [weak self] in
                 guard let self = self else { return }
-                self.pendingNoisePayloadsAfterHandshake[peerID, default: []].append(payload)
+                self.pendingNoisePayloadsAfterHandshake[sessionPeerID, default: []].append(payload)
             }
-            if !noiseService.hasSession(with: peerID) { initiateNoiseHandshake(with: peerID) }
-            SecureLogger.debug("🕒 Queued DELIVERED ack for \(peerID) until handshake completes", category: .session)
+            if !noiseService.hasSession(with: sessionPeerID) { initiateNoiseHandshake(with: sessionPeerID) }
+            SecureLogger.debug("🕒 Queued DELIVERED ack for \(sessionPeerID) until handshake completes", category: .session)
         }
     }
 
@@ -2056,6 +2064,10 @@ extension BLEService {
         }
         handleReceivedPacket(packet, from: fromPeerID)
     }
+
+    func _test_isRecipientAddressedToMe(_ recipientData: Data?) -> Bool {
+        isRecipientAddressedToMe(recipientData)
+    }
 }
 #endif
 
@@ -2773,6 +2785,19 @@ extension BLEService {
         peerID.toShort().routingData
     }
 
+    private func isRecipientAddressedToMe(_ recipientData: Data?) -> Bool {
+        guard let recipientData else {
+            return false
+        }
+        let recipientPeerID = PeerID(hexData: recipientData)
+
+        if recipientPeerID == myPeerID || recipientPeerID.toShort() == myPeerID.toShort() {
+            return true
+        }
+
+        return recipientData == noiseService.getStaticPublicKeyData()
+    }
+
     private func refreshLocalTopology() {
         let neighbors: [Data] = collectionsQueue.sync {
             peers.values.filter { $0.isConnected }.compactMap { $0.peerID.routingData }
@@ -2900,25 +2925,30 @@ extension BLEService {
 
     
     private func sendNoisePayload(_ typedPayload: Data, to peerID: PeerID) {
-        guard noiseService.hasSession(with: peerID) else {
+        let sessionPeerID = peerID.toShort()
+        guard noiseService.hasSession(with: sessionPeerID) else {
             // No session yet - queue the payload SYNCHRONOUSLY before initiating handshake
             // to prevent race where fast handshake completion drains empty queue
             collectionsQueue.sync(flags: .barrier) {
-                if self.pendingNoisePayloadsAfterHandshake[peerID] == nil {
-                    self.pendingNoisePayloadsAfterHandshake[peerID] = []
+                if self.pendingNoisePayloadsAfterHandshake[sessionPeerID] == nil {
+                    self.pendingNoisePayloadsAfterHandshake[sessionPeerID] = []
                 }
-                self.pendingNoisePayloadsAfterHandshake[peerID]?.append(typedPayload)
-                SecureLogger.debug("📥 Queued noise payload for \(peerID) pending handshake", category: .session)
+                self.pendingNoisePayloadsAfterHandshake[sessionPeerID]?.append(typedPayload)
+                SecureLogger.debug("📥 Queued noise payload for \(sessionPeerID) pending handshake", category: .session)
             }
-            initiateNoiseHandshake(with: peerID)
+            initiateNoiseHandshake(with: sessionPeerID)
             return
         }
         do {
-            let encrypted = try noiseService.encrypt(typedPayload, for: peerID)
+            let encrypted = try noiseService.encrypt(typedPayload, for: sessionPeerID)
+            guard let recipientData = routingData(for: sessionPeerID) else {
+                SecureLogger.error("Invalid recipient peer ID for verification payload: \(peerID)", category: .session)
+                return
+            }
             let packet = BitchatPacket(
                 type: MessageType.noiseEncrypted.rawValue,
                 senderID: myPeerIDData,
-                recipientID: Data(hexString: peerID.id),
+                recipientID: recipientData,
                 timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                 payload: encrypted,
                 signature: nil,
@@ -3156,10 +3186,11 @@ extension BLEService {
     // MARK: Private Message Handling
     
     private func sendPrivateMessage(_ content: String, to recipientID: PeerID, messageID: String) {
-        SecureLogger.debug("📨 Sending PM to \(recipientID): \(content.prefix(30))...", category: .session)
+        let sessionPeerID = recipientID.toShort()
+        SecureLogger.debug("📨 Sending PM to \(sessionPeerID), id: \(messageID.prefix(8))...", category: .session)
         
         // Check if we have an established Noise session
-        if noiseService.hasEstablishedSession(with: recipientID) {
+        if noiseService.hasEstablishedSession(with: sessionPeerID) {
             // Encrypt and send
             do {
                 // Create TLV-encoded private message
@@ -3173,22 +3204,10 @@ extension BLEService {
                 var messagePayload = Data([NoisePayloadType.privateMessage.rawValue])
                 messagePayload.append(tlvData)
                 
-                let encrypted = try noiseService.encrypt(messagePayload, for: recipientID)
-                
-                // Convert recipientID to Data (assuming it's a hex string)
-                var recipientData = Data()
-                var tempID = recipientID.id
-                while tempID.count >= 2 {
-                    let hexByte = String(tempID.prefix(2))
-                    if let byte = UInt8(hexByte, radix: 16) {
-                        recipientData.append(byte)
-                    }
-                    tempID = String(tempID.dropFirst(2))
-                }
-                if tempID.count == 1 {
-                    if let byte = UInt8(tempID, radix: 16) {
-                        recipientData.append(byte)
-                    }
+                let encrypted = try noiseService.encrypt(messagePayload, for: sessionPeerID)
+                guard let recipientData = routingData(for: sessionPeerID) else {
+                    SecureLogger.error("Invalid recipient peer ID for private message: \(recipientID)", category: .session)
+                    return
                 }
 
                 let packet = BitchatPacket(
@@ -3212,17 +3231,17 @@ extension BLEService {
             }
         } else {
             // Queue message for sending after handshake completes
-            SecureLogger.debug("🤝 No session with \(recipientID), initiating handshake and queueing message", category: .session)
+            SecureLogger.debug("🤝 No session with \(sessionPeerID), initiating handshake and queueing message", category: .session)
             
             // Queue the message (especially important for favorite notifications)
             collectionsQueue.sync(flags: .barrier) {
-                if pendingMessagesAfterHandshake[recipientID] == nil {
-                    pendingMessagesAfterHandshake[recipientID] = []
+                if pendingMessagesAfterHandshake[sessionPeerID] == nil {
+                    pendingMessagesAfterHandshake[sessionPeerID] = []
                 }
-                pendingMessagesAfterHandshake[recipientID]?.append((content, messageID))
+                pendingMessagesAfterHandshake[sessionPeerID]?.append((content, messageID))
             }
             
-            initiateNoiseHandshake(with: recipientID)
+            initiateNoiseHandshake(with: sessionPeerID)
             
             // Notify delegate that message is pending
             notifyUI { [weak self] in
@@ -3232,17 +3251,22 @@ extension BLEService {
     }
     
     private func initiateNoiseHandshake(with peerID: PeerID) {
+        let sessionPeerID = peerID.toShort()
         // Use NoiseEncryptionService for handshake
-        guard !noiseService.hasSession(with: peerID) else { return }
+        guard !noiseService.hasSession(with: sessionPeerID) else { return }
+        guard let recipientData = routingData(for: sessionPeerID) else {
+            SecureLogger.error("Invalid recipient peer ID for handshake: \(peerID)", category: .session)
+            return
+        }
         
         do {
-            let handshakeData = try noiseService.initiateHandshake(with: peerID)
+            let handshakeData = try noiseService.initiateHandshake(with: sessionPeerID)
             
             // Send handshake init
             let packet = BitchatPacket(
                 type: MessageType.noiseHandshake.rawValue,
                 senderID: myPeerIDData,
-                recipientID: Data(hexString: peerID.id),
+                recipientID: recipientData,
                 timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                 payload: handshakeData,
                 signature: nil,
@@ -3255,16 +3279,17 @@ extension BLEService {
     }
     
     private func sendPendingMessagesAfterHandshake(for peerID: PeerID) {
+        let sessionPeerID = peerID.toShort()
         // Atomically take all pending messages to process (prevents concurrent modification)
         let pendingMessages = collectionsQueue.sync(flags: .barrier) { () -> [(content: String, messageID: String)]? in
-            let messages = pendingMessagesAfterHandshake[peerID]
-            pendingMessagesAfterHandshake.removeValue(forKey: peerID)
+            let messages = pendingMessagesAfterHandshake[sessionPeerID]
+            pendingMessagesAfterHandshake.removeValue(forKey: sessionPeerID)
             return messages
         }
 
         guard let messages = pendingMessages, !messages.isEmpty else { return }
 
-        SecureLogger.debug("📤 Sending \(messages.count) pending messages after handshake to \(peerID)", category: .session)
+        SecureLogger.debug("📤 Sending \(messages.count) pending messages after handshake to \(sessionPeerID)", category: .session)
 
         // Track failed messages for re-queuing
         var failedMessages: [(content: String, messageID: String)] = []
@@ -3283,12 +3308,17 @@ extension BLEService {
                 var messagePayload = Data([NoisePayloadType.privateMessage.rawValue])
                 messagePayload.append(tlvData)
 
-                let encrypted = try noiseService.encrypt(messagePayload, for: peerID)
+                let encrypted = try noiseService.encrypt(messagePayload, for: sessionPeerID)
+                guard let recipientData = routingData(for: sessionPeerID) else {
+                    SecureLogger.error("Invalid recipient peer ID for pending private message: \(peerID)", category: .session)
+                    failedMessages.append((content, messageID))
+                    continue
+                }
 
                 let packet = BitchatPacket(
                     type: MessageType.noiseEncrypted.rawValue,
                     senderID: myPeerIDData,
-                    recipientID: Data(hexString: peerID.id),
+                    recipientID: recipientData,
                     timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                     payload: encrypted,
                     signature: nil,
@@ -3319,12 +3349,12 @@ extension BLEService {
         if !failedMessages.isEmpty {
             collectionsQueue.async(flags: .barrier) { [weak self] in
                 guard let self = self else { return }
-                if self.pendingMessagesAfterHandshake[peerID] == nil {
-                    self.pendingMessagesAfterHandshake[peerID] = []
+                if self.pendingMessagesAfterHandshake[sessionPeerID] == nil {
+                    self.pendingMessagesAfterHandshake[sessionPeerID] = []
                 }
                 // Prepend failed messages to maintain order
-                self.pendingMessagesAfterHandshake[peerID]?.insert(contentsOf: failedMessages, at: 0)
-                SecureLogger.warning("⚠️ Re-queued \(failedMessages.count) failed messages for \(peerID)", category: .session)
+                self.pendingMessagesAfterHandshake[sessionPeerID]?.insert(contentsOf: failedMessages, at: 0)
+                SecureLogger.warning("⚠️ Re-queued \(failedMessages.count) failed messages for \(sessionPeerID)", category: .session)
             }
         }
     }
@@ -3702,8 +3732,7 @@ extension BLEService {
         
         // Deduplication (thread-safe)
         let senderID = PeerID(hexData: packet.senderID)
-        // Include packet type in message ID to prevent collisions between different packet types
-        let messageID = "\(senderID)-\(packet.timestamp)-\(packet.type)"
+        let messageID = makeMessageID(for: packet)
         
         // Only log non-announce packets to reduce noise
         if packet.type != MessageType.announce.rawValue {
@@ -4110,9 +4139,7 @@ extension BLEService {
         let ts = Date(timeIntervalSince1970: Double(packet.timestamp) / 1000)
         var resolvedSelfMessageID: String? = nil
         if peerID == myPeerID {
-            let senderHex = packet.senderID.hexEncodedString()
-            let dedupID = "\(senderHex)-\(packet.timestamp)-\(packet.type)"
-            resolvedSelfMessageID = selfBroadcastMessageIDs.removeValue(forKey: dedupID)?.id
+            resolvedSelfMessageID = selfBroadcastMessageIDs.removeValue(forKey: makeMessageID(for: packet))?.id
         }
         notifyUI { [weak self] in
             self?.delegate?.didReceivePublicMessage(from: peerID,
@@ -4125,15 +4152,19 @@ extension BLEService {
     
     private func handleNoiseHandshake(_ packet: BitchatPacket, from peerID: PeerID) {
         // Use NoiseEncryptionService for handshake processing
-        if PeerID(hexData: packet.recipientID) == myPeerID {
+        if isRecipientAddressedToMe(packet.recipientID) {
             // Handshake is for us
             do {
                 if let response = try noiseService.processHandshakeMessage(from: peerID, message: packet.payload) {
+                    guard let recipientData = routingData(for: peerID) else {
+                        SecureLogger.error("Invalid recipient peer ID for handshake response: \(peerID)", category: .session)
+                        return
+                    }
                     // Send response
                     let responsePacket = BitchatPacket(
                         type: MessageType.noiseHandshake.rawValue,
                         senderID: myPeerIDData,
-                        recipientID: Data(hexString: peerID.id),
+                        recipientID: recipientData,
                         timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                         payload: response,
                         signature: nil,
@@ -4163,7 +4194,7 @@ extension BLEService {
             return
         }
         
-        if recipientID != myPeerID {
+        if !isRecipientAddressedToMe(packet.recipientID) {
             SecureLogger.debug("🔐 Encrypted message not for me (for \(recipientID), I am \(myPeerID))", category: .session)
             return
         }
@@ -4227,20 +4258,25 @@ extension BLEService {
     // MARK: Helper Functions
     
     private func sendPendingNoisePayloadsAfterHandshake(for peerID: PeerID) {
+        let sessionPeerID = peerID.toShort()
         let payloads = collectionsQueue.sync(flags: .barrier) { () -> [Data] in
-            let list = pendingNoisePayloadsAfterHandshake[peerID] ?? []
-            pendingNoisePayloadsAfterHandshake.removeValue(forKey: peerID)
+            let list = pendingNoisePayloadsAfterHandshake[sessionPeerID] ?? []
+            pendingNoisePayloadsAfterHandshake.removeValue(forKey: sessionPeerID)
             return list
         }
         guard !payloads.isEmpty else { return }
-        SecureLogger.debug("📤 Sending \(payloads.count) pending noise payloads to \(peerID) after handshake", category: .session)
+        SecureLogger.debug("📤 Sending \(payloads.count) pending noise payloads to \(sessionPeerID) after handshake", category: .session)
         for payload in payloads {
             do {
-                let encrypted = try noiseService.encrypt(payload, for: peerID)
+                let encrypted = try noiseService.encrypt(payload, for: sessionPeerID)
+                guard let recipientData = routingData(for: sessionPeerID) else {
+                    SecureLogger.error("Invalid recipient peer ID for pending noise payload: \(peerID)", category: .session)
+                    continue
+                }
                 let packet = BitchatPacket(
                     type: MessageType.noiseEncrypted.rawValue,
                     senderID: myPeerIDData,
-                    recipientID: Data(hexString: peerID.id),
+                    recipientID: recipientData,
                     timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
                     payload: encrypted,
                     signature: nil,
@@ -4248,7 +4284,7 @@ extension BLEService {
                 )
                 broadcastPacket(packet)
             } catch {
-                SecureLogger.error("❌ Failed to send pending noise payload to \(peerID): \(error)")
+                SecureLogger.error("❌ Failed to send pending noise payload to \(sessionPeerID): \(error)")
             }
         }
     }

--- a/bitchat/Services/MessageRouter.swift
+++ b/bitchat/Services/MessageRouter.swift
@@ -9,6 +9,7 @@ final class MessageRouter {
 
     // Outbox entry with timestamp for TTL-based eviction
     private struct QueuedMessage {
+        let destinationPeerID: PeerID
         let content: String
         let nickname: String
         let messageID: String
@@ -51,11 +52,24 @@ final class MessageRouter {
     // MARK: - Transport Selection
 
     private func reachableTransport(for peerID: PeerID) -> Transport? {
-        transports.first { $0.isPeerReachable(peerID) }
+        transports.first { transport in
+            candidatePeerIDs(for: peerID).contains { transport.isPeerReachable($0) }
+        }
     }
 
     private func connectedTransport(for peerID: PeerID) -> Transport? {
-        transports.first { $0.isPeerConnected(peerID) }
+        transports.first { transport in
+            candidatePeerIDs(for: peerID).contains { transport.isPeerConnected($0) }
+        }
+    }
+
+    private func candidatePeerIDs(for peerID: PeerID) -> [PeerID] {
+        let shortPeerID = peerID.toShort()
+        return shortPeerID == peerID ? [peerID] : [peerID, shortPeerID]
+    }
+
+    private func outboxKey(for peerID: PeerID) -> PeerID {
+        peerID.toShort()
     }
 
     // MARK: - Message Sending
@@ -65,19 +79,20 @@ final class MessageRouter {
             SecureLogger.debug("Routing PM via \(type(of: transport)) to \(peerID.id.prefix(8))… id=\(messageID.prefix(8))…", category: .session)
             transport.sendPrivateMessage(content, to: peerID, recipientNickname: recipientNickname, messageID: messageID)
         } else {
+            let key = outboxKey(for: peerID)
             // Queue for later with timestamp for TTL tracking
-            if outbox[peerID] == nil { outbox[peerID] = [] }
+            if outbox[key] == nil { outbox[key] = [] }
 
-            let message = QueuedMessage(content: content, nickname: recipientNickname, messageID: messageID, timestamp: Date())
-            outbox[peerID]?.append(message)
+            let message = QueuedMessage(destinationPeerID: peerID, content: content, nickname: recipientNickname, messageID: messageID, timestamp: Date())
+            outbox[key]?.append(message)
 
             // Enforce per-peer size limit with FIFO eviction
-            if let count = outbox[peerID]?.count, count > Self.maxMessagesPerPeer {
-                let evicted = outbox[peerID]?.removeFirst()
-                SecureLogger.warning("📤 Outbox overflow for \(peerID.id.prefix(8))… - evicted oldest message: \(evicted?.messageID.prefix(8) ?? "?")…", category: .session)
+            if let count = outbox[key]?.count, count > Self.maxMessagesPerPeer {
+                let evicted = outbox[key]?.removeFirst()
+                SecureLogger.warning("📤 Outbox overflow for \(key.id.prefix(8))… - evicted oldest message: \(evicted?.messageID.prefix(8) ?? "?")…", category: .session)
             }
 
-            SecureLogger.debug("Queued PM for \(peerID.id.prefix(8))… (no reachable transport) id=\(messageID.prefix(8))… queue=\(outbox[peerID]?.count ?? 0)", category: .session)
+            SecureLogger.debug("Queued PM for \(peerID.id.prefix(8))… (no reachable transport) id=\(messageID.prefix(8))… queue=\(outbox[key]?.count ?? 0)", category: .session)
         }
     }
 
@@ -108,8 +123,18 @@ final class MessageRouter {
     // MARK: - Outbox Management
 
     func flushOutbox(for peerID: PeerID) {
-        guard let queued = outbox[peerID], !queued.isEmpty else { return }
-        SecureLogger.debug("Flushing outbox for \(peerID.id.prefix(8))… count=\(queued.count)", category: .session)
+        let key = outboxKey(for: peerID)
+        let matchingKeys = Array(outbox.keys.filter { $0 == peerID || outboxKey(for: $0) == key })
+        guard !matchingKeys.isEmpty else { return }
+
+        let queued = matchingKeys.flatMap { outbox[$0] ?? [] }
+        guard !queued.isEmpty else { return }
+
+        for matchingKey in matchingKeys {
+            outbox.removeValue(forKey: matchingKey)
+        }
+
+        SecureLogger.debug("Flushing outbox for \(key.id.prefix(8))… count=\(queued.count)", category: .session)
 
         let now = Date()
         var remaining: [QueuedMessage] = []
@@ -117,22 +142,20 @@ final class MessageRouter {
         for message in queued {
             // Skip expired messages (TTL exceeded)
             if now.timeIntervalSince(message.timestamp) > Self.messageTTLSeconds {
-                SecureLogger.debug("⏰ Expired queued message for \(peerID.id.prefix(8))… id=\(message.messageID.prefix(8))… (age: \(Int(now.timeIntervalSince(message.timestamp)))s)", category: .session)
+                SecureLogger.debug("⏰ Expired queued message for \(message.destinationPeerID.id.prefix(8))… id=\(message.messageID.prefix(8))… (age: \(Int(now.timeIntervalSince(message.timestamp)))s)", category: .session)
                 continue
             }
 
-            if let transport = reachableTransport(for: peerID) {
-                SecureLogger.debug("Outbox -> \(type(of: transport)) for \(peerID.id.prefix(8))… id=\(message.messageID.prefix(8))…", category: .session)
-                transport.sendPrivateMessage(message.content, to: peerID, recipientNickname: message.nickname, messageID: message.messageID)
+            if let transport = reachableTransport(for: message.destinationPeerID) {
+                SecureLogger.debug("Outbox -> \(type(of: transport)) for \(message.destinationPeerID.id.prefix(8))… id=\(message.messageID.prefix(8))…", category: .session)
+                transport.sendPrivateMessage(message.content, to: message.destinationPeerID, recipientNickname: message.nickname, messageID: message.messageID)
             } else {
                 remaining.append(message)
             }
         }
 
-        if remaining.isEmpty {
-            outbox.removeValue(forKey: peerID)
-        } else {
-            outbox[peerID] = remaining
+        for message in remaining {
+            outbox[outboxKey(for: message.destinationPeerID), default: []].append(message)
         }
     }
 

--- a/bitchat/Services/NostrTransport.swift
+++ b/bitchat/Services/NostrTransport.swift
@@ -125,13 +125,11 @@ final class NostrTransport: Transport, @unchecked Sendable {
     
     func isPeerReachable(_ peerID: PeerID) -> Bool {
         queue.sync {
-            // Check if exact match
-            if reachablePeers.contains(peerID) { return true }
-            // Check for short ID match
-            if peerID.isShort {
-                return reachablePeers.contains(where: { $0.toShort() == peerID })
+            let shortPeerID = peerID.toShort()
+            if reachablePeers.contains(peerID) || reachablePeers.contains(shortPeerID) {
+                return true
             }
-            return false
+            return reachablePeers.contains { $0.toShort() == shortPeerID }
         }
     }
     

--- a/bitchat/Views/MessageListView.swift
+++ b/bitchat/Views/MessageListView.swift
@@ -7,6 +7,9 @@
 
 import BitFoundation
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 private struct MessageDisplayItem: Identifiable {
     let id: String
@@ -105,6 +108,9 @@ struct MessageListView: View {
                             .padding(.horizontal, 12)
                             .padding(.vertical, 1)
                     }
+                    Color.clear
+                        .frame(height: 1)
+                        .id(bottomAnchorID)
                 }
                 .transaction { tx in if viewModel.isBatchingPublic { tx.disablesAnimations = true } }
                 .padding(.vertical, 2)
@@ -115,9 +121,15 @@ struct MessageListView: View {
             }
             .onAppear {
                 scrollToBottom(on: proxy)
+                if shouldHandleComposerScroll {
+                    scrollToBottomAfterLayoutSettles(on: proxy)
+                }
             }
             .onChange(of: privatePeer) { _ in
                 scrollToBottom(on: proxy)
+                if shouldHandleComposerScroll {
+                    scrollToBottomAfterLayoutSettles(on: proxy)
+                }
             }
             .onChange(of: viewModel.messages.count) { _ in
                 onMessagesChange(proxy: proxy)
@@ -128,6 +140,23 @@ struct MessageListView: View {
             .onChange(of: locationManager.selectedChannel) { newChannel in
                 onSelectedChannelChange(newChannel, proxy: proxy)
             }
+            .onChange(of: isTextFieldFocused.wrappedValue) { isFocused in
+                onTextFieldFocusChange(isFocused: isFocused, proxy: proxy)
+            }
+#if os(iOS)
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+                onKeyboardFrameChange(proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { _ in
+                onKeyboardFrameChange(proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
+                onKeyboardFrameChange(proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidChangeFrameNotification)) { _ in
+                onKeyboardFrameChange(proxy: proxy)
+            }
+#endif
             .confirmationDialog(
                 selectedMessageSender.map { "@\($0)" } ?? String(localized: "content.actions.title", comment: "Fallback title for the message action sheet"),
                 isPresented: $showMessageActions,
@@ -325,26 +354,47 @@ private extension MessageListView {
 
     func scrollToBottom(on proxy: ScrollViewProxy) {
         isAtBottom = true
-        if let targetPeerID {
-            proxy.scrollTo(targetPeerID, anchor: .bottom)
-        }
+        proxy.scrollTo(bottomAnchorID, anchor: .bottom)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            if let secondTarget = self.targetPeerID {
-                proxy.scrollTo(secondTarget, anchor: .bottom)
+            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
+        }
+    }
+
+    var shouldHandleComposerScroll: Bool {
+        if let privatePeer {
+            return viewModel.selectedPrivateChatPeer == privatePeer
+        }
+        return viewModel.selectedPrivateChatPeer == nil && !showSidebar
+    }
+
+    var bottomAnchorID: String {
+        if let peer = privatePeer {
+            return "dm:\(peer)|bottom"
+        }
+        return "\(locationManager.selectedChannel.contextKey)|bottom"
+    }
+
+    func onTextFieldFocusChange(isFocused: Bool, proxy: ScrollViewProxy) {
+        guard isFocused, shouldHandleComposerScroll else { return }
+        scrollToBottomAfterLayoutSettles(on: proxy)
+    }
+
+    func scrollToBottomAfterLayoutSettles(on proxy: ScrollViewProxy) {
+        scrollToBottom(on: proxy)
+
+        for delay in [0.05, 0.15, 0.30, 0.45, 0.60, 0.85] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                scrollToBottom(on: proxy)
             }
         }
     }
 
-    var targetPeerID: String? {
-        if let peer = privatePeer,
-           let last = viewModel.getPrivateChatMessages(for: peer).suffix(300).last?.id {
-            return "dm:\(peer)|\(last)"
-        }
-        if let last = viewModel.messages.suffix(300).last?.id {
-            return "\(locationManager.selectedChannel.contextKey)|\(last)"
-        }
-        return nil
+#if os(iOS)
+    func onKeyboardFrameChange(proxy: ScrollViewProxy) {
+        guard shouldHandleComposerScroll else { return }
+        scrollToBottomAfterLayoutSettles(on: proxy)
     }
+#endif
 
     func onMessagesChange(proxy: ScrollViewProxy) {
         guard privatePeer == nil, let lastMsg = viewModel.messages.last else { return }
@@ -359,10 +409,7 @@ private extension MessageListView {
 
         func scrollIfNeeded(date: Date) {
             lastScrollTime = date
-            let contextKey = locationManager.selectedChannel.contextKey
-            if let target = viewModel.messages.suffix(windowCountPublic).last.map({ "\(contextKey)|\($0.id)" }) {
-                proxy.scrollTo(target, anchor: .bottom)
-            }
+            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
         }
 
         // Throttle scroll animations to prevent excessive UI updates
@@ -382,7 +429,12 @@ private extension MessageListView {
     }
 
     func onPrivateChatsChange(proxy: ScrollViewProxy) {
-        guard let peerID = privatePeer, let messages = viewModel.privateChats[peerID], let lastMsg = messages.last else {
+        guard let peerID = privatePeer else {
+            return
+        }
+
+        let messages = viewModel.getPrivateChatMessages(for: peerID)
+        guard let lastMsg = messages.last else {
             return
         }
 
@@ -396,11 +448,7 @@ private extension MessageListView {
 
         func scrollIfNeeded(date: Date) {
             lastScrollTime = date
-            let contextKey = "dm:\(peerID)"
-            let count = windowCountPrivate[peerID] ?? 300
-            if let target = messages.suffix(count).last.map({ "\(contextKey)|\($0.id)" }){
-                proxy.scrollTo(target, anchor: .bottom)
-            }
+            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
         }
 
         // Same throttling for private chats
@@ -423,14 +471,11 @@ private extension MessageListView {
         switch channel {
         case .mesh:
             break
-        case .location(let ch):
+        case .location:
             // Reset window size
             isAtBottom = true
             windowCountPublic = TransportConfig.uiWindowInitialCountPublic
-            let contextKey = "geo:\(ch.geohash)"
-            if let target = viewModel.messages.suffix(windowCountPublic).last?.id.map({ "\(contextKey)|\($0)" }) {
-                proxy.scrollTo(target, anchor: .bottom)
-            }
+            scrollToBottomAfterLayoutSettles(on: proxy)
         }
     }
 }

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -60,6 +60,37 @@ struct BLEServiceCoreTests {
     }
 
     @Test
+    func sameTimestampDistinctPackets_areNotDeduped() async {
+        let ble = makeService()
+        let delegate = PublicCaptureDelegate()
+        ble.delegate = delegate
+
+        let sender = PeerID(str: "0102030405060708")
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let first = makePublicPacket(content: "one", sender: sender, timestamp: timestamp)
+        let second = makePublicPacket(content: "two", sender: sender, timestamp: timestamp)
+
+        ble._test_handlePacket(first, fromPeerID: sender)
+        ble._test_handlePacket(second, fromPeerID: sender)
+
+        let receivedBoth = await TestHelpers.waitUntil(
+            { delegate.publicMessagesSnapshot().count == 2 },
+            timeout: TestConstants.defaultTimeout
+        )
+        #expect(receivedBoth)
+        #expect(Set(delegate.publicMessagesSnapshot().map(\.content)) == Set(["one", "two"]))
+    }
+
+    @Test
+    func localRecipientAddressing_acceptsShortIDAndFullNoiseKey() {
+        let ble = makeService()
+
+        #expect(ble._test_isRecipientAddressedToMe(Data(hexString: ble.myPeerID.id)))
+        #expect(ble._test_isRecipientAddressedToMe(ble.getNoiseService().getStaticPublicKeyData()))
+        #expect(!ble._test_isRecipientAddressedToMe(Data(repeating: 0xAA, count: 8)))
+    }
+
+    @Test
     func announceSenderMismatch_isRejected() async throws {
         let ble = makeService()
 

--- a/bitchatTests/Services/MessageRouterTests.swift
+++ b/bitchatTests/Services/MessageRouterTests.swift
@@ -27,6 +27,21 @@ struct MessageRouterTests {
     }
 
     @Test @MainActor
+    func sendPrivate_routesFullNoiseKeyWhenShortIDIsReachable() async {
+        let noiseKey = Data((0..<32).map { UInt8($0) })
+        let fullPeerID = PeerID(hexData: noiseKey)
+        let shortPeerID = fullPeerID.toShort()
+        let transport = MockTransport()
+        transport.reachablePeers.insert(shortPeerID)
+
+        let router = MessageRouter(transports: [transport])
+        router.sendPrivate("Hello", to: fullPeerID, recipientNickname: "Peer", messageID: "m-short-route")
+
+        #expect(transport.sentPrivateMessages.count == 1)
+        #expect(transport.sentPrivateMessages.first?.peerID == fullPeerID)
+    }
+
+    @Test @MainActor
     func sendPrivate_queuesThenFlushesWhenReachable() async {
         let peerID = PeerID(str: "0000000000000002")
         let transport = MockTransport()
@@ -40,6 +55,25 @@ struct MessageRouterTests {
         router.flushOutbox(for: peerID)
 
         #expect(transport.sentPrivateMessages.count == 1)
+    }
+
+    @Test @MainActor
+    func sendPrivate_queuesFullNoiseKeyThenFlushesWhenShortIDConnects() async {
+        let noiseKey = Data((32..<64).map { UInt8($0) })
+        let fullPeerID = PeerID(hexData: noiseKey)
+        let shortPeerID = fullPeerID.toShort()
+        let transport = MockTransport()
+
+        let router = MessageRouter(transports: [transport])
+        router.sendPrivate("Queued", to: fullPeerID, recipientNickname: "Peer", messageID: "m-short-flush")
+
+        #expect(transport.sentPrivateMessages.isEmpty)
+
+        transport.reachablePeers.insert(shortPeerID)
+        router.flushOutbox(for: shortPeerID)
+
+        #expect(transport.sentPrivateMessages.count == 1)
+        #expect(transport.sentPrivateMessages.first?.peerID == fullPeerID)
     }
 
     @Test @MainActor

--- a/bitchatTests/Services/NostrTransportTests.swift
+++ b/bitchatTests/Services/NostrTransportTests.swift
@@ -42,7 +42,7 @@ struct NostrTransportTests {
             )
         )
 
-        #expect(!transport.isPeerReachable(fullPeerID))
+        #expect(transport.isPeerReachable(fullPeerID))
         #expect(transport.isPeerReachable(shortPeerID))
         #expect(!transport.isPeerReachable(PeerID(str: "feedfeedfeedfeed")))
     }


### PR DESCRIPTION
## Summary

This PR improves two rough edges that showed up during real device testing:

- Keeps the latest messages visible when the keyboard opens by scrolling to a stable bottom anchor after focus and keyboard frame changes.
- Makes private-message routing more robust when peers are represented by either their full Noise public key or their short mesh peer ID.
- Prevents BLE receive-side deduplication from dropping distinct packets that share the same sender, packet type, and millisecond timestamp.

## Root Cause

The BLE receive deduplication key only used sender, timestamp, and packet type. During quick message bursts, two distinct packets could share those fields and the later packet would be treated as a duplicate.

Private chat delivery also mixed full Noise public keys and short peer IDs across routing, handshakes, queued outbox messages, read receipts, delivery ACKs, and reachability checks. That made some paths fail to find the established session or reachable transport even though the peer was present.

## Details

- Uses payload-aware packet IDs for BLE deduplication and self-broadcast tracking.
- Normalizes Noise session operations and queued private payloads to the short peer ID.
- Preserves the original full destination ID when flushing queued messages, while using a canonical short-ID outbox key.
- Accepts inbound private packets addressed to either the local short peer ID or the local full Noise static public key.
- Extends Nostr reachability checks to match full and short peer IDs.
- Adds regression tests for burst packet deduplication, local recipient addressing, and full/short private-message routing.

## Validation

- `git diff --check`
- `xcodebuild test -project bitchat.xcodeproj -scheme "bitchat (iOS)" -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/bitchat-pr-final-ios-test-derived -parallel-testing-enabled NO`  
  Passed: 526 tests in 76 suites.
- `xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath /tmp/bitchat-reliability-pr-derived -allowProvisioningUpdates build`
- Manual two-device mesh/private chat testing with an installed debug build.