### PR TITLE
docs: reconcile whitepaper and protocol docs with implementation

### DIFF
--- a/bitchat/Protocols/BitchatProtocol.swift
+++ b/bitchat/Protocols/BitchatProtocol.swift
@@ -18,7 +18,7 @@
 /// - Efficient binary message encoding
 /// - Message fragmentation for large payloads
 /// - TTL-based routing for mesh networks
-/// - Privacy features like padding and timing obfuscation
+/// - Privacy features: message padding and randomized relay jitter
 /// - Integration points for end-to-end encryption
 ///
 /// ## Protocol Design
@@ -38,18 +38,20 @@
 /// 7. **Decoding**: Binary data parsed back to message objects
 ///
 /// ## Security Considerations
-/// - Message padding obscures actual content length
-/// - Timing obfuscation prevents traffic analysis
+/// - Message padding (to 256/512/1024/2048-byte blocks) obscures actual content length
+/// - Randomized relay jitter reduces the traffic-analysis signal; there is no
+///   cover traffic or per-message timing obfuscation
 /// - Integration with Noise Protocol for E2E encryption
 /// - No persistent identifiers in protocol headers
 ///
 /// ## Message Types
 /// - **Announce/Leave**: Peer presence notifications
-/// - **Message**: User chat messages (broadcast or directed)
+/// - **Message**: Public chat messages
 /// - **Fragment**: Multi-part message handling
-/// - **Delivery/Read**: Message acknowledgments
-/// - **Noise**: Encrypted channel establishment
-/// - **Version**: Protocol version negotiation
+/// - **NoiseHandshake/NoiseEncrypted**: Encrypted channel establishment and
+///   all private payloads (messages, delivery acks, read receipts)
+/// - **CourierEnvelope**: Sealed store-and-forward mail
+/// - **RequestSync/FileTransfer**: Gossip history sync and media transfer
 ///
 /// ## Future Extensions
 /// The protocol is designed to be extensible:

--- a/localPackages/BitFoundation/Sources/BitFoundation/MessageType.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/MessageType.swift
@@ -7,7 +7,7 @@
 //
 
 /// Simplified BitChat protocol message types.
-/// Reduced from 24 types to just 6 essential ones.
+/// Consolidated from the original 24 wire types down to the 9 cases below.
 /// All private communication metadata (receipts, status) is embedded in noiseEncrypted payloads.
 public enum MessageType: UInt8 {
     // Public messages (unencrypted)


### PR DESCRIPTION
Docs/comments-only PR fixing documentation claims that no longer match the implementation.

## Claim → reality fixes

**`bitchat/Protocols/BitchatProtocol.swift` (docstring only)**
- Claim: "Timing obfuscation prevents traffic analysis" / "Privacy features like padding and timing obfuscation".
  Reality: randomized relay jitter (`RelayController`, 10–220 ms scaled by connection degree) and PKCS#7-style padding to 256/512/1024/2048-byte blocks (`MessagePadding`). There is **no** cover traffic or per-message timing obfuscation. Reworded to "randomized relay jitter and message padding reduce the traffic-analysis signal", with the limitation stated explicitly.
- Claim: Message Types list included "Delivery/Read" and "Version: Protocol version negotiation" as top-level wire types.
  Reality: delivery acks and read receipts are `NoisePayloadType` cases inside `noiseEncrypted`, and no version-negotiation message type exists. Updated the list to the actual `MessageType` enum (announce/leave, message, fragment, noiseHandshake/noiseEncrypted, courierEnvelope, requestSync, fileTransfer).

**`localPackages/BitFoundation/Sources/BitFoundation/MessageType.swift` (comment only)**
- Claim: "Reduced from 24 types to just 6 essential ones."
  Reality: the enum has 9 cases. Now reads "Consolidated from the original 24 wire types down to the 9 cases below."

## WHITEPAPER.md — checked, no changes needed

This task originally targeted the whitepaper's Bloom-filter dedup and `MessageRetryService` claims, expecting a conflict with then-open #1372. #1372 has since **merged** (73416962) and its rewrite already removed both claims, so there is no conflict and no whitepaper diff here. I verified the rewritten whitepaper against code and every checked claim matches:

- dedup: exact-ID LRU seen-set, 1000 entries / 5-min expiry, keyed by sender + timestamp + type + payload-digest prefix (`MessageDeduplicator`, `BLEIngressLinkRegistry.messageID`)
- relay jitter ranges, TTL 7, fragment size 469 B / 128 assemblies
- sender outbox: 100 msgs/peer, 24 h TTL, 8 send attempts (`MessageRouter`)
- courier: 16 KiB cap, 24 h lifetime, 40-envelope pool with 20 verified-tier cap, 5/favorite + 2/verified depositor quotas, spray budget 4 initial / 8 max, 3 couriers/message, 10-min remote-handover cooldown (`CourierStore`, `CourierEnvelope`, `TransportConfig`)
- gossip sync: 1000-packet cache, ~15 s interval, 6 h public window, 15-min fragment window

## Verification

Comment-only edits; `swift build` of the BitFoundation package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)