### PR TITLE
Isolate tests from the developer's real login keychain

### DIFF
--- a/bitchat/App/AppRuntime.swift
+++ b/bitchat/App/AppRuntime.swift
@@ -40,7 +40,7 @@ final class AppRuntime: ObservableObject {
     #endif
 
     init(
-        keychain: KeychainManagerProtocol = KeychainManager(),
+        keychain: KeychainManagerProtocol = KeychainManager.makeDefault(),
         idBridge: NostrIdentityBridge = NostrIdentityBridge()
     ) {
         self.idBridge = idBridge

--- a/bitchat/Nostr/NostrIdentityBridge.swift
+++ b/bitchat/Nostr/NostrIdentityBridge.swift
@@ -15,7 +15,7 @@ final class NostrIdentityBridge {
 
     private let keychain: KeychainManagerProtocol
 
-    init(keychain: KeychainManagerProtocol = KeychainManager()) {
+    init(keychain: KeychainManagerProtocol = KeychainManager.makeDefault()) {
         self.keychain = keychain
     }
     
@@ -49,29 +49,10 @@ final class NostrIdentityBridge {
     
     /// Clear all Nostr identity associations and current identity
     func clearAllAssociations() {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        if status == errSecSuccess, let items = result as? [[String: Any]] {
-            for item in items {
-                var deleteQuery: [String: Any] = [
-                    kSecClass as String: kSecClassGenericPassword,
-                    kSecAttrService as String: keychainService
-                ]
-                if let account = item[kSecAttrAccount as String] as? String {
-                    deleteQuery[kSecAttrAccount as String] = account
-                }
-                SecItemDelete(deleteQuery as CFDictionary)
-            }
-        } else if status == errSecItemNotFound {
-            // nothing persisted; no action needed
-        }
+        // Must go through the injected keychain, not raw SecItem calls:
+        // under test that keychain is in-memory, and a direct delete here
+        // would wipe the developer's real Nostr identity on every test run.
+        keychain.deleteAll(service: keychainService)
 
         deviceSeedCache = nil
         // Also drop the in-memory derived per-geohash identities. These hold the

--- a/bitchat/Services/FavoritesPersistenceService.swift
+++ b/bitchat/Services/FavoritesPersistenceService.swift
@@ -34,23 +34,7 @@ final class FavoritesPersistenceService: ObservableObject {
     
     static let shared = FavoritesPersistenceService()
 
-    /// Default keychain for the `shared` singleton. Under test this is an
-    /// in-memory keychain so touching `shared` never blocks on securityd
-    /// (`SecItemCopyMatching` can hang in test environments) and never reads
-    /// or writes the developer's real keychain. Production behavior is
-    /// unchanged. Tests that need their own instance keep injecting a mock
-    /// via `init(keychain:)`.
-    private nonisolated static func makeDefaultKeychain() -> KeychainManagerProtocol {
-        // PreviewKeychainManager lives in _PreviewHelpers, a development
-        // asset excluded from archive builds — release code must not
-        // reference it. Tests always run Debug, so the guard is lossless.
-        #if DEBUG
-        if TestEnvironment.isRunningTests { return PreviewKeychainManager() }
-        #endif
-        return KeychainManager()
-    }
-
-    init(keychain: KeychainManagerProtocol = FavoritesPersistenceService.makeDefaultKeychain()) {
+    init(keychain: KeychainManagerProtocol = KeychainManager.makeDefault()) {
         self.keychain = keychain
         loadFavorites()
         

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -12,6 +12,23 @@ import Foundation
 import Security
 
 final class KeychainManager: KeychainManagerProtocol {
+    /// Default keychain for components that construct their own rather than
+    /// having one injected. Under test this is an in-memory keychain: the
+    /// xctest runner's code signature changes every build, so any read of a
+    /// real login-keychain item triggers a macOS password prompt that
+    /// "Always Allow" can never satisfy — and tests must never read or
+    /// mutate the developer's real keychain (`SecItemCopyMatching` can also
+    /// hang in test environments). Production behavior is unchanged.
+    static func makeDefault() -> KeychainManagerProtocol {
+        // PreviewKeychainManager lives in _PreviewHelpers, a development
+        // asset excluded from archive builds — release code must not
+        // reference it. Tests always run Debug, so the guard is lossless.
+        #if DEBUG
+        if TestEnvironment.isRunningTests { return PreviewKeychainManager() }
+        #endif
+        return KeychainManager()
+    }
+
     // Use consistent service name for all keychain items
     private let service = BitchatApp.bundleID
     private let appGroup = "group.\(BitchatApp.bundleID)"
@@ -539,5 +556,31 @@ final class KeychainManager: KeychainManagerProtocol {
         ]
 
         SecItemDelete(query as CFDictionary)
+    }
+
+    /// Delete every item stored under a custom service
+    func deleteAll(service customService: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: customService,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            return
+        }
+        for item in items {
+            var deleteQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: customService
+            ]
+            if let account = item[kSecAttrAccount as String] as? String {
+                deleteQuery[kSecAttrAccount as String] = account
+            }
+            SecItemDelete(deleteQuery as CFDictionary)
+        }
     }
 }

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -24,10 +24,19 @@ final class KeychainManager: KeychainManagerProtocol {
         // asset excluded from archive builds — release code must not
         // reference it. Tests always run Debug, so the guard is lossless.
         #if DEBUG
-        if TestEnvironment.isRunningTests { return PreviewKeychainManager() }
+        if TestEnvironment.isRunningTests { return sharedTestKeychain }
         #endif
         return KeychainManager()
     }
+
+    #if DEBUG
+    /// One store per process, mirroring the real keychain: separate
+    /// default-constructed components (e.g. two NostrIdentityBridge
+    /// instances in BoardManager's publish and delete paths) must see each
+    /// other's writes, or they would derive different Nostr identities
+    /// under test.
+    private static let sharedTestKeychain = PreviewKeychainManager()
+    #endif
 
     // Use consistent service name for all keychain items
     private let service = BitchatApp.bundleID

--- a/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
+++ b/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
@@ -10,25 +10,37 @@ import BitFoundation
 import Foundation
 
 final class PreviewKeychainManager: KeychainManagerProtocol {
+    // Locked: KeychainManager.makeDefault() hands one shared instance to
+    // every default-constructed component under test, which access it from
+    // arbitrary threads.
+    private let lock = NSLock()
     private var storage: [String: Data] = [:]
     private var serviceStorage: [String: [String: Data]] = [:]
     init() {}
 
     func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         storage[key] = keyData
         return true
     }
 
     func getIdentityKey(forKey key: String) -> Data? {
-        storage[key]
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[key]
     }
 
     func deleteIdentityKey(forKey key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         storage.removeValue(forKey: key)
         return true
     }
 
     func deleteAllKeychainData() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         storage.removeAll()
         serviceStorage.removeAll()
         return true
@@ -39,11 +51,15 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     func secureClear(_ string: inout String) {}
 
     func verifyIdentityKeyExists() -> Bool {
-        storage["identity_noiseStaticKey"] != nil
+        lock.lock()
+        defer { lock.unlock() }
+        return storage["identity_noiseStaticKey"] != nil
     }
 
     // BCH-01-009: New methods with proper error classification
     func getIdentityKeyWithResult(forKey key: String) -> KeychainReadResult {
+        lock.lock()
+        defer { lock.unlock() }
         if let data = storage[key] {
             return .success(data)
         }
@@ -51,6 +67,8 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     }
 
     func saveIdentityKeyWithResult(_ keyData: Data, forKey key: String) -> KeychainSaveResult {
+        lock.lock()
+        defer { lock.unlock() }
         storage[key] = keyData
         return .success
     }
@@ -58,21 +76,26 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     // MARK: - Generic Data Storage (consolidated from KeychainHelper)
 
     func save(key: String, data: Data, service: String, accessible: CFString?) {
-        if serviceStorage[service] == nil {
-            serviceStorage[service] = [:]
-        }
-        serviceStorage[service]?[key] = data
+        lock.lock()
+        defer { lock.unlock() }
+        serviceStorage[service, default: [:]][key] = data
     }
 
     func load(key: String, service: String) -> Data? {
-        serviceStorage[service]?[key]
+        lock.lock()
+        defer { lock.unlock() }
+        return serviceStorage[service]?[key]
     }
 
     func delete(key: String, service: String) {
+        lock.lock()
+        defer { lock.unlock() }
         serviceStorage[service]?.removeValue(forKey: key)
     }
 
     func deleteAll(service: String) {
+        lock.lock()
+        defer { lock.unlock() }
         serviceStorage.removeValue(forKey: service)
     }
 }

--- a/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
+++ b/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
@@ -71,4 +71,8 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
     }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
+    }
 }

--- a/bitchatTests/Mocks/MockKeychain.swift
+++ b/bitchatTests/Mocks/MockKeychain.swift
@@ -85,6 +85,10 @@ final class MockKeychain: KeychainManagerProtocol {
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
     }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
+    }
 }
 
 /// Typealias for backwards compatibility with tests using MockKeychainHelper
@@ -197,5 +201,9 @@ final class TrackingMockKeychain: KeychainManagerProtocol {
 
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
+    }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
     }
 }

--- a/bitchatTests/Services/SecureIdentityStateManagerTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerTests.swift
@@ -496,4 +496,8 @@ private final class FailingCacheSaveKeychain: KeychainManagerProtocol {
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
     }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
+    }
 }

--- a/localPackages/BitFoundation/Sources/BitFoundation/KeychainManagerProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/KeychainManagerProtocol.swift
@@ -34,6 +34,8 @@ public protocol KeychainManagerProtocol {
     func load(key: String, service: String) -> Data?
     /// Delete data from a custom service
     func delete(key: String, service: String)
+    /// Delete every item stored under a custom service
+    func deleteAll(service: String)
 }
 
 // MARK: - Keychain Error Types

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/MockKeychain.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/MockKeychain.swift
@@ -85,6 +85,10 @@ final class MockKeychain: KeychainManagerProtocol {
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
     }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
+    }
 }
 
 /// Typealias for backwards compatibility with tests using MockKeychainHelper
@@ -197,5 +201,9 @@ final class TrackingMockKeychain: KeychainManagerProtocol {
 
     func delete(key: String, service: String) {
         serviceStorage[service]?.removeValue(forKey: key)
+    }
+
+    func deleteAll(service: String) {
+        serviceStorage.removeValue(forKey: service)
     }
 }


### PR DESCRIPTION
## Problem

Running the test suite on macOS triggers repeated login-keychain password prompts for the `chat.bitchat.nostr` item. "Always Allow" never sticks because the xctest runner's code signature changes on every rebuild, so macOS treats each run as a new app.

Worse than the prompts: the panic-mode tests (`panicClearAllData_*`) have been **deleting the developer's real Nostr identity from the login keychain on every test run**, causing silent identity rotation.

Two holes let tests reach the real keychain even though every test injects a mock:

1. `NostrIdentityBridge()` defaulted to the real `KeychainManager`. App-side constructions with no injection point — `LocationNotesManager`'s static bridge, `GeohashPresenceService`, `BoardManager`, `AppRuntime` — read the real `chat.bitchat.nostr` item when exercised under test.
2. `NostrIdentityBridge.clearAllAssociations()` used raw `SecItem*` calls that bypassed the injected keychain entirely.

## Fix

- Centralize `FavoritesPersistenceService`'s existing test-guarded in-memory default as `KeychainManager.makeDefault()` and use it for the default keychain parameters of `NostrIdentityBridge`, `AppRuntime`, and `FavoritesPersistenceService`. Under XCTest/CI it returns a `PreviewKeychainManager`; production behavior unchanged (`#if DEBUG`-guarded, and `_PreviewHelpers` is excluded from archive builds).
- Add `deleteAll(service:)` to `KeychainManagerProtocol` (BitFoundation), implemented in `KeychainManager` with the enumerate-and-delete loop moved out of `clearAllAssociations()`, which now goes through the injected keychain like every other operation. Mock/preview conformers get the trivial in-memory implementation.
- Verified no raw `SecItem*` calls remain anywhere outside `KeychainManager`.

## Testing

- Full SPM suite: 1414 tests in 184 suites, all passing, with **zero keychain prompts** during the run.
- BitFoundation package builds with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)