### PR TITLE
Courier: deposit in parallel when the only route is a send queue

### DIFF
--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -137,6 +137,10 @@ final class NostrRelayManager: ObservableObject {
     
     @Published private(set) var relays: [Relay] = []
     @Published private(set) var isConnected = false
+    /// Whether a relay that carries private messages is connected. DMs
+    /// target the default (gift-wrap-capable) relay set, so a connected
+    /// geohash/custom relay alone must not count — sends would still queue.
+    @Published private(set) var isDMRelayConnected = false
     
     private let dependencies: NostrRelayManagerDependencies
     private var allowDefaultRelays: Bool = false
@@ -1087,6 +1091,9 @@ final class NostrRelayManager: ObservableObject {
     
     private func updateConnectionStatus() {
         isConnected = relays.contains { $0.isConnected }
+        // Relay URLs are normalized before entries are created, so direct
+        // set membership is sound.
+        isDMRelayConnected = relays.contains { $0.isConnected && Self.defaultRelaySet.contains($0.url) }
     }
     
     /// A relay that drops before sending EOSE must not stall initial-load

--- a/bitchat/Services/MessageRouter.swift
+++ b/bitchat/Services/MessageRouter.swift
@@ -128,6 +128,14 @@ final class MessageRouter {
             SecureLogger.debug("Routing PM via \(type(of: transport)) (reachable) to \(peerID.id.prefix(8))… id=\(messageID.prefix(8))…", category: .session)
             transport.sendPrivateMessage(content, to: peerID, recipientNickname: recipientNickname, messageID: messageID)
             enqueue(message, for: peerID)
+            // "Reachable" without prompt delivery means the send only joined
+            // a queue (Nostr with relays down): also hand a sealed copy to
+            // any connected couriers rather than waiting for internet that
+            // may never come. Double delivery is harmless — receivers dedup
+            // by message ID, and delivered/read acks never downgrade.
+            if !transport.canDeliverPromptly(to: peerID) {
+                attemptCourierDeposit(content: content, messageID: messageID, for: peerID)
+            }
         } else {
             var unsent = message
             unsent.sendAttempts = 0
@@ -137,11 +145,12 @@ final class MessageRouter {
         }
     }
 
-    /// Last resort when no transport can reach the peer: seal the message to
-    /// their known static key and hand it to connected mutual favorites who
-    /// may physically encounter them. The queued copy above stays retained,
-    /// so direct delivery still wins if the peer reappears first (receivers
-    /// dedup by message ID).
+    /// Last resort when no transport can deliver promptly — the peer is
+    /// unreachable, or only reachable through a send queue waiting on
+    /// internet: seal the message to their known static key and hand it to
+    /// connected mutual favorites who may physically encounter them. The
+    /// queued copy above stays retained, so direct delivery still wins if
+    /// the peer reappears first (receivers dedup by message ID).
     private func attemptCourierDeposit(content: String, messageID: String, for peerID: PeerID) {
         guard let recipientKey = courierDirectory.noiseKey(peerID) else { return }
         for transport in transports {

--- a/bitchat/Services/NostrTransport.swift
+++ b/bitchat/Services/NostrTransport.swift
@@ -14,7 +14,10 @@ final class NostrTransport: Transport, @unchecked Sendable {
         let registerPendingGiftWrap: @MainActor (String) -> Void
         let sendEvent: @MainActor (NostrEvent) -> Void
         let scheduleAfter: @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void
-        /// Emits whether any relay connection is up (fail-closed behind Tor).
+        /// Emits whether a relay that carries private messages is up
+        /// (fail-closed behind Tor). A connected geohash/custom relay alone
+        /// doesn't count: DM sends target the default relay set and would
+        /// still queue.
         let relayConnectivity: @MainActor () -> AnyPublisher<Bool, Never>
 
         @MainActor
@@ -30,7 +33,7 @@ final class NostrTransport: Transport, @unchecked Sendable {
                 scheduleAfter: { delay, action in
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: action)
                 },
-                relayConnectivity: { NostrRelayManager.shared.$isConnected.eraseToAnyPublisher() }
+                relayConnectivity: { NostrRelayManager.shared.$isDMRelayConnected.eraseToAnyPublisher() }
             )
         }
     }

--- a/bitchat/Services/NostrTransport.swift
+++ b/bitchat/Services/NostrTransport.swift
@@ -14,7 +14,10 @@ final class NostrTransport: Transport, @unchecked Sendable {
         let registerPendingGiftWrap: @MainActor (String) -> Void
         let sendEvent: @MainActor (NostrEvent) -> Void
         let scheduleAfter: @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void
+        /// Emits whether any relay connection is up (fail-closed behind Tor).
+        let relayConnectivity: @MainActor () -> AnyPublisher<Bool, Never>
 
+        @MainActor
         static func live(idBridge: NostrIdentityBridge) -> Dependencies {
             Dependencies(
                 notificationCenter: .default,
@@ -26,7 +29,8 @@ final class NostrTransport: Transport, @unchecked Sendable {
                 sendEvent: { NostrRelayManager.shared.sendEvent($0) },
                 scheduleAfter: { delay, action in
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: action)
-                }
+                },
+                relayConnectivity: { NostrRelayManager.shared.$isConnected.eraseToAnyPublisher() }
             )
         }
     }
@@ -49,6 +53,10 @@ final class NostrTransport: Transport, @unchecked Sendable {
 
     // Reachability Cache (thread-safe)
     private var reachablePeers: Set<PeerID> = []
+    // Mirror of the relay manager's connection state, cached here because
+    // canDeliverPromptly is called synchronously off the main actor.
+    private var relaysConnected = false
+    private var relayConnectivityCancellable: AnyCancellable?
     private let queue = DispatchQueue(label: "nostr.transport.state", attributes: .concurrent)
 
     @MainActor
@@ -72,6 +80,12 @@ final class NostrTransport: Transport, @unchecked Sendable {
         queue.sync(flags: .barrier) {
             self.reachablePeers = Set(reachable)
         }
+
+        relayConnectivityCancellable = self.dependencies.relayConnectivity()
+            .sink { [weak self] connected in
+                guard let self else { return }
+                self.queue.async(flags: .barrier) { self.relaysConnected = connected }
+            }
     }
 
     deinit {
@@ -132,6 +146,14 @@ final class NostrTransport: Transport, @unchecked Sendable {
             if reachablePeers.contains(peerID) { return true }
             return reachablePeers.contains(where: { $0.toShort() == short })
         }
+    }
+
+    func canDeliverPromptly(to peerID: PeerID) -> Bool {
+        // A known npub makes a peer "reachable", but with no relay
+        // connection a send only joins the local queue. Answering honestly
+        // here lets the router hand a sealed copy to a courier in parallel
+        // instead of waiting for internet that may never come.
+        isPeerReachable(peerID) && queue.sync { relaysConnected }
     }
     
     func peerNickname(peerID: PeerID) -> String? { nil }

--- a/bitchat/Services/Transport.swift
+++ b/bitchat/Services/Transport.swift
@@ -54,6 +54,11 @@ protocol Transport: AnyObject {
     // Connectivity and peers
     func isPeerConnected(_ peerID: PeerID) -> Bool
     func isPeerReachable(_ peerID: PeerID) -> Bool
+    /// Whether a send to this peer is likely to leave the device promptly.
+    /// Distinct from reachability: Nostr claims any favorite with a known
+    /// npub as reachable even with no relay connection, where a send only
+    /// joins a queue waiting for internet that may never come.
+    func canDeliverPromptly(to peerID: PeerID) -> Bool
     func peerNickname(peerID: PeerID) -> String?
     func getPeerNicknames() -> [PeerID: String]
 
@@ -111,6 +116,10 @@ protocol Transport: AnyObject {
 }
 
 extension Transport {
+    // Reachability implies prompt delivery for transports that hand packets
+    // straight to the radio; queue-backed transports override this.
+    func canDeliverPromptly(to peerID: PeerID) -> Bool { isPeerReachable(peerID) }
+
     // Noise identity hooks default to inert for transports that do not carry
     // Noise sessions (e.g. NostrTransport).
     func noiseSessionPublicKeyData(for peerID: PeerID) -> Data? { nil }

--- a/bitchatTests/EndToEnd/CourierEndToEndTests.swift
+++ b/bitchatTests/EndToEnd/CourierEndToEndTests.swift
@@ -544,7 +544,16 @@ private final class CourierCaptureTransport: Transport {
     func isPeerConnected(_ peerID: PeerID) -> Bool {
         snapshots.contains { $0.peerID == peerID && $0.isConnected }
     }
-    func isPeerReachable(_ peerID: PeerID) -> Bool { isPeerConnected(peerID) }
+    // Nostr-style reachability: claimed for peers with no live link (known
+    // npub), where prompt delivery additionally needs a relay connection.
+    var reachablePeers: Set<PeerID> = []
+    var promptDelivery = true
+    func isPeerReachable(_ peerID: PeerID) -> Bool {
+        isPeerConnected(peerID) || reachablePeers.contains(peerID)
+    }
+    func canDeliverPromptly(to peerID: PeerID) -> Bool {
+        isPeerReachable(peerID) && promptDelivery
+    }
     func peerNickname(peerID: PeerID) -> String? { nil }
     func getPeerNicknames() -> [PeerID: String] { [:] }
 
@@ -651,5 +660,71 @@ struct MessageRouterCourierTests {
 
         #expect(transport.directSends == ["m3"])
         #expect(transport.courierSends.isEmpty)
+    }
+
+    /// A peer can be "reachable" through a transport that cannot deliver
+    /// promptly (Nostr claims any favorite with a known npub, even with no
+    /// relay connection). The queued send must not shadow the courier: a
+    /// sealed copy goes to connected couriers in parallel, and receivers
+    /// dedup by message ID if both arrive.
+    @Test @MainActor
+    func queuedReachableSendAlsoDepositsWithCourier() {
+        let bobKey = Data(repeating: 0xB0, count: 32)
+        let bobID = PeerID(publicKey: bobKey)
+        let carolKey = Data(repeating: 0xC0, count: 32)
+        let carolID = PeerID(publicKey: carolKey)
+
+        let transport = CourierCaptureTransport()
+        transport.snapshots = [
+            TransportPeerSnapshot(peerID: carolID, nickname: "carol", isConnected: true, noisePublicKey: carolKey, lastSeen: Date())
+        ]
+        transport.reachablePeers = [bobID]
+        transport.promptDelivery = false
+
+        let directory = CourierDirectory(
+            noiseKey: { peerID in peerID == bobID ? bobKey : nil },
+            isTrustedCourier: { $0 == carolKey }
+        )
+        let router = MessageRouter(transports: [transport], courierDirectory: directory)
+        var carried: [String] = []
+        router.onMessageCarried = { messageID, _ in carried.append(messageID) }
+
+        router.sendPrivate("hi bob", to: bobID, recipientNickname: "bob", messageID: "m4")
+
+        #expect(transport.directSends == ["m4"])
+        #expect(transport.courierSends.count == 1)
+        #expect(transport.courierSends.first?.messageID == "m4")
+        #expect(transport.courierSends.first?.couriers == [carolID])
+        #expect(carried == ["m4"])
+    }
+
+    /// When the reachable transport can deliver promptly (relays up), the
+    /// send is trusted and no courier quota is spent.
+    @Test @MainActor
+    func promptlyDeliverableReachablePeerSkipsCourier() {
+        let bobKey = Data(repeating: 0xB0, count: 32)
+        let bobID = PeerID(publicKey: bobKey)
+        let carolKey = Data(repeating: 0xC0, count: 32)
+        let carolID = PeerID(publicKey: carolKey)
+
+        let transport = CourierCaptureTransport()
+        transport.snapshots = [
+            TransportPeerSnapshot(peerID: carolID, nickname: "carol", isConnected: true, noisePublicKey: carolKey, lastSeen: Date())
+        ]
+        transport.reachablePeers = [bobID]
+
+        let directory = CourierDirectory(
+            noiseKey: { peerID in peerID == bobID ? bobKey : nil },
+            isTrustedCourier: { $0 == carolKey }
+        )
+        let router = MessageRouter(transports: [transport], courierDirectory: directory)
+        var carried: [String] = []
+        router.onMessageCarried = { messageID, _ in carried.append(messageID) }
+
+        router.sendPrivate("hi bob", to: bobID, recipientNickname: "bob", messageID: "m5")
+
+        #expect(transport.directSends == ["m5"])
+        #expect(transport.courierSends.isEmpty)
+        #expect(carried.isEmpty)
     }
 }

--- a/bitchatTests/Services/NostrTransportTests.swift
+++ b/bitchatTests/Services/NostrTransportTests.swift
@@ -6,6 +6,7 @@
 // For more information, see <https://unlicense.org>
 //
 
+import Combine
 import Foundation
 import Testing
 import BitFoundation
@@ -83,6 +84,51 @@ struct NostrTransportTests {
 
         let didRefresh = await TestHelpers.waitUntil({ transport.isPeerReachable(peerID) }, timeout: 5.0)
         #expect(didRefresh)
+    }
+
+    @Test("Prompt delivery requires both a known npub and a relay connection")
+    @MainActor
+    func canDeliverPromptlyTracksRelayConnectivity() async throws {
+        let keychain = MockKeychain()
+        let idBridge = NostrIdentityBridge(keychain: keychain)
+        let recipient = try NostrIdentity.generate()
+        let noiseKey = Data((0..<32).map(UInt8.init))
+        let peerID = PeerID(hexData: noiseKey)
+        let relationship = makeRelationship(
+            peerNoisePublicKey: noiseKey,
+            peerNostrPublicKey: recipient.npub,
+            peerNickname: "Alice"
+        )
+        let connectivity = CurrentValueSubject<Bool, Never>(false)
+
+        let transport = NostrTransport(
+            keychain: keychain,
+            idBridge: idBridge,
+            dependencies: makeDependencies(
+                loadFavorites: { [noiseKey: relationship] },
+                relayConnectivity: { connectivity.eraseToAnyPublisher() }
+            )
+        )
+
+        // Reachable (npub known) but relays down: the peer must not be
+        // treated as promptly deliverable, or the router would skip the
+        // courier and let the message rot in the Nostr send queue.
+        #expect(transport.isPeerReachable(peerID))
+        #expect(!transport.canDeliverPromptly(to: peerID))
+
+        connectivity.send(true)
+        let deliverable = await TestHelpers.waitUntil(
+            { transport.canDeliverPromptly(to: peerID) },
+            timeout: 5.0
+        )
+        #expect(deliverable)
+
+        connectivity.send(false)
+        let undeliverable = await TestHelpers.waitUntil(
+            { !transport.canDeliverPromptly(to: peerID) },
+            timeout: 5.0
+        )
+        #expect(undeliverable)
     }
 
     @Test("Private message resolves short peer ID and emits decryptable packet")
@@ -375,7 +421,8 @@ struct NostrTransportTests {
         currentIdentity: @escaping @MainActor () throws -> NostrIdentity? = { nil },
         registerPendingGiftWrap: @escaping @MainActor (String) -> Void = { _ in },
         sendEvent: @escaping @MainActor (NostrEvent) -> Void = { _ in },
-        scheduleAfter: @escaping @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void = { _, _ in }
+        scheduleAfter: @escaping @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void = { _, _ in },
+        relayConnectivity: @escaping @MainActor () -> AnyPublisher<Bool, Never> = { Just(false).eraseToAnyPublisher() }
     ) -> NostrTransport.Dependencies {
         NostrTransport.Dependencies(
             notificationCenter: notificationCenter,
@@ -385,7 +432,8 @@ struct NostrTransportTests {
             currentIdentity: currentIdentity,
             registerPendingGiftWrap: registerPendingGiftWrap,
             sendEvent: sendEvent,
-            scheduleAfter: scheduleAfter
+            scheduleAfter: scheduleAfter,
+            relayConnectivity: relayConnectivity
         )
     }
 


### PR DESCRIPTION
## Problem

The friend-courier feature (merged in #1367, originally #1342) was nearly unreachable in practice. `MessageRouter.sendPrivate` only attempted a courier deposit when **no** transport claimed the peer was reachable — but `NostrTransport.isPeerReachable` returns true for any mutual favorite with a known npub, with no regard for actual connectivity. Since the mesh favorite exchange shares npubs (`[FAVORITED]:npub…`), essentially every courier-eligible recipient (couriering requires their Noise key, i.e. a favorite) was always "reachable" via Nostr.

Net effect in the flagship scenario — internet shutdown, recipient off-mesh, mutual friend standing next to you: the message joined the Nostr relay send queue to wait for internet that may never come, and the courier walked away carrying nothing.

## Fix

- **`Transport.canDeliverPromptly(to:)`** — new protocol method, defaulting to `isPeerReachable` for radio-backed transports. Distinct from reachability: it answers "will a send actually leave the device now?"
- **`NostrTransport`** answers honestly: npub known **and** a relay connection is up (mirrored from `NostrRelayManager.$isConnected`, which is fail-closed behind Tor; cached thread-safely since the router calls synchronously).
- **`MessageRouter.sendPrivate`**: when the chosen reachable transport can't deliver promptly, *also* deposit a sealed copy with connected couriers — in parallel with the queued send, not instead of it.

Double delivery is safe by construction: receivers dedup by message ID, and delivered/read acks never downgrade the `carried` status. When relays are up, nothing changes — sends are trusted and no courier quota is spent.

## Tests

- `queuedReachableSendAlsoDepositsWithCourier` — reachable-but-queued send also deposits with a trusted courier (fails without the router change, verified).
- `promptlyDeliverableReachablePeerSkipsCourier` — relays up → no courier quota spent.
- `canDeliverPromptlyTracksRelayConnectivity` — NostrTransport flips with relay connectivity while reachability stays true.
- Full suite: 1015 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)