### PR TITLE
Fix Cashu long-message guard bypass

### DIFF
--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -255,9 +255,8 @@ final class MessageFormattingEngine {
         isSelf: Bool,
         isMentioned: Bool
     ) -> AttributedString {
-        // For very long content without special tokens, use plain formatting
-        let containsCashu = containsCashuToken(content)
-        if (content.count > 4000 || content.hasVeryLongToken(threshold: 1024)) && !containsCashu {
+        // For very long content, use plain formatting to avoid expensive regex and detector work.
+        if content.isOversizedForRichFormatting() {
             return formatPlainContent(content, baseColor: baseColor, isSelf: isSelf)
         }
 

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -70,12 +70,7 @@ final class ChatMessageFormatter {
             let content = message.content
             let nsContent = content as NSString
             let nsLen = nsContent.length
-            let containsCashuEarly: Bool = {
-                let regex = Patterns.quickCashuPresence
-                return regex.numberOfMatches(in: content, options: [], range: NSRange(location: 0, length: nsLen)) > 0
-            }()
-
-            if (content.count > 4000 || content.hasVeryLongToken(threshold: 1024)) && !containsCashuEarly {
+            if content.isOversizedForRichFormatting() {
                 var plainStyle = AttributeContainer()
                 plainStyle.foregroundColor = baseColor
                 plainStyle.font = isSelf

--- a/bitchat/Views/Components/TextMessageView.swift
+++ b/bitchat/Views/Components/TextMessageView.swift
@@ -22,7 +22,7 @@ struct TextMessageView: View {
             let cashuLinks = message.content.extractCashuLinks()
             let lightningLinks = message.content.extractLightningLinks()
             HStack(alignment: .top, spacing: 0) {
-                let isLong = (message.content.count > TransportConfig.uiLongMessageLengthThreshold || message.content.hasVeryLongToken(threshold: TransportConfig.uiVeryLongTokenThreshold)) && cashuLinks.isEmpty
+                let isLong = message.content.isLongForDisplay()
                 let isExpanded = expandedMessageIDs.contains(message.id)
                 Text(conversationUIModel.formatMessage(message, colorScheme: colorScheme))
                     .fixedSize(horizontal: false, vertical: true)
@@ -38,7 +38,7 @@ struct TextMessageView: View {
             }
             
             // Expand/Collapse for very long messages
-            if (message.content.count > TransportConfig.uiLongMessageLengthThreshold || message.content.hasVeryLongToken(threshold: TransportConfig.uiVeryLongTokenThreshold)) && cashuLinks.isEmpty {
+            if message.content.isLongForDisplay() {
                 let isExpanded = expandedMessageIDs.contains(message.id)
                 let labelKey = isExpanded ? LocalizedStringKey("content.message.show_less") : LocalizedStringKey("content.message.show_more")
                 Button(labelKey) {

--- a/bitchat/Views/MessageTextHelpers.swift
+++ b/bitchat/Views/MessageTextHelpers.swift
@@ -21,6 +21,19 @@ extension String {
         return current >= threshold
     }
 
+    // Detect if message content should be collapsed to avoid expensive unbounded layout.
+    func isLongForDisplay(
+        lengthThreshold: Int = TransportConfig.uiLongMessageLengthThreshold,
+        tokenThreshold: Int = TransportConfig.uiVeryLongTokenThreshold
+    ) -> Bool {
+        count > lengthThreshold || hasVeryLongToken(threshold: tokenThreshold)
+    }
+
+    // Detect if message content should use plain formatting to avoid expensive regex parsing.
+    func isOversizedForRichFormatting(lengthThreshold: Int = 4000, tokenThreshold: Int = 1024) -> Bool {
+        count > lengthThreshold || hasVeryLongToken(threshold: tokenThreshold)
+    }
+
     // Extract up to `max` Cashu tokens (cashuA/cashuB). Allow dot '.' and shorter lengths.
     func extractCashuLinks(max: Int = 3) -> [String] {
         let regex = MessageFormattingEngine.Patterns.cashu

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -606,6 +606,25 @@ struct ChatViewModelFormattingTests {
 
         #expect(String(header.characters) == "<@Alice#a1b2> ")
     }
+
+    @Test @MainActor
+    func formatMessageAsText_longCashuMessageUsesPlainFastPath() async {
+        let (viewModel, _) = makeTestableViewModel()
+        let cashu = "cashuA" + String(repeating: "a", count: 40)
+        let longContent = "hi @bob " + cashu + " " + String(repeating: "x", count: 4_100)
+        let message = BitchatMessage(
+            id: "fmt-long-cashu",
+            sender: "Alice#a1b2",
+            content: longContent,
+            timestamp: Date(timeIntervalSince1970: 1_700_010_123),
+            isRelay: false,
+            senderPeerID: PeerID(str: "00000000000000b3")
+        )
+
+        let formatted = viewModel.formatMessageAsText(message, colorScheme: .light)
+
+        #expect(String(formatted.characters) == "<@Alice#a1b2> \(longContent) [\(message.formattedTimestamp)]")
+    }
 }
 
 // MARK: - Verification Tests

--- a/bitchatTests/MessageFormattingEngineTests.swift
+++ b/bitchatTests/MessageFormattingEngineTests.swift
@@ -323,6 +323,32 @@ struct MessageFormattingEngineTests {
         // Exactly at threshold DOES trigger (uses >= comparison)
         #expect(content.hasVeryLongToken(threshold: 50))
     }
+
+    @Test func isLongForDisplay_doesNotIgnoreCashuLinks() {
+        let cashu = "cashuA" + String(repeating: "a", count: 40)
+        let content = String(repeating: "a", count: TransportConfig.uiLongMessageLengthThreshold + 1) + " " + cashu
+
+        #expect(content.extractCashuLinks().count == 1)
+        #expect(content.isLongForDisplay())
+    }
+
+    @MainActor
+    @Test func formatMessage_longCashuMessageFallsBackToPlainContentPath() {
+        let context = MockMessageFormattingContext(nickname: "carol")
+        let cashu = "cashuA" + String(repeating: "a", count: 40)
+        let longContent = "hi @bob " + cashu + " " + String(repeating: "x", count: 4_100)
+        let message = BitchatMessage(
+            id: "long-cashu",
+            sender: "alice",
+            content: longContent,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_999),
+            isRelay: false
+        )
+
+        let formatted = MessageFormattingEngine.formatMessage(message, context: context, colorScheme: .light)
+
+        #expect(String(formatted.characters) == "<@alice> \(longContent) [\(message.formattedTimestamp)]")
+    }
 }
 
 @MainActor


### PR DESCRIPTION
### Motivation
- Cashu-looking substrings were exempting messages from both the UI collapse (lineLimit / Show more) and the plain-text fast-path formatter, enabling remote oversized messages to trigger expensive regex/detector work and unbounded layout (DoS vector).
- The intent is to restore size-based protections so untrusted content cannot disable long-message mitigation by embedding a Cashu-like token.

### Description
- Add shared heuristics in `MessageTextHelpers.swift`: `isLongForDisplay(...)` and `isOversizedForRichFormatting(...)` to centralize length/very-long-token checks and avoid consulting Cashu detection when deciding UI collapse or plain formatting.
- Update the message cell view in `TextMessageView.swift` to use `isLongForDisplay()` for collapse/Show more behavior so Cashu tokens do not disable the UI line-limit.
- Remove the Cashu exception from rich-text fast-paths in `ChatMessageFormatter.swift` and `MessageFormattingEngine.swift` so oversized messages always use the plain formatting path to avoid heavy regex/NSDataDetector work.
- Add regression tests in `MessageFormattingEngineTests.swift` and `ChatViewModelTests.swift` to assert long Cashu-containing messages are detected as long and take the plain formatting path.

### Testing
- Ran `git diff --check` to validate workspace changes (no whitespace errors) which passed.
- Added unit tests and attempted `swift test --filter MessageFormattingEngineTests`, but the test run could not complete in this Linux environment because a local package (`localPackages/Arti`) uses Apple-platform APIs (`@Published`/`ObservableObject`, `URLSession`/FoundationNetworking) that are unavailable or not imported here, causing the build to fail; the new tests verify the regression when run in an appropriate Apple/Xcode environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efd2d9ac08331b8f5ce70f4ce6746)