### PR TITLE
Fix slash-command suggestions that insert commands the processor rejects

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -14707,6 +14707,18 @@
         }
       }
     },
+    "content.commands.help" : {
+      "comment" : "Description of the /help command in the suggestions panel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "show available commands"
+          }
+        }
+      }
+    },
     "content.commands.hug" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/bitchat/Models/CommandInfo.swift
+++ b/bitchat/Models/CommandInfo.swift
@@ -11,33 +11,38 @@ import Foundation
 // MARK: - CommandInfo Enum
 
 enum CommandInfo: String, Identifiable {
+    // Raw values must match the aliases CommandProcessor actually accepts —
+    // the suggestion panel is the app's only command-discovery surface, and
+    // suggesting a spelling the processor rejects teaches users dead ends.
     case block
     case clear
+    case help
     case hug
-    case message = "dm"
+    case message = "msg"
     case slap
     case unblock
     case who
-    case favorite
-    case unfavorite
-    
+    case favorite = "fav"
+    case unfavorite = "unfav"
+
     var id: String { rawValue }
-    
+
     var alias: String { "/" + rawValue }
-    
+
     var placeholder: String? {
         switch self {
         case .block, .hug, .message, .slap, .unblock, .favorite, .unfavorite:
             return "<" + String(localized: "content.input.nickname_placeholder") + ">"
-        case .clear, .who:
+        case .clear, .help, .who:
             return nil
         }
     }
-    
+
     var description: String {
         switch self {
         case .block:        String(localized: "content.commands.block")
         case .clear:        String(localized: "content.commands.clear")
+        case .help:         String(localized: "content.commands.help")
         case .hug:          String(localized: "content.commands.hug")
         case .message:      String(localized: "content.commands.message")
         case .slap:         String(localized: "content.commands.slap")
@@ -47,12 +52,14 @@ enum CommandInfo: String, Identifiable {
         case .unfavorite:   String(localized: "content.commands.unfavorite")
         }
     }
-    
+
     static func all(isGeoPublic: Bool, isGeoDM: Bool) -> [CommandInfo] {
-        let baseCommands: [CommandInfo] = [.block, .unblock, .clear, .hug, .message, .slap, .who]
+        let baseCommands: [CommandInfo] = [.block, .unblock, .clear, .help, .hug, .message, .slap, .who]
+        // The processor rejects favorites in geohash contexts, so only
+        // suggest them where they actually work: mesh.
         if isGeoPublic || isGeoDM {
-            return baseCommands + [.favorite, .unfavorite]
+            return baseCommands
         }
-        return baseCommands
+        return baseCommands + [.favorite, .unfavorite]
     }
 }

--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -105,10 +105,27 @@ final class CommandProcessor {
         case "/unfav":
             if inGeoPublic || inGeoDM { return .error(message: "favorites are only for mesh peers in #mesh") }
             return handleFavorite(args, add: false)
+        case "/help":
+            return .success(message: Self.helpText)
         default:
-            return .error(message: "unknown command: \(cmd)")
+            return .error(message: "unknown command: \(cmd) — type /help for commands")
         }
     }
+
+    /// Local-only command reference, printed as a system message. The
+    /// suggestion panel hides once arguments are typed, and typos used to
+    /// dead-end in a bare "unknown command" — this is the way out.
+    static let helpText = """
+    commands:
+    /msg @name [message] — start a private chat
+    /who — list who's here
+    /clear — clear this chat
+    /hug @name — send a hug
+    /slap @name — slap with a large trout
+    /block @name · /unblock @name
+    /fav @name · /unfav @name — favorites (mesh only)
+    /help — this list
+    """
 
     // MARK: - Command Handlers
     

--- a/bitchat/Views/Components/CommandSuggestionsView.swift
+++ b/bitchat/Views/Components/CommandSuggestionsView.swift
@@ -14,23 +14,41 @@ struct CommandSuggestionsView: View {
 
     @Binding var messageText: String
 
+    /// The command already typed in full, once arguments have begun.
+    private var typedCommandAlias: String? {
+        guard messageText.hasPrefix("/"),
+              let spaceIndex = messageText.firstIndex(of: " ")
+        else { return nil }
+        return String(messageText[..<spaceIndex]).lowercased()
+    }
+
     private var filteredCommands: [CommandInfo] {
-        guard messageText.hasPrefix("/") && !messageText.contains(" ") else { return [] }
+        guard messageText.hasPrefix("/") else { return [] }
         let isGeoPublic = locationChannelsModel.selectedChannel.isLocation
         let isGeoDM = privateConversationModel.selectedPeerID?.isGeoDM == true
-        return CommandInfo.all(isGeoPublic: isGeoPublic, isGeoDM: isGeoDM).filter { command in
+        let commands = CommandInfo.all(isGeoPublic: isGeoPublic, isGeoDM: isGeoDM)
+        // While arguments are being typed, keep the matched command's usage
+        // row visible instead of vanishing at the first space.
+        if let typed = typedCommandAlias {
+            return commands.filter { $0.alias == typed && $0.placeholder != nil }
+        }
+        return commands.filter { command in
             command.alias.starts(with: messageText.lowercased())
         }
     }
-    
+
     var body: some View {
         // Render nothing when there are no matches: a zero-height view would
         // still receive the composer VStack's spacing and push the input row
         // off-center.
         if !filteredCommands.isEmpty {
+            let isUsageReminder = typedCommandAlias != nil
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(filteredCommands) { command in
                     Button {
+                        // In usage-reminder mode the row is informational; an
+                        // insert here would wipe the arguments being typed.
+                        guard !isUsageReminder else { return }
                         messageText = command.alias + " "
                     } label: {
                         buttonRow(for: command)

--- a/bitchatTests/ProtocolContractTests.swift
+++ b/bitchatTests/ProtocolContractTests.swift
@@ -50,14 +50,19 @@ private final class DefaultTransportProbe: Transport {
 struct ProtocolContractTests {
     @Test
     func commandInfo_exposesAliasesPlaceholdersAndGeoVariants() {
-        #expect(CommandInfo.message.id == "dm")
-        #expect(CommandInfo.message.alias == "/dm")
+        // Aliases must match what CommandProcessor actually accepts —
+        // the suggestion panel is the only command-discovery surface.
+        #expect(CommandInfo.message.id == "msg")
+        #expect(CommandInfo.message.alias == "/msg")
         #expect(CommandInfo.message.placeholder != nil)
         #expect(CommandInfo.clear.placeholder == nil)
         #expect(CommandInfo.favorite.description.isEmpty == false)
-        #expect(CommandInfo.all(isGeoPublic: false, isGeoDM: false).contains(.favorite) == false)
-        #expect(CommandInfo.all(isGeoPublic: true, isGeoDM: false).contains(.favorite))
-        #expect(CommandInfo.all(isGeoPublic: false, isGeoDM: true).contains(.unfavorite))
+        #expect(CommandInfo.all(isGeoPublic: false, isGeoDM: false).contains(.help))
+        // Favorites are rejected by the processor in geohash contexts, so
+        // they are suggested only in mesh.
+        #expect(CommandInfo.all(isGeoPublic: false, isGeoDM: false).contains(.favorite))
+        #expect(CommandInfo.all(isGeoPublic: true, isGeoDM: false).contains(.favorite) == false)
+        #expect(CommandInfo.all(isGeoPublic: false, isGeoDM: true).contains(.unfavorite) == false)
     }
 
     @Test


### PR DESCRIPTION
### Problem

The autocomplete panel is the only in-app surface for discovering slash commands, but several of its suggestions don't match what `CommandProcessor` accepts — so tapping one inserts a command that immediately returns `unknown command`:

- `CommandInfo` suggests `/dm`, `/favorite`, `/unfavorite`, but for those the processor accepts only `/m`|`/msg` and `/fav`|`/unfav`.
- Favorites are suggested only in geohash contexts (`isGeoPublic || isGeoDM`) — which is exactly where the processor rejects them (*"favorites are only for mesh peers in #mesh"*).

So the app's own suggestions teach commands it will refuse.

### Change

- Align `CommandInfo` aliases to the accepted spellings (`msg`, `fav`, `unfav`).
- Invert the favorite gating so `/fav` / `/unfav` are suggested in **mesh**, where they work.
- Add a `/help` command: it prints a local, multi-line system message listing the valid commands, and the `unknown command` error now points at it.
- For commands that take an argument, keep the usage row (e.g. `/msg <nickname>`) visible while arguments are typed instead of vanishing at the first space; in that mode the row is informational and no longer overwrites the draft on tap.

### Scope

- No protocol or transport change. The only command-execution change is the new local-only `/help` command and the reworded unknown-command error in `CommandProcessor`.
- The `/help` body text and the reworded unknown-command error are hardcoded English, matching the existing (unlocalized) `CommandProcessor` messages. The new panel-description string (`content.commands.help`) is added in `en` only — unlike the other `content.commands.*` descriptions it isn't yet translated, so the `/help` row shows English in non-English locales until translations are supplied.
- The `CommandInfo` contract test is updated to the corrected metadata.
