### PR TITLE
Fix unbounded public rate limit buckets

### DIFF
--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -56,6 +56,9 @@ enum TransportConfig {
     static let uiSenderRateBucketRefillPerSec: Double = 1.0
     static let uiContentRateBucketCapacity: Double = 3
     static let uiContentRateBucketRefillPerSec: Double = 0.5
+    static let uiSenderRateBucketMaxEntries: Int = 2000
+    static let uiContentRateBucketMaxEntries: Int = 2000
+    static let uiRateBucketIdleTTL: TimeInterval = 10 * 60
 
     // UI sleeps/delays
     static let uiStartupInitialDelaySeconds: TimeInterval = 1.0

--- a/bitchat/ViewModels/MessageRateLimiter.swift
+++ b/bitchat/ViewModels/MessageRateLimiter.swift
@@ -26,6 +26,10 @@ struct MessageRateLimiter {
             }
             return false
         }
+
+        func isIdle(since now: Date, idleTTL: TimeInterval) -> Bool {
+            now.timeIntervalSince(lastRefill) >= idleTTL
+        }
     }
 
     private var senderBuckets: [String: TokenBucket] = [:]
@@ -35,43 +39,93 @@ struct MessageRateLimiter {
     private let senderRefill: Double
     private let contentCapacity: Double
     private let contentRefill: Double
+    private let maxSenderBuckets: Int
+    private let maxContentBuckets: Int
+    private let bucketIdleTTL: TimeInterval
 
     init(
         senderCapacity: Double,
         senderRefillPerSec: Double,
         contentCapacity: Double,
-        contentRefillPerSec: Double
+        contentRefillPerSec: Double,
+        maxSenderBuckets: Int = TransportConfig.uiSenderRateBucketMaxEntries,
+        maxContentBuckets: Int = TransportConfig.uiContentRateBucketMaxEntries,
+        bucketIdleTTL: TimeInterval = TransportConfig.uiRateBucketIdleTTL
     ) {
         self.senderCapacity = senderCapacity
         self.senderRefill = senderRefillPerSec
         self.contentCapacity = contentCapacity
         self.contentRefill = contentRefillPerSec
+        self.maxSenderBuckets = max(1, maxSenderBuckets)
+        self.maxContentBuckets = max(1, maxContentBuckets)
+        self.bucketIdleTTL = bucketIdleTTL
     }
 
     mutating func allow(senderKey: String, contentKey: String, now: Date = Date()) -> Bool {
-        var senderBucket = senderBuckets[senderKey] ?? TokenBucket(
+        var senderBucket = bucket(
+            for: senderKey,
+            in: &senderBuckets,
             capacity: senderCapacity,
-            tokens: senderCapacity,
             refillPerSec: senderRefill,
-            lastRefill: now
+            maxBuckets: maxSenderBuckets,
+            now: now
         )
         let senderAllowed = senderBucket.allow(now: now)
         senderBuckets[senderKey] = senderBucket
+        guard senderAllowed else { return false }
 
-        var contentBucket = contentBuckets[contentKey] ?? TokenBucket(
+        var contentBucket = bucket(
+            for: contentKey,
+            in: &contentBuckets,
             capacity: contentCapacity,
-            tokens: contentCapacity,
             refillPerSec: contentRefill,
-            lastRefill: now
+            maxBuckets: maxContentBuckets,
+            now: now
         )
         let contentAllowed = contentBucket.allow(now: now)
         contentBuckets[contentKey] = contentBucket
 
-        return senderAllowed && contentAllowed
+        return contentAllowed
     }
 
     mutating func reset() {
         senderBuckets.removeAll()
         contentBuckets.removeAll()
+    }
+
+    var bucketCountsForTesting: (sender: Int, content: Int) {
+        (senderBuckets.count, contentBuckets.count)
+    }
+
+    private mutating func bucket(
+        for key: String,
+        in buckets: inout [String: TokenBucket],
+        capacity: Double,
+        refillPerSec: Double,
+        maxBuckets: Int,
+        now: Date
+    ) -> TokenBucket {
+        if let bucket = buckets[key] {
+            return bucket
+        }
+
+        evictIfNeeded(from: &buckets, maxBuckets: maxBuckets, now: now)
+        return TokenBucket(
+            capacity: capacity,
+            tokens: capacity,
+            refillPerSec: refillPerSec,
+            lastRefill: now
+        )
+    }
+
+    private func evictIfNeeded(from buckets: inout [String: TokenBucket], maxBuckets: Int, now: Date) {
+        guard buckets.count >= maxBuckets else { return }
+
+        buckets = buckets.filter { !$0.value.isIdle(since: now, idleTTL: bucketIdleTTL) }
+        guard buckets.count >= maxBuckets else { return }
+
+        if let oldestKey = buckets.min(by: { $0.value.lastRefill < $1.value.lastRefill })?.key {
+            buckets.removeValue(forKey: oldestKey)
+        }
     }
 }

--- a/bitchatTests/MessageRateLimiterTests.swift
+++ b/bitchatTests/MessageRateLimiterTests.swift
@@ -1,0 +1,56 @@
+//
+// MessageRateLimiterTests.swift
+// bitchatTests
+//
+// Ensures public-message rate limiter state remains bounded for attacker-derived keys.
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+struct MessageRateLimiterTests {
+    @Test("Content buckets do not grow when sender is rate limited")
+    func contentBucketsDoNotGrowAfterSenderLimit() {
+        var limiter = MessageRateLimiter(
+            senderCapacity: 1,
+            senderRefillPerSec: 0,
+            contentCapacity: 1,
+            contentRefillPerSec: 0,
+            maxSenderBuckets: 10,
+            maxContentBuckets: 10,
+            bucketIdleTTL: 60
+        )
+        let now = Date()
+
+        #expect(limiter.allow(senderKey: "sender", contentKey: "content-0", now: now))
+        for index in 1...100 {
+            #expect(!limiter.allow(senderKey: "sender", contentKey: "content-\(index)", now: now))
+        }
+
+        #expect(limiter.bucketCountsForTesting.sender == 1)
+        #expect(limiter.bucketCountsForTesting.content == 1)
+    }
+
+    @Test("Bucket maps evict entries at configured caps")
+    func bucketMapsEvictAtConfiguredCaps() {
+        let maxEntries = 3
+        var limiter = MessageRateLimiter(
+            senderCapacity: 1,
+            senderRefillPerSec: 0,
+            contentCapacity: 1,
+            contentRefillPerSec: 0,
+            maxSenderBuckets: maxEntries,
+            maxContentBuckets: maxEntries,
+            bucketIdleTTL: 60
+        )
+        let now = Date()
+
+        for index in 0..<25 {
+            #expect(limiter.allow(senderKey: "sender-\(index)", contentKey: "content-\(index)", now: now.addingTimeInterval(TimeInterval(index))))
+        }
+
+        #expect(limiter.bucketCountsForTesting.sender == maxEntries)
+        #expect(limiter.bucketCountsForTesting.content == maxEntries)
+    }
+}


### PR DESCRIPTION
### Motivation
- The public-message rate limiter stored sender- and content-token-bucket entries in unbounded dictionaries keyed by attacker-controlled values, allowing an attacker to force unbounded memory growth and DoS.  
- The intent of the change is to bound and evict rate-bucket state and avoid creating attacker-keyed content entries when the sender token bucket already rejects the message.

### Description
- Add configurable caps and idle TTLs to `TransportConfig` (`uiSenderRateBucketMaxEntries`, `uiContentRateBucketMaxEntries`, `uiRateBucketIdleTTL`).  
- Replace the previous plain maps with an improved `MessageRateLimiter` that enforces per-map caps, an idle TTL, and an eviction policy that first drops idle entries then the oldest entry when at capacity (changes in `bitchat/ViewModels/MessageRateLimiter.swift`).  
- Avoid creating/updating content buckets when the sender bucket already rejects the message to prevent a rate-limited sender from growing the content map.  
- Add regression tests exercising bounded growth and eviction behavior in `bitchatTests/MessageRateLimiterTests.swift`.

### Testing
- Ran `swiftc -typecheck bitchat/Services/TransportConfig.swift bitchat/ViewModels/MessageRateLimiter.swift` which succeeded.  
- Attempted `swift test --filter MessageRateLimiterTests`, but the test run failed in this Linux container due to platform-only dependencies in a local package (Apple-only `@Published`/Combine/`URLSession` surface in the `Arti` package), so the new tests are present but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efd9b68d483318f89df0d080b8c5e)