### PR TITLE
Remove write-only variable left by #1415

### DIFF
--- a/bitchat/ViewModels/ChatLifecycleCoordinator.swift
+++ b/bitchat/ViewModels/ChatLifecycleCoordinator.swift
@@ -215,16 +215,12 @@ final class ChatLifecycleCoordinator {
         }
 
         var noiseKeyHex: PeerID?
-        var peerNostrPubkey: String?
 
         if let noiseKey = Data(hexString: peerID.id),
-           let favoriteStatus = context.favoriteRelationship(forNoiseKey: noiseKey) {
+           context.favoriteRelationship(forNoiseKey: noiseKey) != nil {
             noiseKeyHex = peerID
-            peerNostrPubkey = favoriteStatus.peerNostrPublicKey
         } else if let peer = context.unifiedPeer(for: peerID) {
             noiseKeyHex = PeerID(hexData: peer.noisePublicKey)
-            let favoriteStatus = context.favoriteRelationship(forNoiseKey: peer.noisePublicKey)
-            peerNostrPubkey = favoriteStatus?.peerNostrPublicKey
 
             if let noiseKeyHex, context.unreadPrivateMessages.contains(noiseKeyHex) {
                 context.markPrivateChatRead(noiseKeyHex)


### PR DESCRIPTION
Xcode warning after #1415: `peerNostrPubkey` was written but never read — it only fed the deleted Nostr-key guard. Removed along with the favorites lookup that existed solely to populate it. Lifecycle coordinator tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)