### PR TITLE
Route command output to the conversation where the command was typed

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1435,7 +1435,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
 
     /// Processes IRC-style commands starting with '/'.
     /// - Parameter command: The full command string including the leading slash
-    /// - Note: Supports commands like /nick, /msg, /who, /slap, /clear, /help
+    /// - Note: Supports commands like /msg, /who, /slap, /clear, /help
     @MainActor
     func handleCommand(_ command: String) {
         let result = commandProcessor.process(command)
@@ -1443,13 +1443,26 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         switch result {
         case .success(let message):
             if let msg = message {
-                addSystemMessage(msg)
+                addCommandOutput(msg)
             }
         case .error(let message):
-            addSystemMessage(message)
+            addCommandOutput(message)
         case .handled:
             // Command was handled, no message needed
             break
+        }
+    }
+
+    /// Command output belongs in the conversation where the user typed the
+    /// command; the public timeline is invisible while a DM is open. The DM
+    /// selection is read *after* processing so commands that switch chats
+    /// (`/msg`) print into the conversation they just opened.
+    @MainActor
+    private func addCommandOutput(_ content: String) {
+        if let peerID = selectedPrivateChatPeer {
+            addLocalPrivateSystemMessage(content, to: peerID)
+        } else {
+            addSystemMessage(content)
         }
     }
 

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -263,6 +263,59 @@ struct ChatViewModelCommandTests {
             #expect(transport.sentPrivateMessages.isEmpty)
         }
     }
+
+    @Test @MainActor
+    func handleCommand_outputRoutesToOpenPrivateChat() async {
+        let (viewModel, transport) = makeTestableViewModel()
+        let peerID = PeerID(str: "0000000000000002")
+        transport.simulateConnect(peerID, nickname: "Alice")
+        viewModel.selectedPrivateChatPeer = peerID
+
+        viewModel.handleCommand("/help")
+
+        #expect(viewModel.privateChats[peerID]?.last?.content == CommandProcessor.helpText)
+        #expect(!viewModel.messages.contains { $0.content == CommandProcessor.helpText })
+    }
+
+    @Test @MainActor
+    func handleCommand_errorRoutesToOpenPrivateChat() async {
+        let (viewModel, transport) = makeTestableViewModel()
+        let peerID = PeerID(str: "0000000000000002")
+        transport.simulateConnect(peerID, nickname: "Alice")
+        viewModel.selectedPrivateChatPeer = peerID
+
+        viewModel.handleCommand("/bogus")
+
+        let dmContents = viewModel.privateChats[peerID]?.map(\.content) ?? []
+        #expect(dmContents.contains { $0.hasPrefix("unknown command: /bogus") })
+        #expect(!viewModel.messages.contains { $0.content.hasPrefix("unknown command: /bogus") })
+    }
+
+    @Test @MainActor
+    func handleCommand_outputRoutesToPublicTimelineWithoutOpenDM() async {
+        let (viewModel, _) = makeTestableViewModel()
+
+        viewModel.handleCommand("/bogus")
+
+        #expect(viewModel.messages.last?.content.hasPrefix("unknown command: /bogus") == true)
+    }
+
+    @Test @MainActor
+    func handleCommand_msgSuccessLandsInNewlyOpenedChat() async {
+        let (viewModel, transport) = makeTestableViewModel()
+        let peerID = PeerID(str: "0000000000000002")
+        transport.simulateConnect(peerID, nickname: "Alice")
+        let resolved = await TestHelpers.waitUntil({
+            viewModel.getPeerIDForNickname("Alice") == peerID
+        }, timeout: TestConstants.defaultTimeout)
+        #expect(resolved)
+
+        viewModel.handleCommand("/msg Alice")
+
+        #expect(viewModel.selectedPrivateChatPeer == peerID)
+        #expect(viewModel.privateChats[peerID]?.last?.content == "started private chat with Alice")
+        #expect(!viewModel.messages.contains { $0.content == "started private chat with Alice" })
+    }
 }
 
 // MARK: - Composer Tests


### PR DESCRIPTION
### Problem

`ChatViewModel.handleCommand` appended every `CommandResult` message through `addSystemMessage`, which writes to the **public timeline** — regardless of where the command was typed. With a DM open, `/help` output, error messages ("unknown command", "'nickname' not found"), and `/msg` confirmations all landed in a timeline the user couldn't see, so commands appeared to do nothing. Flagged by Codex on #1354 (a real finding, though the routing predates that PR and affects all command output, not just the new `/help`).

### Change

- `handleCommand` routes `.success`/`.error` output through a new `addCommandOutput` helper: to the open private chat via the existing `addLocalPrivateSystemMessage` (local-only, no network send) when one is selected, otherwise to the public timeline as before.
- The DM selection is read **after** the processor runs, so commands that switch conversations (`/msg alice`) print their confirmation into the chat they just opened rather than the timeline the user left.
- `/clear` is unaffected: it returns `.handled` and already branches on the DM selection itself.

### Tests

Four new tests in `ChatViewModelCommandTests` cover: `/help` output and error output landing in the open DM (and not the public timeline), fallback to the public timeline with no DM open, and the `/msg` confirmation landing in the newly opened chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)