### PR TITLE
Fix press-and-hold mic dying instantly in private chats

### DIFF
--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -393,6 +393,11 @@ private struct ContentPrivateChatSheetView: View {
             )
             .themedSurface()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Swipe-right-to-leave lives on the message list only. On the
+            // whole sheet it preempted the composer's press-and-hold mic
+            // gesture (a high-priority ancestor drag cancels child gestures
+            // within milliseconds — same starvation as the image-reveal bug).
+            .highPriorityGesture(swipeToLeaveGesture)
 
             if !theme.usesGlassChrome {
                 Divider()
@@ -423,18 +428,19 @@ private struct ContentPrivateChatSheetView: View {
         }
         .themedSheetBackground()
         .foregroundColor(palette.primary)
-        .highPriorityGesture(
-            DragGesture(minimumDistance: 25, coordinateSpace: .local)
-                .onEnded { value in
-                    let horizontal = value.translation.width
-                    let vertical = abs(value.translation.height)
-                    guard horizontal > 80, vertical < 60 else { return }
-                    withAnimation(.easeInOut(duration: TransportConfig.uiAnimationMediumSeconds)) {
-                        showSidebar = true
-                        privateConversationModel.endConversation()
-                    }
+    }
+
+    private var swipeToLeaveGesture: some Gesture {
+        DragGesture(minimumDistance: 25, coordinateSpace: .local)
+            .onEnded { value in
+                let horizontal = value.translation.width
+                let vertical = abs(value.translation.height)
+                guard horizontal > 80, vertical < 60 else { return }
+                withAnimation(.easeInOut(duration: TransportConfig.uiAnimationMediumSeconds)) {
+                    showSidebar = true
+                    privateConversationModel.endConversation()
                 }
-        )
+            }
     }
 
     /// Persistent one-line reminder that this composer feeds a private


### PR DESCRIPTION
## What

Holding the mic to record a voice note inside a **private chat** cancels within 3–10 ms of touch-down, on both iOS and macOS — voice notes are effectively unrecordable in DMs (they work fine in the public timeline). Found during push-to-talk field testing (#1403/#1404), but this is a standing `main` bug independent of those PRs.

## Why

The private-chat sheet wraps its **entire** content — composer included — in a `.highPriorityGesture` swipe-right-to-leave `DragGesture`. A high-priority ancestor drag preempts child gestures while it evaluates the touch, so the mic button's `DragGesture(minimumDistance: 0)` gets cancelled almost immediately. It's the same starvation mechanism as the DM image-reveal bug (#1402), hitting a drag instead of a tap.

Field-log signature (instrumented build, finger held down the whole time):

```
08:50:53.379  PTT: mic hold began (backend: live)
08:50:53.389  PTT: mic released before recording started (state was requestingPermission)
```

## Fix

Attach the swipe-to-leave gesture to the **message list only** — where users actually swipe — so the composer's gestures (mic hold, text field, attachment/send buttons) are out of its reach. Swipe-to-leave behavior is unchanged over the chat body.

Verified on device (Mac + iPhone): mic hold in a DM now starts recording normally; swipe-right on the message list still leaves the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)