### PR TITLE
Fix received DM images stuck as grey box: stamp incoming media delivered, reveal tap as Button

### DIFF
--- a/bitchat/Services/BLE/BLEFileTransferHandler.swift
+++ b/bitchat/Services/BLE/BLEFileTransferHandler.swift
@@ -113,7 +113,13 @@ final class BLEFileTransferHandler {
             originalSender: nil,
             isPrivate: deliveryPlan.isPrivateMessage,
             recipientNickname: nil,
-            senderPeerID: peerID
+            senderPeerID: peerID,
+            // Received messages need an explicit status: BitchatMessage
+            // defaults private messages to .sending, which the media views
+            // render as an in-flight send (empty reveal mask, disabled tap).
+            deliveryStatus: deliveryPlan.isPrivateMessage
+                ? .delivered(to: env.localNickname(), at: ts)
+                : nil
         )
 
         SecureLogger.debug("📁 Stored incoming media from \(peerID.id.prefix(8))… -> \(destination.lastPathComponent)", category: .session)

--- a/bitchat/Views/Media/BlockRevealImageView.swift
+++ b/bitchat/Views/Media/BlockRevealImageView.swift
@@ -74,6 +74,23 @@ struct BlockRevealImageView: View {
             imageContent
         }
         .buttonStyle(.plain)
+        // The cancel control must sit outside the Button label: nested
+        // buttons don't get reliable independent hit testing, and the outer
+        // tap is a no-op while sending — the x could become untappable.
+        .overlay(alignment: .topTrailing) {
+            if let onCancel = onCancel, isSending {
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .font(.bitchatSystem(size: 12, weight: .bold))
+                        .padding(8)
+                        .background(Circle().fill(Color.black.opacity(0.7)))
+                        .foregroundColor(.white)
+                        .padding(8)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Strings.cancelSend)
+            }
+        }
         .simultaneousGesture(hideSwipe)
         .onAppear {
             isBlurred = initiallyBlurred
@@ -117,71 +134,57 @@ struct BlockRevealImageView: View {
         }
     }
 
+    @ViewBuilder
     private var imageContent: some View {
-        ZStack(alignment: .topTrailing) {
-            if let image = platformImage {
-                Image(platformImage: image)
-                    .resizable()
-                    .aspectRatio(aspectRatio, contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                    .overlay(
+        if let image = platformImage {
+            Image(platformImage: image)
+                .resizable()
+                .aspectRatio(aspectRatio, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                )
+                .mask(
+                    BlockRevealMask(
+                        fraction: fraction,
+                        columns: 24,
+                        rows: 16
+                    )
+                    .animation(.easeOut(duration: 0.2), value: fraction)
+                )
+                .blur(radius: isBlurred ? 20 : 0)
+                .overlay {
+                    if isBlurred {
                         RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(Color.gray.opacity(0.2), lineWidth: 1)
-                    )
-                    .mask(
-                        BlockRevealMask(
-                            fraction: fraction,
-                            columns: 24,
-                            rows: 16
-                        )
-                        .animation(.easeOut(duration: 0.2), value: fraction)
-                    )
-                    .blur(radius: isBlurred ? 20 : 0)
-                    .overlay {
-                        if isBlurred {
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color.black.opacity(0.35))
-                                .overlay(
-                                    VStack(spacing: 6) {
-                                        Image(systemName: "eye.slash.fill")
-                                            .font(.bitchatSystem(size: 24, weight: .semibold))
-                                        Text(verbatim: Strings.tapToReveal)
-                                            // Themed: monospaced under matrix,
-                                            // system under liquid glass.
-                                            .bitchatFont(size: 12, weight: .medium)
-                                    }
-                                    .foregroundColor(.white.opacity(0.85))
-                                )
-                        }
+                            .fill(Color.black.opacity(0.35))
+                            .overlay(
+                                VStack(spacing: 6) {
+                                    Image(systemName: "eye.slash.fill")
+                                        .font(.bitchatSystem(size: 24, weight: .semibold))
+                                    Text(verbatim: Strings.tapToReveal)
+                                        // Themed: monospaced under matrix,
+                                        // system under liquid glass.
+                                        .bitchatFont(size: 12, weight: .medium)
+                                }
+                                .foregroundColor(.white.opacity(0.85))
+                            )
                     }
-            } else {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(palette.secondary.opacity(0.2))
-                    .frame(height: 200)
-                    .overlay {
-                        if loadFailed {
-                            Image(systemName: "photo")
-                                .font(.bitchatSystem(size: 24, weight: .semibold))
-                                .foregroundColor(palette.secondary)
-                        } else {
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                        }
-                    }
-            }
-
-            if let onCancel = onCancel, isSending {
-                Button(action: onCancel) {
-                    Image(systemName: "xmark")
-                        .font(.bitchatSystem(size: 12, weight: .bold))
-                        .padding(8)
-                        .background(Circle().fill(Color.black.opacity(0.7)))
-                        .foregroundColor(.white)
-                        .padding(8)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(Strings.cancelSend)
-            }
+        } else {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(palette.secondary.opacity(0.2))
+                .frame(height: 200)
+                .overlay {
+                    if loadFailed {
+                        Image(systemName: "photo")
+                            .font(.bitchatSystem(size: 24, weight: .semibold))
+                            .foregroundColor(palette.secondary)
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                    }
+                }
         }
     }
 

--- a/bitchat/Views/Media/BlockRevealImageView.swift
+++ b/bitchat/Views/Media/BlockRevealImageView.swift
@@ -65,6 +65,59 @@ struct BlockRevealImageView: View {
     }
 
     var body: some View {
+        // The DM sheet wraps the conversation in a high-priority
+        // swipe-to-close DragGesture (ContentSheetViews). An ancestor
+        // high-priority gesture starves descendant TapGestures, but Button
+        // actions still fire — the reveal/open tap must stay a Button or
+        // received DM images become untappable.
+        Button(action: handleTap) {
+            imageContent
+        }
+        .buttonStyle(.plain)
+        .simultaneousGesture(hideSwipe)
+        .onAppear {
+            isBlurred = initiallyBlurred
+            loadImage()
+        }
+        .onChange(of: url) { _ in
+            isBlurred = initiallyBlurred
+            loadImage()
+        }
+        .contextMenu {
+            if isSending {
+                cancelSendAction
+            } else {
+                imageActions
+            }
+        }
+        .confirmationDialog(
+            Strings.deleteConfirmTitle,
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(Strings.delete, role: .destructive) {
+                onDelete?()
+            }
+            Button("common.cancel", role: .cancel) {}
+        } message: {
+            Text(verbatim: Strings.deleteConfirmMessage)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityHint(accessibilityHintText)
+        .accessibilityAddTraits(isSending || loadFailed ? [] : .isButton)
+        .accessibilityActions {
+            if isSending {
+                // children: .ignore collapses the visible cancel button, so
+                // expose it as an action while the send is in flight.
+                cancelSendAction
+            } else {
+                imageActions
+            }
+        }
+    }
+
+    private var imageContent: some View {
         ZStack(alignment: .topTrailing) {
             if let image = platformImage {
                 Image(platformImage: image)
@@ -128,47 +181,6 @@ struct BlockRevealImageView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(Strings.cancelSend)
-            }
-        }
-        .onAppear {
-            isBlurred = initiallyBlurred
-            loadImage()
-        }
-        .onChange(of: url) { _ in
-            isBlurred = initiallyBlurred
-            loadImage()
-        }
-        .gesture(mainGesture)
-        .contextMenu {
-            if isSending {
-                cancelSendAction
-            } else {
-                imageActions
-            }
-        }
-        .confirmationDialog(
-            Strings.deleteConfirmTitle,
-            isPresented: $showDeleteConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button(Strings.delete, role: .destructive) {
-                onDelete?()
-            }
-            Button("common.cancel", role: .cancel) {}
-        } message: {
-            Text(verbatim: Strings.deleteConfirmMessage)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabelText)
-        .accessibilityHint(accessibilityHintText)
-        .accessibilityAddTraits(isSending || loadFailed ? [] : .isButton)
-        .accessibilityActions {
-            if isSending {
-                // children: .ignore collapses the visible cancel button, so
-                // expose it as an action while the send is in flight.
-                cancelSendAction
-            } else {
-                imageActions
             }
         }
     }
@@ -235,18 +247,19 @@ struct BlockRevealImageView: View {
     // photo gesture on mobile, racing the reveal tap, with no confirmation
     // and no way to get the file back. Delete now lives in the context menu
     // behind a confirmation; taps only reveal and open.
-    private var mainGesture: some Gesture {
-        let singleTap = TapGesture().onEnded {
-            guard !isSending, !loadFailed else { return }
-            if isBlurred {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    isBlurred = false
-                }
-            } else {
-                onOpen?()
+    private func handleTap() {
+        guard !isSending, !loadFailed else { return }
+        if isBlurred {
+            withAnimation(.easeOut(duration: 0.2)) {
+                isBlurred = false
             }
+        } else {
+            onOpen?()
         }
-        let swipe = DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { value in
+    }
+
+    private var hideSwipe: some Gesture {
+        DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { value in
             guard !isSending, !loadFailed else { return }
             let horizontal = value.translation.width
             let vertical = value.translation.height
@@ -257,7 +270,6 @@ struct BlockRevealImageView: View {
                 }
             }
         }
-        return singleTap.simultaneously(with: swipe)
     }
 }
 

--- a/bitchat/Views/Media/MediaMessageView.swift
+++ b/bitchat/Views/Media/MediaMessageView.swift
@@ -33,8 +33,8 @@ struct MediaMessageView: View {
     }
 
     var body: some View {
-        let state = mediaSendState(for: deliveryStatus)
         let isFromMe = conversationUIModel.isMediaMessageFromCurrentUser(message)
+        let state = mediaSendState(for: deliveryStatus, isFromMe: isFromMe)
         let cancelAction: (() -> Void)? = state.canCancel ? { conversationUIModel.cancelMediaSend(messageID: message.id) } : nil
 
         // Baseline alignment (via the header text inside the VStack) keeps the
@@ -127,7 +127,11 @@ struct MediaMessageView: View {
         }
     }
 
-    private func mediaSendState(for deliveryStatus: DeliveryStatus?) -> (isSending: Bool, progress: Double?, canCancel: Bool) {
+    private func mediaSendState(for deliveryStatus: DeliveryStatus?, isFromMe: Bool) -> (isSending: Bool, progress: Double?, canCancel: Bool) {
+        // A received message is never in a send state: BitchatMessage defaults
+        // private messages to .sending, so an incoming message's status must
+        // not drive the reveal mask or disable the reveal tap.
+        guard isFromMe else { return (false, nil, false) }
         var isSending = false
         var progress: Double?
         if let status = deliveryStatus {

--- a/bitchatTests/Services/BLEFileTransferHandlerTests.swift
+++ b/bitchatTests/Services/BLEFileTransferHandlerTests.swift
@@ -77,6 +77,7 @@ struct BLEFileTransferHandlerTests {
         #expect(message?.isPrivate == false)
         #expect(message?.senderPeerID == remotePeerID)
         #expect(message?.timestamp == Date(timeIntervalSince1970: 900))
+        #expect(message?.deliveryStatus == nil)
     }
 
     @Test
@@ -157,6 +158,10 @@ struct BLEFileTransferHandlerTests {
         #expect(recorder.lastSeenUpdates == [remotePeerID])
         #expect(recorder.deliveredMessages.count == 1)
         #expect(recorder.deliveredMessages.first?.isPrivate == true)
+        // Must be explicit: BitchatMessage defaults private messages to
+        // .sending, which the media views render as an in-flight send
+        // (empty reveal mask, disabled reveal tap).
+        #expect(recorder.deliveredMessages.first?.deliveryStatus == .delivered(to: "Me", at: Date(timeIntervalSince1970: 900)))
     }
 
     @Test


### PR DESCRIPTION
Fixes #1388

## Root cause (found via on-device testing)

`BitchatMessage`'s initializer defaults every private message without an explicit status to **`.sending`** (`BitchatMessage.swift:74`). `BLEFileTransferHandler` built incoming media messages without one, so every received private image/voice note was permanently "sending". In `MediaMessageView` that meant `mediaSendState` returned `progress = 0` → `BlockRevealMask` rendered **0% of the image** — the "flat grey box" is the blur overlay sitting on an empty mask — and the reveal tap was disabled by the `isSending` guard, regardless of which gesture carried it. This is why the original investigation (data ✓, mask ✓, "fraction=1 for non-sending" ✓) never found it: received messages were assumed to be non-sending.

## Fix

- **`BLEFileTransferHandler`**: incoming private media is now stamped `.delivered(to: <local nickname>, at: <packet time>)`, matching what the received-text path sets (`ChatPrivateConversationCoordinator`). Public media stays `nil`.
- **`MediaMessageView`**: received messages are treated as never-sending, so no other construction path can reproduce the grey-box/dead-tap state.
- **`BlockRevealImageView`**: the reveal/open tap is a plain-style `Button` instead of a raw `TapGesture` (defense against the DM sheet's ancestor `.highPriorityGesture(DragGesture)`, which starves descendant TapGestures but not Button actions), with the in-flight cancel control kept outside the Button label so it hit-tests independently.

## Tests

- `BLEFileTransferHandlerTests`: private delivery now asserts the explicit `.delivered` status; broadcast delivery asserts `nil`.
- Media/BLE suites green; base suite was 1359 green.
- Device verification pending (needs a peer-sent image in a DM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)