### PR TITLE
BLE background presence: pending-connect wake-on-proximity + wake-window maintenance

### DIFF
--- a/bitchat/Services/BLE/BLERecentPeripheralCache.swift
+++ b/bitchat/Services/BLE/BLERecentPeripheralCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Remembers recently seen bitchat peripherals (fresh discoveries and dropped
+/// links) so the service can arm pending background connections against them
+/// when the app leaves the foreground. Generic over the peripheral type so
+/// the eviction/expiry logic is testable without CoreBluetooth.
+final class BLERecentPeripheralCache<Peripheral> {
+    private struct Entry {
+        let peripheral: Peripheral
+        var lastSeen: Date
+    }
+
+    private var entries: [String: Entry] = [:]
+    private let capacity: Int
+    private let maxAge: TimeInterval
+
+    init(
+        capacity: Int = TransportConfig.bleRecentPeripheralCacheCap,
+        maxAge: TimeInterval = TransportConfig.bleRecentPeripheralMaxAgeSeconds
+    ) {
+        self.capacity = capacity
+        self.maxAge = maxAge
+    }
+
+    var count: Int { entries.count }
+
+    func record(_ peripheral: Peripheral, peripheralID: String, at now: Date) {
+        entries[peripheralID] = Entry(peripheral: peripheral, lastSeen: now)
+        guard entries.count > capacity else { return }
+        // Inserts overshoot capacity by at most one; evict the stalest entry
+        if let stalest = entries.min(by: { $0.value.lastSeen < $1.value.lastSeen }) {
+            entries.removeValue(forKey: stalest.key)
+        }
+    }
+
+    /// Most-recently-seen peripherals eligible for a pending background
+    /// connect, freshest first, capped at `limit`. Expired entries are
+    /// pruned as a side effect.
+    func reconnectTargets(
+        now: Date,
+        limit: Int,
+        excluding: (String) -> Bool
+    ) -> [(peripheralID: String, peripheral: Peripheral)] {
+        let cutoff = now.addingTimeInterval(-maxAge)
+        entries = entries.filter { $0.value.lastSeen >= cutoff }
+        guard limit > 0 else { return [] }
+        return entries
+            .filter { !excluding($0.key) }
+            .sorted { $0.value.lastSeen > $1.value.lastSeen }
+            .prefix(limit)
+            .map { (peripheralID: $0.key, peripheral: $0.value.peripheral) }
+    }
+}

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -1519,6 +1519,19 @@ extension BLEService: CBCentralManagerDelegate {
                 assembler: assembler
             )
             linkStateStore.setPeripheralState(restoredState, for: identifier)
+
+            // Restored peripherals are the freshest wake-on-proximity
+            // candidates we have after a relaunch — without this the cache
+            // starts empty and backgrounding right after a restore arms
+            // nothing.
+            recentPeripheralCache.record(peripheral, peripheralID: identifier, at: Date())
+
+            // A link restored as connected has no characteristic in the new
+            // process; without rediscovery it would sit connected-but-unusable
+            // (no writes, no notifications) until the peer disconnects.
+            if peripheral.state == .connected && characteristic == nil {
+                peripheral.discoverServices([BLEService.serviceUUID])
+            }
         }
 
         captureBluetoothStatus(context: "central-restore")

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -197,6 +197,7 @@ final class BLEService: NSObject {
     
     private var maintenanceTimer: DispatchSourceTimer?  // Single timer for all maintenance tasks
     private var maintenanceCounter = 0  // Track maintenance cycles
+    private var lastMaintenanceAt = Date.distantPast  // bleQueue-confined; drives background-wake catch-up passes
     /// Whether real CoreBluetooth managers were initialized. When false (unit
     /// tests), periodic mesh background work is not started — the maintenance
     /// timer and the gossip-sync timers only drain BLE writes/notifications,
@@ -207,6 +208,9 @@ final class BLEService: NSObject {
 
     // MARK: - Connection budget & scheduling (central role)
     private var connectionScheduler = BLEConnectionScheduler<CBPeripheral>()
+    // Recently seen peripherals retained for background wake-on-proximity
+    // connects (bleQueue-confined, like the link state store)
+    private let recentPeripheralCache = BLERecentPeripheralCache<CBPeripheral>()
 
     // MARK: - Adaptive scanning duty-cycle
     private var scanDutyTimer: DispatchSourceTimer?
@@ -1609,6 +1613,9 @@ extension BLEService: CBCentralManagerDelegate {
             isConnectable: isConnectable,
             discoveredAt: Date()
         )
+        if isConnectable {
+            recentPeripheralCache.record(peripheral, peripheralID: peripheralID, at: candidate.discoveredAt)
+        }
         let existingState = linkStateStore.state(forPeripheralID: peripheralID).map(BLEExistingConnectionState.init)
 
         switch connectionScheduler.handleDiscovery(
@@ -1635,7 +1642,15 @@ extension BLEService: CBCentralManagerDelegate {
     
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         let peripheralID = peripheral.identifier.uuidString
-        
+
+        #if os(iOS)
+        // A connect completing while backgrounded is the wake-on-proximity
+        // path doing its job — worth an info line for field verification.
+        if !isAppActive {
+            SecureLogger.info("🌙 Background wake: connected to \(peripheral.name ?? peripheralID) while backgrounded", category: .session)
+        }
+        #endif
+
         // Update state to connected
         linkStateStore.markConnected(peripheral)
         
@@ -1660,7 +1675,24 @@ extension BLEService: CBCentralManagerDelegate {
         if error != nil {
             connectionScheduler.recordDisconnectError(peripheralID: peripheralID, at: Date())
         }
-        
+
+        // Retain the handle: a dropped link is the best wake-on-proximity
+        // candidate if the app backgrounds before the peer returns.
+        recentPeripheralCache.record(peripheral, peripheralID: peripheralID, at: Date())
+
+        #if os(iOS)
+        // Link lost while backgrounded (peer walked away): re-arm a pending
+        // connect during this wake window so the peer's return wakes us again.
+        // Delayed past the disconnect-settle window to avoid reconnect thrash
+        // at range edge.
+        if !isAppActive {
+            bleQueue.asyncAfter(deadline: .now() + TransportConfig.bleDisconnectDiscoveryIgnoreSeconds) { [weak self] in
+                guard let self, !self.isAppActive else { return }
+                self.armPendingBackgroundConnects()
+            }
+        }
+        #endif
+
         // Clean up references and peer mappings
         _ = linkStateStore.removePeripheral(peripheralID)
         if let peerID {
@@ -1787,6 +1819,18 @@ extension BLEService {
                 SecureLogger.debug("⏱️ Timeout fired but peripheral already connected: \(candidate.name)", category: .session)
                 return
             }
+
+            #if os(iOS)
+            if !self.isAppActive {
+                // Backgrounded: leave the connect pending. iOS never expires
+                // it — the controller completes it whenever the peer comes
+                // back into range, waking the app (state restoration relaunches
+                // us if we were terminated). Foreground return cancels stale
+                // pendings via cancelStalePendingConnects().
+                SecureLogger.info("🌙 Connect timeout deferred while backgrounded, left pending for wake-on-proximity: \(candidate.name)", category: .session)
+                return
+            }
+            #endif
 
             SecureLogger.debug("⏱️ Timeout: \(candidate.name)", category: .session)
             central.cancelPeripheralConnection(peripheral)
@@ -3407,11 +3451,12 @@ extension BLEService {
             centralManager?.stopScan()
             startScanning()
         }
+        cancelStalePendingConnects()
         logBluetoothStatus("became-active")
         scheduleBluetoothStatusSample(after: 5.0, context: "active-5s")
         // No Local Name; nothing to refresh for advertising policy
     }
-    
+
     @objc private func appDidEnterBackground() {
         isAppActive = false
         // Restart scanning without allow duplicates in background
@@ -3419,12 +3464,83 @@ extension BLEService {
             centralManager?.stopScan()
             startScanning()
         }
+        armPendingBackgroundConnects()
         // Backgrounding may precede a kill; flush the public-history archive
         // outside its 30s maintenance cadence.
         gossipSyncManager?.persistNow()
         logBluetoothStatus("entered-background")
         scheduleBluetoothStatusSample(after: 15.0, context: "background-15s")
         // No Local Name; nothing to refresh for advertising policy
+    }
+
+    /// Issue indefinite `connect()` requests to recently seen peripherals on
+    /// backgrounding. Pending connects live in the Bluetooth controller's
+    /// allowlist — no scanning and no app CPU — and complete whenever a peer
+    /// comes into range, waking (or relaunching) the app. A couple of central
+    /// slots stay reserved for connects driven by live background discovery.
+    private func armPendingBackgroundConnects() {
+        bleQueue.async { [weak self] in
+            guard let self, let central = self.centralManager, central.state == .poweredOn else { return }
+            let budget = TransportConfig.bleMaxCentralLinks
+                - TransportConfig.bleBackgroundPendingConnectSlotReserve
+                - self.linkStateStore.connectedOrConnectingPeripheralCount
+            let now = Date()
+            let targets = self.recentPeripheralCache.reconnectTargets(now: now, limit: budget) { peripheralID in
+                let state = self.linkStateStore.state(forPeripheralID: peripheralID)
+                return state?.isConnected == true || state?.isConnecting == true
+            }
+            guard !targets.isEmpty else { return }
+            for target in targets {
+                // lastConnectionAttempt stays nil: an indefinite pending connect
+                // has no attempt clock, and nil marks it always-stale so
+                // cancelStalePendingConnects() reclaims it on foreground even
+                // after a quick background→foreground bounce.
+                self.linkStateStore.setPeripheralState(
+                    BLEPeripheralLinkState(
+                        peripheral: target.peripheral,
+                        characteristic: nil,
+                        peerID: nil,
+                        isConnecting: true,
+                        isConnected: false,
+                        lastConnectionAttempt: nil,
+                        assembler: NotificationStreamAssembler()
+                    ),
+                    for: target.peripheralID
+                )
+                target.peripheral.delegate = self
+                central.connect(target.peripheral, options: [
+                    CBConnectPeripheralOptionNotifyOnConnectionKey: true,
+                    CBConnectPeripheralOptionNotifyOnDisconnectionKey: true,
+                    CBConnectPeripheralOptionNotifyOnNotificationKey: true
+                ])
+            }
+            SecureLogger.info("🌙 Armed \(targets.count) pending background connect(s) for wake-on-proximity", category: .session)
+        }
+    }
+
+    /// Foreground restores normal connection management: pending connects
+    /// older than the connect timeout (including ones rebuilt by state
+    /// restoration after a relaunch) are cancelled so live scanning and the
+    /// scheduler take over. Anything still nearby is rediscovered within
+    /// seconds by the allow-duplicates foreground scan.
+    private func cancelStalePendingConnects() {
+        bleQueue.async { [weak self] in
+            guard let self, let central = self.centralManager else { return }
+            let now = Date()
+            var cancelled = 0
+            for state in self.linkStateStore.peripheralStates where state.isConnecting && !state.isConnected {
+                let age = state.lastConnectionAttempt.map { now.timeIntervalSince($0) } ?? .infinity
+                guard age > TransportConfig.bleConnectTimeoutSeconds else { continue }
+                let peripheralID = state.peripheral.identifier.uuidString
+                central.cancelPeripheralConnection(state.peripheral)
+                _ = self.linkStateStore.removePeripheral(peripheralID)
+                cancelled += 1
+            }
+            if cancelled > 0 {
+                SecureLogger.info("🌅 Cancelled \(cancelled) stale pending connect(s) on foreground", category: .session)
+                self.tryConnectFromQueue()
+            }
+        }
     }
     #endif
     
@@ -3773,6 +3889,16 @@ extension BLEService {
                 meshTopology.recordObservedVersion(packet.version, for: routingData(for: peerID))
             }
         }
+
+        #if os(iOS)
+        // The maintenance timer is suspended with the app, so a packet arriving
+        // while backgrounded means the radio woke us — use the wake window to
+        // run the announce/flush/drain pass the timer would have run.
+        if !isAppActive {
+            bleQueue.async { [weak self] in self?.performBackgroundWakeMaintenanceIfStale() }
+        }
+        #endif
+
 
         // Process by type
         switch context.messageType {
@@ -4270,6 +4396,7 @@ extension BLEService {
     
     private func performMaintenance() {
         maintenanceCounter += 1
+        lastMaintenanceAt = Date()
 
         let now = Date()
         let connectedCount = collectionsQueue.sync { peerRegistry.connectedCount }
@@ -4334,6 +4461,18 @@ extension BLEService {
         }
     }
     
+    #if os(iOS)
+    /// Catch-up maintenance for background wake windows (bleQueue-confined).
+    /// Rate-limited to the normal maintenance cadence so a burst of inbound
+    /// packets during one wake still runs at most one extra pass.
+    private func performBackgroundWakeMaintenanceIfStale() {
+        guard meshBackgroundEnabled,
+              !isAppActive,
+              Date().timeIntervalSince(lastMaintenanceAt) >= TransportConfig.bleMaintenanceInterval else { return }
+        performMaintenance()
+    }
+    #endif
+
     private func checkPeerConnectivity() {
         let now = Date()
         let peerIDsForLinkState: [PeerID] = collectionsQueue.sync { peerRegistry.peerIDs }

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -1707,7 +1707,9 @@ extension BLEService: CBCentralManagerDelegate {
         if !isAppActive {
             bleQueue.asyncAfter(deadline: .now() + TransportConfig.bleDisconnectDiscoveryIgnoreSeconds) { [weak self] in
                 guard let self, !self.isAppActive else { return }
-                self.armPendingBackgroundConnects()
+                // Reserve 0: use the slot this disconnect freed even in a
+                // dense mesh, so the lost peer can wake us when it returns.
+                self.armPendingBackgroundConnects(slotReserve: 0)
             }
         }
         #endif
@@ -3496,12 +3498,17 @@ extension BLEService {
     /// backgrounding. Pending connects live in the Bluetooth controller's
     /// allowlist — no scanning and no app CPU — and complete whenever a peer
     /// comes into range, waking (or relaunching) the app. A couple of central
-    /// slots stay reserved for connects driven by live background discovery.
-    private func armPendingBackgroundConnects() {
+    /// slots stay reserved for connects driven by live background discovery —
+    /// except on the disconnect re-arm path, which may consume the slot the
+    /// disconnect itself just freed (a dense mesh with 4+ remaining links
+    /// would otherwise compute a zero budget and never re-arm the lost peer).
+    private func armPendingBackgroundConnects(
+        slotReserve: Int = TransportConfig.bleBackgroundPendingConnectSlotReserve
+    ) {
         bleQueue.async { [weak self] in
             guard let self, let central = self.centralManager, central.state == .poweredOn else { return }
             let budget = TransportConfig.bleMaxCentralLinks
-                - TransportConfig.bleBackgroundPendingConnectSlotReserve
+                - slotReserve
                 - self.linkStateStore.connectedOrConnectingPeripheralCount
             let now = Date()
             let targets = self.recentPeripheralCache.reconnectTargets(now: now, limit: budget) { peripheralID in

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -1523,15 +1523,10 @@ extension BLEService: CBCentralManagerDelegate {
             // Restored peripherals are the freshest wake-on-proximity
             // candidates we have after a relaunch — without this the cache
             // starts empty and backgrounding right after a restore arms
-            // nothing.
+            // nothing. Service rediscovery for restored-connected links waits
+            // for poweredOn: CoreBluetooth drops commands issued during
+            // restoration (API MISUSE warnings).
             recentPeripheralCache.record(peripheral, peripheralID: identifier, at: Date())
-
-            // A link restored as connected has no characteristic in the new
-            // process; without rediscovery it would sit connected-but-unusable
-            // (no writes, no notifications) until the peer disconnects.
-            if peripheral.state == .connected && characteristic == nil {
-                peripheral.discoverServices([BLEService.serviceUUID])
-            }
         }
 
         captureBluetoothStatus(context: "central-restore")
@@ -1547,6 +1542,17 @@ extension BLEService: CBCentralManagerDelegate {
 
         switch central.state {
         case .poweredOn:
+            // Links restored as connected have no characteristic in the new
+            // process; without rediscovery they sit connected-but-unusable
+            // until the peer disconnects. Runs here (not willRestoreState)
+            // because commands issued before poweredOn are dropped.
+            for state in linkStateStore.peripheralStates where state.isConnected
+                && state.characteristic == nil
+                && state.peripheral.state == .connected {
+                SecureLogger.info("♻️ Rediscovering services on restored link: \(state.peripheral.identifier.uuidString.prefix(8))…", category: .session)
+                state.peripheral.discoverServices([BLEService.serviceUUID])
+            }
+
             // Start scanning - use allow duplicates for faster discovery when active
             startScanning()
 

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -242,6 +242,16 @@ enum TransportConfig {
     static let bleDisconnectNotifyDebounceSeconds: TimeInterval = 0.9
     static let bleReconnectLogDebounceSeconds: TimeInterval = 2.0
 
+    // Background wake-on-proximity (iOS). Pending connects issued on
+    // backgrounding never expire at the OS level: the Bluetooth controller
+    // completes them whenever the peer reappears in range and relaunches the
+    // app via state restoration. Entries older than the BLE address-rotation
+    // window no longer map to a reachable address, so the cache prunes them.
+    static let bleRecentPeripheralCacheCap: Int = 16
+    static let bleRecentPeripheralMaxAgeSeconds: TimeInterval = 15 * 60
+    // Central slots kept free for connects driven by live background discovery
+    static let bleBackgroundPendingConnectSlotReserve: Int = 2
+
     // Weak-link cooldown after connection timeouts
     static let bleWeakLinkCooldownSeconds: TimeInterval = 30.0
     static let bleWeakLinkRSSICutoff: Int = -90

--- a/bitchatTests/Services/BLERecentPeripheralCacheTests.swift
+++ b/bitchatTests/Services/BLERecentPeripheralCacheTests.swift
@@ -1,0 +1,99 @@
+//
+// BLERecentPeripheralCacheTests.swift
+// bitchatTests
+//
+// Eviction, expiry, and reconnect-target selection for the background
+// wake-on-proximity peripheral cache.
+//
+
+import Testing
+import Foundation
+@testable import bitchat
+
+struct BLERecentPeripheralCacheTests {
+
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeCache(capacity: Int = 4, maxAge: TimeInterval = 900) -> BLERecentPeripheralCache<String> {
+        BLERecentPeripheralCache<String>(capacity: capacity, maxAge: maxAge)
+    }
+
+    @Test
+    func recordUpsertsByPeripheralID() {
+        let cache = makeCache()
+        cache.record("p1", peripheralID: "A", at: base)
+        cache.record("p1-updated", peripheralID: "A", at: base.addingTimeInterval(10))
+
+        #expect(cache.count == 1)
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(11), limit: 10) { _ in false }
+        #expect(targets.map(\.peripheral) == ["p1-updated"])
+    }
+
+    @Test
+    func overCapacityEvictsStalestEntry() {
+        let cache = makeCache(capacity: 2)
+        cache.record("p1", peripheralID: "A", at: base)
+        cache.record("p2", peripheralID: "B", at: base.addingTimeInterval(1))
+        cache.record("p3", peripheralID: "C", at: base.addingTimeInterval(2))
+
+        #expect(cache.count == 2)
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(3), limit: 10) { _ in false }
+        #expect(targets.map(\.peripheralID) == ["C", "B"])
+    }
+
+    @Test
+    func refreshingAnEntryProtectsItFromEviction() {
+        let cache = makeCache(capacity: 2)
+        cache.record("p1", peripheralID: "A", at: base)
+        cache.record("p2", peripheralID: "B", at: base.addingTimeInterval(1))
+        // A becomes the freshest again; adding C must evict B, not A
+        cache.record("p1", peripheralID: "A", at: base.addingTimeInterval(2))
+        cache.record("p3", peripheralID: "C", at: base.addingTimeInterval(3))
+
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(4), limit: 10) { _ in false }
+        #expect(targets.map(\.peripheralID) == ["C", "A"])
+    }
+
+    @Test
+    func expiredEntriesArePruned() {
+        let cache = makeCache(maxAge: 100)
+        cache.record("p1", peripheralID: "A", at: base)
+        cache.record("p2", peripheralID: "B", at: base.addingTimeInterval(50))
+
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(120), limit: 10) { _ in false }
+        #expect(targets.map(\.peripheralID) == ["B"])
+        #expect(cache.count == 1)
+    }
+
+    @Test
+    func targetsAreFreshestFirstAndCappedAtLimit() {
+        let cache = makeCache(capacity: 8)
+        for (index, id) in ["A", "B", "C", "D"].enumerated() {
+            cache.record("p\(id)", peripheralID: id, at: base.addingTimeInterval(TimeInterval(index)))
+        }
+
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(10), limit: 2) { _ in false }
+        #expect(targets.map(\.peripheralID) == ["D", "C"])
+    }
+
+    @Test
+    func excludedPeripheralsAreSkippedWithoutConsumingTheLimit() {
+        let cache = makeCache(capacity: 8)
+        for (index, id) in ["A", "B", "C"].enumerated() {
+            cache.record("p\(id)", peripheralID: id, at: base.addingTimeInterval(TimeInterval(index)))
+        }
+
+        // C (freshest) is already connected; the two slots go to B and A
+        let targets = cache.reconnectTargets(now: base.addingTimeInterval(10), limit: 2) { $0 == "C" }
+        #expect(targets.map(\.peripheralID) == ["B", "A"])
+    }
+
+    @Test
+    func nonPositiveLimitReturnsNothing() {
+        let cache = makeCache()
+        cache.record("p1", peripheralID: "A", at: base)
+
+        #expect(cache.reconnectTargets(now: base, limit: 0) { _ in false }.isEmpty)
+        #expect(cache.reconnectTargets(now: base, limit: -3) { _ in false }.isEmpty)
+    }
+}


### PR DESCRIPTION
Re-opened for on-device testing (was #1395, merged prematurely and reverted in 0c313628).

## What

Keeps bitchat responsive to nearby bitchatters while backgrounded, at ~zero battery cost.

iOS never expires a pending `CBCentralManager.connect()`: the Bluetooth controller completes it whenever the target comes back into range, and relaunches the app via the existing state-restoration path. Previously the app-level 8s timeout cancelled every connect, throwing that wake-on-proximity capability away.

- **`BLERecentPeripheralCache`** — retains handles to recently seen/dropped peripherals (LRU 16, 15 min max age to respect BLE address rotation)
- **On backgrounding** — arm indefinite pending connects to cached peripherals, budgeted so 2 of the 6 central slots stay free for live background discovery; armed entries carry `lastConnectionAttempt == nil` so a quick background→foreground bounce can't strand them as connecting
- **Connect timeout defers while backgrounded** — discovery-driven background connects also stay pending
- **Foreground return** — cancels stale pendings (including `connecting` entries rebuilt by state restoration after a relaunch) and hands control back to the scanner/scheduler
- **Link dropped while backgrounded** — re-arms after the 3s disconnect-settle window so a peer walking away and returning wakes us again
- **Wake-window maintenance** — packet ingress while backgrounded triggers one catch-up `performMaintenance` pass (announces/spool flush/drains), since the maintenance timer is suspended with the app; rate-limited to the normal 5s cadence

Battery: pending connects live in the controller's allowlist (no scanning, no app CPU, no new timers); the catch-up pass only runs inside wake windows the radio already granted.

Known physics unchanged: two backgrounded iPhones can't *discover* each other cold (overflow-area limit) — but reconnection to recently-seen peers now works from suspension, and any foreground device or Mac still bridges everyone.

## Testing

- 7 new unit tests for the cache (eviction/expiry/budget/exclusion)
- Full suite: 1355 tests in 179 suites pass
- macOS + iOS device builds green
- Field-test logs at info level: `🌙` armed/deferred/background-wake, `🌅` foreground cleanup
- [ ] On-device walk-away/walk-back test (Mac + iPhone), pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)