### PR TITLE
Raise positive waitUntil timeouts to 5s for loaded CI runners

### DIFF
--- a/bitchatTests/ChatViewModelExtensionsTests.swift
+++ b/bitchatTests/ChatViewModelExtensionsTests.swift
@@ -469,7 +469,7 @@ struct ChatViewModelNostrExtensionTests {
 
         let didUpdate = await TestHelpers.waitUntil(
             { isDelivered(status: deliveryStatus(in: viewModel, peerID: convKey, messageID: messageID)) },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didUpdate)
     }
@@ -507,7 +507,7 @@ struct ChatViewModelNostrExtensionTests {
 
         let didUpdate = await TestHelpers.waitUntil(
             { isRead(status: deliveryStatus(in: viewModel, peerID: convKey, messageID: messageID)) },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didUpdate)
     }
@@ -535,7 +535,7 @@ struct ChatViewModelNostrExtensionTests {
 
         let didStore = await TestHelpers.waitUntil(
             { viewModel.privateChats[convKey]?.first?.content == "Hello from gift wrap" },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didStore)
         #expect(viewModel.nostrKeyMapping[convKey] == sender.publicKeyHex)
@@ -603,7 +603,7 @@ struct ChatViewModelNostrExtensionTests {
 
         let didUpdate = await TestHelpers.waitUntil(
             { isDelivered(status: deliveryStatus(in: viewModel, peerID: convKey, messageID: messageID)) },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didUpdate)
     }
@@ -1000,7 +1000,7 @@ struct ChatViewModelMediaTransferTests {
         viewModel.selectedPrivateChatPeer = peerID
         viewModel.sendVoiceNote(at: url)
 
-        let didSend = await TestHelpers.waitUntil({ transport.sentPrivateFiles.count == 1 }, timeout: 0.5)
+        let didSend = await TestHelpers.waitUntil({ transport.sentPrivateFiles.count == 1 }, timeout: 5.0)
         #expect(didSend)
         #expect(transport.sentPrivateFiles.first?.peerID == peerID)
         #expect(viewModel.privateChats[peerID]?.last?.content.contains("[voice]") == true)
@@ -1020,7 +1020,7 @@ struct ChatViewModelMediaTransferTests {
 
         let didFail = await TestHelpers.waitUntil({
             isFailed(status: viewModel.privateChats[peerID]?.last?.deliveryStatus)
-        }, timeout: 0.5)
+        }, timeout: 5.0)
         #expect(didFail)
         #expect(!FileManager.default.fileExists(atPath: url.path))
         #expect(transport.sentPrivateFiles.isEmpty)

--- a/bitchatTests/Noise/NoiseCoverageTests.swift
+++ b/bitchatTests/Noise/NoiseCoverageTests.swift
@@ -542,7 +542,7 @@ struct NoiseCoverageTests {
 
         let didEstablish = await TestHelpers.waitUntil(
             { establishedRecorder.establishedCount == 2 },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didEstablish)
         #expect(establishedRecorder.establishedPeerIDs.contains(alicePeerID))
@@ -561,7 +561,7 @@ struct NoiseCoverageTests {
 
         let didFail = await TestHelpers.waitUntil(
             { failureRecorder.failureCount == 1 },
-            timeout: 0.5
+            timeout: 5.0
         )
         #expect(didFail)
         #expect(failingManager.getSession(for: charliePeerID) == nil)

--- a/bitchatTests/Services/NoiseEncryptionServiceTests.swift
+++ b/bitchatTests/Services/NoiseEncryptionServiceTests.swift
@@ -101,7 +101,7 @@ struct NoiseEncryptionServiceTests {
 
         try establishSessions(alice: alice, bob: bob, alicePeerID: alicePeerID, bobPeerID: bobPeerID)
 
-        let authenticated = await TestHelpers.waitUntil({ recorder.count >= 2 }, timeout: 0.5)
+        let authenticated = await TestHelpers.waitUntil({ recorder.count >= 2 }, timeout: 5.0)
         #expect(authenticated)
         #expect(alice.hasEstablishedSession(with: alicePeerID))
         #expect(bob.hasEstablishedSession(with: bobPeerID))

--- a/bitchatTests/Services/NostrTransportTests.swift
+++ b/bitchatTests/Services/NostrTransportTests.swift
@@ -79,7 +79,7 @@ struct NostrTransportTests {
         )
         notificationCenter.post(name: .favoriteStatusChanged, object: nil)
 
-        let didRefresh = await TestHelpers.waitUntil({ transport.isPeerReachable(peerID) }, timeout: 0.5)
+        let didRefresh = await TestHelpers.waitUntil({ transport.isPeerReachable(peerID) }, timeout: 5.0)
         #expect(didRefresh)
     }
 
@@ -116,7 +116,7 @@ struct NostrTransportTests {
 
         transport.sendPrivateMessage("hello over nostr", to: shortPeerID, recipientNickname: "Carol", messageID: "pm-1")
 
-        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 0.5)
+        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 5.0)
         #expect(didSend)
         let result = try decodeEmbeddedPayload(from: probe.sentEvents[0], recipient: recipient)
         let privateMessage = try decodePrivateMessage(from: result.payload)
@@ -161,7 +161,7 @@ struct NostrTransportTests {
 
         transport.sendFavoriteNotification(to: fullPeerID, isFavorite: true)
 
-        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 0.5)
+        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 5.0)
         #expect(didSend)
         let result = try decodeEmbeddedPayload(from: probe.sentEvents[0], recipient: recipient)
         let privateMessage = try decodePrivateMessage(from: result.payload)
@@ -202,7 +202,7 @@ struct NostrTransportTests {
 
         transport.sendDeliveryAck(for: "ack-1", to: fullPeerID)
 
-        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 0.5)
+        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 5.0)
         #expect(didSend)
         let result = try decodeEmbeddedPayload(from: probe.sentEvents[0], recipient: recipient)
 
@@ -240,7 +240,7 @@ struct NostrTransportTests {
             messageID: "geo-1"
         )
 
-        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 0.5)
+        let didSend = await TestHelpers.waitUntil({ probe.sentEvents.count == 1 }, timeout: 5.0)
         #expect(didSend)
         let event = probe.sentEvents[0]
         let result = try decodeEmbeddedPayload(from: event, recipient: recipient)

--- a/bitchatTests/Services/TransferProgressManagerTests.swift
+++ b/bitchatTests/Services/TransferProgressManagerTests.swift
@@ -24,7 +24,7 @@ struct TransferProgressManagerTests {
 
         let didReceive = await TestHelpers.waitUntil({
             recorder.values == ["started:\(transferID):3"]
-        }, timeout: 0.5)
+        }, timeout: 5.0)
         #expect(didReceive)
 
         #expect(recorder.values == ["started:\(transferID):3"])
@@ -59,7 +59,7 @@ struct TransferProgressManagerTests {
 
         let didReceive = await TestHelpers.waitUntil({
             recorder.values.count == 3
-        }, timeout: 0.5)
+        }, timeout: 5.0)
         #expect(didReceive)
 
         #expect(recorder.values == [
@@ -97,7 +97,7 @@ struct TransferProgressManagerTests {
         let didReceive = await TestHelpers.waitUntil({
             recorder.values.contains("started:\(transferID):4") &&
             recorder.values.contains("cancelled:\(transferID):1:4")
-        }, timeout: 0.5)
+        }, timeout: 5.0)
         #expect(didReceive)
 
         #expect(recorder.values.contains("started:\(transferID):4"))


### PR DESCRIPTION
## Summary

First real CI execution of the resurrected Noise coverage tests (post-#1339, which fixed the suite-wide hang) surfaced a latent flake: `Session manager callbacks establish and failed handshakes clean up state` failed on the #1338 branch run because `onSessionEstablished` is delivered via `DispatchQueue.global().async` and the test only waited **0.5s** — fine locally, too tight on a loaded CI runner running parallel workers.

## Change

Raise every *positive* `waitUntil` timeout from 0.5s → 5s (= `TestConstants.defaultTimeout`) across the suites polling for async callbacks (`NoiseCoverageTests`, `NoiseEncryptionServiceTests`, `NostrTransportTests`, `TransferProgressManagerTests`, `ChatViewModelExtensionsTests`). `waitUntil` polls every 10ms and returns the moment the condition holds, so passing runs are unaffected — only genuine failures wait longer.

The two **negative** waits in `BLEServiceCoreTests` ("expect nothing arrives in the window") deliberately keep their short 0.3s windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)