### PR TITLE
Fix SyncTypeFlags tests: bit 8 (boardPost) is a known type (main is red)

### DIFF
--- a/bitchatTests/Sync/SyncTypeFlagsTests.swift
+++ b/bitchatTests/Sync/SyncTypeFlagsTests.swift
@@ -13,31 +13,41 @@ struct SyncTypeFlagsTests {
     }
 
     @Test func decodeDropsPhantomBits() {
-        // Bits 8+ map to no message type. They must not survive decode as
-        // phantom membership.
-        let phantom = Data([0x00, 0xFF]) // bits 8..15 set, no known type
+        // Bits 9+ map to no message type (bit 8 is boardPost). They must not
+        // survive decode as phantom membership.
+        let phantom = Data([0x00, 0xFE]) // bits 9..15 set, no known type
         let decoded = SyncTypeFlags.decode(phantom)
         #expect(decoded?.rawValue == 0)
         #expect(decoded?.toMessageTypes().isEmpty == true)
     }
 
+    @Test func boardBitSurvivesDecode() {
+        // Bit 8 maps to boardPost and spills the field into a second byte;
+        // it must survive decode while the phantom high bits are stripped.
+        let mixed = Data([0x00, 0xFF]) // bit 8 (board) known, bits 9..15 phantom
+        let decoded = SyncTypeFlags.decode(mixed)
+        #expect(decoded?.contains(.board) == true)
+        #expect(decoded?.rawValue == 0b1_0000_0000)
+    }
+
     @Test func phantomBitsAreStrippedButKnownBitsSurvive() {
-        // Low byte = announce(0) + message(1); high byte = phantom.
-        let mixed = Data([0b0000_0011, 0xFF])
+        // Low byte = announce(0) + message(1); high byte bits 9+ are phantom.
+        let mixed = Data([0b0000_0011, 0xFE])
         let decoded = SyncTypeFlags.decode(mixed)
         #expect(decoded?.contains(.announce) == true)
         #expect(decoded?.contains(.message) == true)
-        // Only the two known bits remain; phantom high byte is gone.
+        // Only the two known bits remain; phantom high bits are gone.
         #expect(decoded?.rawValue == 0b0000_0011)
     }
 
     @Test func rawValueInitNormalizesPhantomBits() {
         let flags = SyncTypeFlags(rawValue: 0xFFFF_FFFF_FFFF_FFFF)
-        // Every known type bit is set; nothing above them survives, so the
-        // field serializes to a single byte.
+        // Every known type bit is set; nothing above them survives. boardPost
+        // occupies bit 8, so the known set spills into a second byte.
         #expect(flags.contains(.announce))
         #expect(flags.contains(.fileTransfer))
+        #expect(flags.contains(.board))
         let data = flags.toData()
-        #expect(data?.count == 1)
+        #expect(data?.count == 2)
     }
 }


### PR DESCRIPTION
## Main is currently red — this fixes it

`Run Swift Tests (app)` fails on `SyncTypeFlagsTests` (`decodeDropsPhantomBits`, `phantomBitsAreStrippedButKnownBitsSurvive`, `rawValueInitNormalizesPhantomBits`).

### Root cause — a cross-PR semantic conflict
- **#1373** (sync cleanups) added phantom-bit tests asserting **bit 8 is unknown**.
- **#1379** (board) changed `SyncTypeFlags` to map **bit 8 → `.boardPost`**, making it a *known* bit that spills the encoded field into a second byte.

Each PR was green against a `main` that lacked the other, so neither CI run caught the contradiction. Once both squashed onto `main`, the impl (bit 8 known) and the tests (bit 8 phantom) disagree → red.

### Fix (tests only)
The impl is correct — `board` is a real sync type. The tests were stale:
- phantom coverage moves to bits **9+** (`0xFE` high byte instead of `0xFF`)
- the all-known field now serializes to **2 bytes** (boardPost occupies bit 8)
- adds `boardBitSurvivesDecode` as a regression guard that bit 8 survives while phantom high bits are stripped

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)