### PR TITLE
Header: globe opens channel sheet; deterministic crowding cascade

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -13457,6 +13457,186 @@
         }
       }
     },
+    "content.accessibility.gateway_hint" : {
+      "comment" : "Accessibility hint for the internet gateway indicator explaining a tap opens the channel sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يفتح إعدادات القنوات لتشغيل البوابة أو إيقافها"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "গেটওয়ে চালু বা বন্ধ করতে চ্যানেল সেটিংস খোলে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Öffnet die kanaleinstellungen, um das gateway ein- oder auszuschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opens channel settings to turn the gateway on or off"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre los ajustes de canales para activar o desactivar la puerta de enlace"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Binubuksan ang mga setting ng channel para i-on o i-off ang gateway"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ouvre les réglages des canaux pour activer ou désactiver la passerelle"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פותח את הגדרות הערוצים כדי להפעיל או לכבות את השער"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "गेटवे चालू या बंद करने के लिए चैनल सेटिंग्स खोलता है"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Membuka pengaturan kanal untuk menyalakan atau mematikan gateway"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apre le impostazioni dei canali per attivare o disattivare il gateway"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "チャンネル設定を開いてゲートウェイのオン/オフを切り替えます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "채널 설정을 열어 게이트웨이를 켜거나 끕니다"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Membuka tetapan saluran untuk menghidupkan atau mematikan gateway"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "गेटवे खोल्न वा बन्द गर्न च्यानल सेटिङहरू खोल्छ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opent kanaalinstellingen om de gateway aan of uit te zetten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Otwiera ustawienia kanałów, aby włączyć lub wyłączyć bramę"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre as definições de canais para ligar ou desligar o gateway"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre as configurações de canais para ligar ou desligar o gateway"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Открывает настройки каналов, чтобы включить или выключить шлюз"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Öppnar kanalinställningar för att slå på eller av gatewayen"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "கேட்வேயை இயக்க அல்லது அணைக்க சேனல் அமைப்புகளைத் திறக்கிறது"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "เปิดการตั้งค่าช่องเพื่อเปิดหรือปิดเกตเวย์"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ağ geçidini açmak veya kapatmak için kanal ayarlarını açar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Відкриває налаштування каналів, щоб увімкнути або вимкнути шлюз"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "گیٹ وے کو آن یا آف کرنے کے لیے چینل کی ترتیبات کھولتا ہے"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mở cài đặt kênh để bật hoặc tắt gateway"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "打开频道设置以开启或关闭网关"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開啟頻道設定以開啟或關閉閘道"
+          }
+        }
+      }
+    },
     "content.accessibility.group_chat" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/bitchat/Views/ContentHeaderView.swift
+++ b/bitchat/Views/ContentHeaderView.swift
@@ -33,7 +33,12 @@ struct ContentHeaderView: View {
         HStack(spacing: 0) {
             Text(verbatim: "bitchat/")
                 .bitchatFont(size: 18, weight: .medium)
+                .lineLimit(1)
                 .foregroundColor(palette.primary)
+                // When icons crowd the header, squeeze the nickname first
+                // (priority 0) and the logo only as a last resort; the icon
+                // cluster at priority 3 never gives up width.
+                .layoutPriority(2)
                 .onTapGesture(count: 3) {
                     appChromeModel.panicClearAllData()
                 }
@@ -55,6 +60,8 @@ struct ContentHeaderView: View {
                 Text(verbatim: "@")
                     .bitchatFont(size: 14)
                     .foregroundColor(palette.secondary)
+                    // Keep the sigil whole while the field beside it shrinks.
+                    .fixedSize()
 
                 TextField(
                     "content.input.nickname_placeholder",
@@ -96,16 +103,22 @@ struct ContentHeaderView: View {
 
             HStack(spacing: 2) {
                 if locationChannelsModel.gatewayEnabled {
-                    Image(systemName: "globe")
-                        .font(.bitchatSystem(size: 12))
-                        .foregroundColor(palette.secondary.opacity(0.8))
-                        .headerTapTarget()
-                        .accessibilityLabel(
-                            String(localized: "content.accessibility.gateway_active", defaultValue: "Internet gateway active, sharing your connection with the mesh", comment: "Accessibility label for the internet gateway indicator")
-                        )
-                        .help(
-                            String(localized: "content.header.gateway_active", defaultValue: "Sharing your internet connection with nearby mesh peers", comment: "Tooltip for the internet gateway indicator")
-                        )
+                    Button(action: { appChromeModel.isLocationChannelsSheetPresented = true }) {
+                        Image(systemName: "globe")
+                            .font(.bitchatSystem(size: 12))
+                            .foregroundColor(palette.secondary.opacity(0.8))
+                            .headerTapTarget()
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        String(localized: "content.accessibility.gateway_active", defaultValue: "Internet gateway active, sharing your connection with the mesh", comment: "Accessibility label for the internet gateway indicator")
+                    )
+                    .accessibilityHint(
+                        String(localized: "content.accessibility.gateway_hint", defaultValue: "Opens channel settings to turn the gateway on or off", comment: "Accessibility hint for the internet gateway indicator explaining a tap opens the channel sheet")
+                    )
+                    .help(
+                        String(localized: "content.header.gateway_active", defaultValue: "Sharing your internet connection with nearby mesh peers", comment: "Tooltip for the internet gateway indicator")
+                    )
                 }
 
                 if carriedMailCount > 0 {


### PR DESCRIPTION
## What

Two header fixes:

**1. The gateway globe is now tappable.** It was a plain `Image` with a tooltip and accessibility label but no tap handler — purely an indicator. It's now a button that opens the location channels sheet, where the gateway toggle lives, so people can turn the gateway on or off directly from the icon that announces it. Adds a VoiceOver hint ("Opens channel settings to turn the gateway on or off") localized into all 29 locales (`needs_review`, machine-translated, matching the catalog's convention), keeping `LocalizationCoverageTests` green.

**2. Deterministic degradation when icons crowd the header.** The icon cluster already protected itself (`layoutPriority(3)`, fixed-size children, 30pt tap targets each), but the `bitchat/` logo and the nickname field both sat at priority 0, so compression was split arbitrarily between them — and the logo, lacking a `lineLimit`, **wrapped to two lines** inside the fixed-height bar. Now the cascade is explicit:

1. the nickname field shrinks and clips first (it's the only flexible priority-0 element);
2. the `@` sigil stays whole as an anchor (`.fixedSize()`);
3. the logo holds its full width until the name is fully collapsed, then truncates on a single line (`lineLimit(1)`, `layoutPriority(2)`);
4. the icons never compress.

## Verification

- Render-verified before/after with an offscreen `ImageRenderer` harness replicating the header's modifier structure at 320/375/500pt with the maximum icon load (globe + courier + envelope + pin + bookmark + geohash badge + people count). Before: logo wraps to two lines at 375pt, entire leading section vanishes at 320pt. After: name collapses first, logo shows `bit…` on one line, icons intact throughout.
- `LocalizationCoverageTests` (3/3) pass on the macOS scheme; macOS build clean.

## Caveat

With all five indicator icons showing at 375pt (smallest supported iPhone width), the protected trailing cluster (~280pt) leaves no room for the nickname at all — the field collapses to zero and only `bit…@` remains. That's inherent to the math, not the cascade. If we ever want the name to survive that state, the lever is shrinking the 30pt per-icon tap targets under pressure, which this PR deliberately leaves alone since they're sized for tappability. Five simultaneous indicators (gateway on + carrying courier mail + unread DM + notices pin + bookmarked geohash) is a rare state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)