### PR TITLE
Fix CI app-suite deadlock: cooperative-pool-blocking thread-safety tests

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -41,6 +41,13 @@ jobs:
             ${{ runner.os }}-${{ matrix.name }}-${{ hashFiles(format('{0}/**/Package.resolved', matrix.path)) }}
             ${{ runner.os }}-${{ matrix.name }}-
 
+      - name: Build tests
+        # Built separately so the hang watchdog below times only test
+        # execution: a cold-cache coverage build on a slow runner can
+        # legitimately take several minutes, and is already bounded by the
+        # 15-minute job timeout.
+        run: swift build --build-tests --enable-code-coverage --package-path ${{ matrix.path }}
+
       - name: Run Tests
         # Perf benchmarks are excluded here and run in their own serial step
         # below: measuring while parallel test processes contend for cores
@@ -50,20 +57,21 @@ jobs:
         # baselines landed timed out at the 15-minute job limit with the
         # baseline tests dispatched into the parallel phase.
         #
-        # The watchdog samples any still-running test processes after 10
-        # minutes and kills the run, so a hang fails fast with stacks in the
-        # log instead of a silent timeout.
+        # The watchdog samples any still-running test processes after 5
+        # minutes (the suite passes in seconds when healthy; the build is
+        # done by this step) and kills the run, so a hang fails fast with
+        # stacks in the log instead of a silent timeout.
         env:
           BITCHAT_SKIP_PERF_BASELINES: "1"
         run: |
-          swift test --parallel --quiet --enable-code-coverage \
+          swift test --skip-build --parallel --quiet --enable-code-coverage \
             --skip PerformanceBaselineTests \
             --package-path ${{ matrix.path }} &
           test_pid=$!
           (
-            sleep 600
+            sleep 300
             if kill -0 "$test_pid" 2>/dev/null; then
-              echo "::group::Tests still running after 10 minutes — sampling before kill"
+              echo "::group::Tests still running after 5 minutes — sampling before kill"
               for pid in $(pgrep -if 'swiftpm-testing|xctest|PackageTests' || true); do
                 echo "--- sample of pid $pid ---"
                 sample "$pid" 5 2>/dev/null || true

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -45,10 +45,38 @@ jobs:
         # Perf benchmarks are excluded here and run in their own serial step
         # below: measuring while parallel test processes contend for cores
         # produces noisy numbers, and the XCTest measure machinery has hung
-        # intermittently under parallel workers on loaded runners.
+        # intermittently under parallel workers on loaded runners. Excluded
+        # via --skip (not just the env guard): every app run since the
+        # baselines landed timed out at the 15-minute job limit with the
+        # baseline tests dispatched into the parallel phase.
+        #
+        # The watchdog samples any still-running test processes after 10
+        # minutes and kills the run, so a hang fails fast with stacks in the
+        # log instead of a silent timeout.
         env:
           BITCHAT_SKIP_PERF_BASELINES: "1"
-        run: swift test --parallel --quiet --enable-code-coverage --package-path ${{ matrix.path }}
+        run: |
+          swift test --parallel --quiet --enable-code-coverage \
+            --skip PerformanceBaselineTests \
+            --package-path ${{ matrix.path }} &
+          test_pid=$!
+          (
+            sleep 600
+            if kill -0 "$test_pid" 2>/dev/null; then
+              echo "::group::Tests still running after 10 minutes — sampling before kill"
+              for pid in $(pgrep -if 'swiftpm-testing|xctest|PackageTests' || true); do
+                echo "--- sample of pid $pid ---"
+                sample "$pid" 5 2>/dev/null || true
+              done
+              echo "::endgroup::"
+              pkill -KILL -P "$test_pid" 2>/dev/null || true
+              kill -KILL "$test_pid" 2>/dev/null || true
+            fi
+          ) &
+          watchdog_pid=$!
+          wait "$test_pid" && status=0 || status=$?
+          kill "$watchdog_pid" 2>/dev/null || true
+          exit "$status"
 
       # Benchmarks run serially on an otherwise idle runner for stable
       # numbers; BITCHAT_PERF_LOG captures the PERF[...] lines for the gate.

--- a/bitchatTests/Services/NostrTransportTests.swift
+++ b/bitchatTests/Services/NostrTransportTests.swift
@@ -310,6 +310,15 @@ struct NostrTransportTests {
         withExtendedLifetime(transport) {}
     }
 
+    // These thread-safety tests must hammer from the dispatch pool
+    // (concurrentPerform), NOT a task group: transport calls block in
+    // queue.sync, and a 100-task group runs them on the Swift Concurrency
+    // cooperative pool — one thread per core, just 3 on CI runners. Parking
+    // every cooperative thread in a blocking sync violates the forward
+    // progress contract and wedged dispatch on the CI runners' macOS,
+    // deadlocking the whole app suite into the 15-minute job timeout
+    // (watchdog stacks: NostrTransport.isPeerReachable syncs holding all
+    // pool threads). Blocking is legal on dispatch worker threads.
     @Test("Concurrent read receipt enqueue does not crash")
     @MainActor
     func concurrentReadReceiptEnqueue() async throws {
@@ -318,9 +327,9 @@ struct NostrTransportTests {
         let transport = NostrTransport(keychain: keychain, idBridge: idBridge)
         let iterations = 100
 
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0..<iterations {
-                group.addTask {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                DispatchQueue.concurrentPerform(iterations: iterations) { i in
                     let receipt = ReadReceipt(
                         originalMessageID: UUID().uuidString,
                         readerID: PeerID(str: String(format: "%016x", i)),
@@ -329,8 +338,10 @@ struct NostrTransportTests {
                     let peerID = PeerID(str: String(format: "%016x", i))
                     transport.sendReadReceipt(receipt, to: peerID)
                 }
+                continuation.resume()
             }
         }
+        withExtendedLifetime(transport) {}
     }
 
     @Test("isPeerReachable is thread safe")
@@ -341,18 +352,16 @@ struct NostrTransportTests {
         let transport = NostrTransport(keychain: keychain, idBridge: idBridge)
         let iterations = 100
 
-        await withTaskGroup(of: Bool.self) { group in
-            for i in 0..<iterations {
-                group.addTask {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                DispatchQueue.concurrentPerform(iterations: iterations) { i in
                     let peerID = PeerID(str: String(format: "%016x", i))
-                    return transport.isPeerReachable(peerID)
+                    #expect(transport.isPeerReachable(peerID) == false)
                 }
-            }
-
-            for await result in group {
-                #expect(result == false)
+                continuation.resume()
             }
         }
+        withExtendedLifetime(transport) {}
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Main's Build & Test workflow has been red since #1335 landed: **seven consecutive runs timed out at the 15-minute job limit** (main and PR branches alike). This PR adds a hang watchdog that samples stuck test processes, and the watchdog's own first two runs captured the root cause with identical stacks both times.

## Root cause (from watchdog stack samples)

`NostrTransportTests.isPeerReachableThreadSafety` / `concurrentReadReceiptEnqueue` (added with the #1335 batch) spawn 100-task groups where **every task makes a blocking `queue.sync` call**. Swift Testing runs tasks on the Swift Concurrency cooperative pool — one thread per core: **3 on CI runners, 10+ on dev machines** (which is exactly why this never reproduced locally). The sample shows precisely pool-width task threads parked forever in `__DISPATCH_WAIT_FOR_QUEUE__`:

```
Thread_14445: NostrTransport.isPeerReachable → queue.sync → __ulock_wait   (full sample window)
Thread_14446: BLEServiceCoreTests.panicReset → resetIdentityForPanic →
              clearEphemeralStateForPanic → serviceQueue.sync(barrier) → __ulock_wait
Thread_14447: NostrTransport.isPeerReachable → queue.sync → __ulock_wait
(all dispatch workers idle, main thread idle)
```

Parking the entire cooperative pool in blocking syncs violates Swift Concurrency's forward-progress contract; the runners' macOS 15.7 dispatch wedges under the resulting `asyncAndWait` flood and never schedules the queues' pending items — deadlocking innocent concurrent tests too (the panic-reset barrier above is collateral).

## Changes

- **Rewrite the two thread-safety tests** to hammer via `DispatchQueue.concurrentPerform` from a single global-queue hop: identical 100-way concurrency coverage, executed on dispatch worker threads where blocking is legal, zero cooperative threads parked.
- **Test-hang watchdog**: tests build in their own step; the run step wraps `swift test --skip-build` with a 5-minute watchdog that `sample`s still-running test processes (full thread stacks into the log) before killing — so any future hang fails fast and self-diagnoses instead of silently eating the 15-minute timeout. This is the tool that produced the stacks above.
- **`--skip PerformanceBaselineTests`** on the parallel phase as belt-and-braces alongside the env guard (the baselines run and gate in their dedicated serial step). Keeps the measure machinery — the other known hang risk — out of parallel workers at the SPM level.

## Testing

- Full suite green locally (954 parallel + baselines separately)
- The PR's own CI run validates the fix end-to-end on the affected runner environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)