### PR TITLE
Add SwiftLint as an advisory CI-only lint job (no Xcode plugin dependency)

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -153,10 +153,19 @@ jobs:
     name: SwiftLint (advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # This job runs a third-party container image, so give it the least
+    # privilege we can: a read-only token, and no credentials left in the
+    # checkout for the container to find.
+    permissions:
+      contents: read
     container:
-      image: ghcr.io/realm/swiftlint:0.65.0   # pinned tag; bump deliberately, never a floating tag
+      # Tag for readability, digest for immutability (tags can be repointed).
+      # Bump both together, deliberately — never a floating tag.
+      image: ghcr.io/realm/swiftlint:0.65.0@sha256:a482729f4b58741875af1566f23397f3f6db300372756fc31606d0a4527fab9e
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run SwiftLint
         run: swiftlint lint --reporter github-actions-logging

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -145,3 +145,18 @@ jobs:
             ARCHS=arm64 \
             CODE_SIGNING_ALLOWED=NO \
             build
+
+  # Advisory only: SwiftLint reports style violations without ever failing the
+  # build. Runs in a pinned container (no Xcode plugin, no pbxproj changes) so
+  # it can never break the documented xcodebuild path or block a merge.
+  lint:
+    name: SwiftLint (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/realm/swiftlint:0.65.0   # pinned tag; bump deliberately, never a floating tag
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run SwiftLint
+        run: swiftlint lint --reporter github-actions-logging

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,23 @@
+disabled_rules:
+  - line_length
+  - type_name
+  - identifier_name
+  - statement_position
+  - implicit_optional_initialization
+  - force_try
+  - vertical_whitespace
+  - for_where
+  - control_statement
+  - void_function_in_ternary
+  - redundant_discardable_let  # SwiftUI breaks without it
+  # To be enabled as we fix the issues
+  - trailing_whitespace
+  - cyclomatic_complexity
+  - function_body_length
+  - function_parameter_count
+  - type_body_length
+  - file_length
+  - large_tuple
+  - force_cast
+  - multiple_closures_with_trailing_closure
+  - nesting

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,13 @@
+# Build artifacts and generated sources; keeps local `swiftlint` runs clean
+# (CI checkouts are fresh, so this only matters in a working tree).
+excluded:
+  - .build
+  - .swiftpm
+  - .DerivedData
+  - DerivedData
+  - build
+  - localPackages/*/.build
+
 disabled_rules:
   - line_length
   - type_name


### PR DESCRIPTION
### What

Adds SwiftLint to CI as an **advisory, informational-only** job — never a build breaker, never a merge gate:

- New `.swiftlint.yml` at the repo root (curated disabled-rule list).
- One new `lint` job in `.github/workflows/swift-tests.yml` that runs `swiftlint lint` in a **pinned** container (`ghcr.io/realm/swiftlint:0.65.0`) with `continue-on-error: true`.

No Xcode Build Tool Plugin. No changes to `bitchat.xcodeproj/project.pbxproj`. No `.swift` files touched. This cannot break any `xcodebuild`/`swift build` path and cannot block a merge — it only surfaces style violations in the Actions log.

### Why this shape

An earlier attempt (#1086) wired SwiftLint in as an Xcode Build Tool Plugin. As @jackjackbits noted on that PR, plugin wiring breaks the documented `xcodebuild` flow unless every invocation passes `-skipPackagePluginValidation`, and he pushed a CI-safe counter-approach on the branch `codex/swiftlint-ci-safe-followup` ("Keep SwiftLint in CI without Xcode plugin dependency") that was never opened as a PR and has since gone stale against `main`.

This PR **finishes that CI-safe approach against current `main`**: a standalone container-based lint job, zero project-file surface, so the linter is purely observational. The image tag is pinned (not `:latest`) so results are reproducible and version bumps are deliberate.

### Prior art & credit

- #1086 (@qalandarov) — original SwiftLint initiative and the disabled-rule curation this config builds on.
- #1087 (@qalandarov) — rule-set / whitespace cleanup on the `swiftlint` branch.
- The shipped `.swiftlint.yml` is @jackjackbits' variant from `codex/swiftlint-ci-safe-followup` (not @qalandarov's byte-exact text), so credit here is prose rather than `Co-authored-by:`.
- #1088 remains the open tracker for the disabled-rule backlog; the `# To be enabled as we fix the issues` block in `.swiftlint.yml` stays as the on-ramp for that work.

### Current violations on `main` (measured with SwiftLint 0.65.0, the pinned version)

The advisory job reports **109** violations today across the enabled rules — none large enough to warrant disabling:

| Rule | Count |
|---|---|
| non_optional_string_data_conversion | 45 |
| trailing_comma | 24 |
| comma | 7 |
| switch_case_alignment | 6 |
| todo | 5 |
| colon | 5 |
| redundant_string_enum_value | 4 |
| unused_optional_binding | 3 |
| trailing_newline | 3 |
| unused_closure_parameter | 2 |
| comment_spacing | 2 |
| unneeded_break_in_switch | 1 |
| static_over_final_class | 1 |
| opening_brace | 1 |

The heavier structural/style rules (function length, cyclomatic complexity, `trailing_whitespace`, etc.) stay disabled and tracked in #1088 so the advisory signal is honest rather than a flood.

---
This contribution was developed with AI assistance via [terminalhire](https://terminalhire.com). The author has reviewed the change and takes responsibility for its content.
