### PR TITLE
PTT hardening: per-peer burst keys + live-capture storage quota

### DIFF
--- a/bitchat/Services/BLE/BLEIncomingFileStore.swift
+++ b/bitchat/Services/BLE/BLEIncomingFileStore.swift
@@ -15,6 +15,18 @@ struct BLEIncomingFileStore {
         self.dateProvider = dateProvider
     }
 
+    /// Whether the store was pointed at an explicit base directory instead
+    /// of the shared application-support root (true for hermetic tests).
+    var hasCustomBaseDirectory: Bool { baseDirectory != nil }
+
+    /// Resolves (and creates) an incoming-media directory for callers that
+    /// write progressively instead of via `save` (live voice captures).
+    func incomingDirectory(subdirectory: String) throws -> URL {
+        let directory = try filesDirectory().appendingPathComponent(subdirectory, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        return directory
+    }
+
     func save(
         data: Data,
         preferredName: String?,
@@ -39,7 +51,11 @@ struct BLEIncomingFileStore {
         }
     }
 
-    func enforceQuota(reservingBytes: Int) {
+    /// Frees least-recently-modified incoming files until `reservingBytes`
+    /// fits under the quota. `excluding` protects files that are still being
+    /// written (in-flight live captures) from eviction; they still count
+    /// toward usage.
+    func enforceQuota(reservingBytes: Int, excluding: Set<URL> = []) {
         do {
             let base = try filesDirectory()
             let incomingDirs = [
@@ -69,9 +85,11 @@ struct BLEIncomingFileStore {
             guard currentUsage > targetUsage else { return }
 
             let needToFree = currentUsage - targetUsage
+            let excludedPaths = Set(excluding.map { $0.standardizedFileURL.path })
             var freedSpace: Int64 = 0
             for file in allFiles.sorted(by: { $0.modified < $1.modified }) {
                 guard freedSpace < needToFree else { break }
+                guard !excludedPaths.contains(file.url.standardizedFileURL.path) else { continue }
                 do {
                     try fileManager.removeItem(at: file.url)
                     freedSpace += file.size

--- a/bitchat/Services/BLE/BLEIncomingFileStore.swift
+++ b/bitchat/Services/BLE/BLEIncomingFileStore.swift
@@ -5,7 +5,16 @@ import Foundation
 struct BLEIncomingFileStore {
     private static let quotaBytes: Int64 = 100 * 1024 * 1024
 
-    private let fileManager: FileManager
+    /// Name prefix of in-flight live voice captures (progressively written by
+    /// `ChatLiveVoiceCoordinator`). Quota eviction skips them by pattern —
+    /// deleting one mid-stream unlinks the inode under an open `FileHandle`
+    /// and kills playback — and the coordinator's startup sweep deletes any
+    /// orphans a previous session left behind.
+    static let liveCapturePrefix = "voice_live_"
+
+    /// Exposed so callers that write progressively into the store's
+    /// directories (live voice captures) share the same file manager.
+    let fileManager: FileManager
     private let baseDirectory: URL?
     private let dateProvider: () -> Date
 
@@ -14,10 +23,6 @@ struct BLEIncomingFileStore {
         self.baseDirectory = baseDirectory
         self.dateProvider = dateProvider
     }
-
-    /// Whether the store was pointed at an explicit base directory instead
-    /// of the shared application-support root (true for hermetic tests).
-    var hasCustomBaseDirectory: Bool { baseDirectory != nil }
 
     /// Resolves (and creates) an incoming-media directory for callers that
     /// write progressively instead of via `save` (live voice captures).
@@ -52,10 +57,11 @@ struct BLEIncomingFileStore {
     }
 
     /// Frees least-recently-modified incoming files until `reservingBytes`
-    /// fits under the quota. `excluding` protects files that are still being
-    /// written (in-flight live captures) from eviction; they still count
-    /// toward usage.
-    func enforceQuota(reservingBytes: Int, excluding: Set<URL> = []) {
+    /// fits under the quota. Files named `voice_live_*` (in-flight live
+    /// captures) are never evicted regardless of who triggers enforcement —
+    /// a finalized transfer can arrive at quota while a burst is still
+    /// streaming — but they still count toward usage.
+    func enforceQuota(reservingBytes: Int) {
         do {
             let base = try filesDirectory()
             let incomingDirs = [
@@ -85,11 +91,10 @@ struct BLEIncomingFileStore {
             guard currentUsage > targetUsage else { return }
 
             let needToFree = currentUsage - targetUsage
-            let excludedPaths = Set(excluding.map { $0.standardizedFileURL.path })
             var freedSpace: Int64 = 0
             for file in allFiles.sorted(by: { $0.modified < $1.modified }) {
                 guard freedSpace < needToFree else { break }
-                guard !excludedPaths.contains(file.url.standardizedFileURL.path) else { continue }
+                guard !file.url.lastPathComponent.hasPrefix(Self.liveCapturePrefix) else { continue }
                 do {
                     try fileManager.removeItem(at: file.url)
                     freedSpace += file.size

--- a/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
+++ b/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
@@ -468,16 +468,22 @@ final class ChatLiveVoiceCoordinator {
         assembly.player?.finishAfterDrain()
         // The bubble's waveform may have been computed from a partial file.
         WaveformCache.shared.purge(url: assembly.fileURL)
-        // Republish so the row re-renders without its LIVE treatment even if
-        // no finalized note ever arrives to swap in.
-        republishBubble(of: assembly)
+        // The capture is the bubble's replayable audio from here on (unless a
+        // finalized note arrives to swap in): move it off its voice_live_
+        // name so only genuinely in-flight files match the startup sweep and
+        // the quota's live-capture guard — a kept fallback is never swept,
+        // and it ages out of the quota like any finalized media.
+        let fileURL = promoteToFallback(assembly.fileURL)
+        // Republish so the row re-renders without its LIVE treatment — and
+        // points at the promoted file — even if no note ever arrives.
+        republishBubble(of: assembly, fileURL: fileURL)
 
         pruneFinishedBursts()
         finishedBursts[assembly.key] = FinishedBurst(
             messageID: assembly.messageID,
             peerID: assembly.peerID,
             scope: assembly.scope,
-            fileURL: assembly.fileURL,
+            fileURL: fileURL,
             messageTimestamp: assembly.messageTimestamp,
             expiresAt: Date().addingTimeInterval(TransportConfig.pttFinishedBurstRegistrySeconds)
         )
@@ -494,12 +500,48 @@ final class ChatLiveVoiceCoordinator {
         }
     }
 
-    private func republishBubble(of assembly: Assembly) {
+    private func republishBubble(of assembly: Assembly, fileURL: URL) {
+        // Same row (same ID), content re-pointed at `fileURL`; the delivery
+        // status is carried over because the inbound pipeline may have
+        // updated it on the shared original.
+        let message = BitchatMessage(
+            id: assembly.messageID,
+            sender: assembly.nickname,
+            content: "\(MimeType.Category.audio.messagePrefix)\(fileURL.lastPathComponent)",
+            timestamp: assembly.messageTimestamp,
+            isRelay: false,
+            isPrivate: assembly.scope == .directMessage,
+            recipientNickname: assembly.scope == .directMessage ? context.nickname : nil,
+            senderPeerID: assembly.peerID,
+            deliveryStatus: assembly.message.deliveryStatus
+        )
         switch assembly.scope {
         case .directMessage:
-            context.upsertPrivateMessage(assembly.message, in: assembly.peerID)
+            context.upsertPrivateMessage(message, in: assembly.peerID)
         case .publicMesh:
-            context.upsertPublicMeshMessage(assembly.message)
+            context.upsertPublicMeshMessage(message)
+        }
+    }
+
+    /// Moves a finished capture off its `voice_live_` prefix (onto plain
+    /// `voice_`), so the in-flight patterns — the startup sweep and the
+    /// quota's eviction guard — only ever match captures still streaming in.
+    /// On failure the live name is kept: worst case the file is reclaimed at
+    /// the next startup, exactly the pre-promotion behavior.
+    private func promoteToFallback(_ liveURL: URL) -> URL {
+        let liveName = liveURL.lastPathComponent
+        guard liveName.hasPrefix(BLEIncomingFileStore.liveCapturePrefix) else { return liveURL }
+        let fallbackName = "voice_" + liveName.dropFirst(BLEIncomingFileStore.liveCapturePrefix.count)
+        let destination = liveURL.deletingLastPathComponent().appendingPathComponent(fallbackName)
+        do {
+            // A leftover from an earlier burst that reused the same
+            // (peer, scope, burstID) triple would block the move.
+            try? fileManager.removeItem(at: destination)
+            try fileManager.moveItem(at: liveURL, to: destination)
+            return destination
+        } catch {
+            SecureLogger.warning("PTT: keeping live-capture name for finished burst — promotion failed: \(error)", category: .session)
+            return liveURL
         }
     }
 
@@ -577,7 +619,12 @@ final class ChatLiveVoiceCoordinator {
 
     /// Deletes partial live captures left behind by a previous session.
     /// In-session cleanup needs no sweep: absorb, cancel, and empty-finalize
-    /// all delete their capture file.
+    /// delete their capture file, and finalize promotes keepers off the
+    /// `voice_live_` name. So anything the sweep matches was orphaned by a
+    /// crash mid-burst — safe to delete, because chat rows are in-memory
+    /// only (ConversationStore never persists; the gossip archive replays
+    /// `MessageType.message` packets only), so no row from a previous
+    /// process can reference the file.
     private func sweepStaleLiveCaptures() {
         guard let directory = try? fileStore.incomingDirectory(subdirectory: Self.incomingSubdirectory),
               let contents = try? fileManager.contentsOfDirectory(

--- a/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
+++ b/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
@@ -59,7 +59,7 @@ extension ChatViewModel: ChatLiveVoiceContext {
 }
 
 /// Where a live voice burst lives: a Noise DM or the public mesh timeline.
-enum VoiceBurstScope: Equatable {
+enum VoiceBurstScope: Hashable {
     case directMessage
     case publicMesh
 }
@@ -72,6 +72,16 @@ enum VoiceBurstScope: Equatable {
 /// bubble so nobody sees a duplicate.
 @MainActor
 final class ChatLiveVoiceCoordinator {
+    /// Burst IDs are sender-chosen, so they only identify a burst *within*
+    /// an authenticated (peer, scope) pair: keying assemblies by the full
+    /// triple stops an attacker who observed a public burst ID from racing
+    /// a START to capture the real talker's frames.
+    private struct AssemblyKey: Hashable {
+        let peerID: PeerID
+        let scope: VoiceBurstScope
+        let burstID: Data
+    }
+
     private final class Assembly {
         let burstID: Data
         let peerID: PeerID
@@ -96,6 +106,8 @@ final class ChatLiveVoiceCoordinator {
         var player: PTTBurstPlayer?
         var idleTimeout: Task<Void, Never>?
         var gapRedrain: Task<Void, Never>?
+
+        var key: AssemblyKey { AssemblyKey(peerID: peerID, scope: scope, burstID: burstID) }
 
         init(burstID: Data, peerID: PeerID, scope: VoiceBurstScope, nickname: String, message: BitchatMessage, fileURL: URL, fileHandle: FileHandle) {
             self.burstID = burstID
@@ -123,11 +135,21 @@ final class ChatLiveVoiceCoordinator {
     private static let finishedBurstsCap = 32
 
     private unowned let context: any ChatLiveVoiceContext
-    private var assemblies: [Data: Assembly] = [:]
-    private var finishedBursts: [Data: FinishedBurst] = [:]
+    private let fileStore: BLEIncomingFileStore
+    private var assemblies: [AssemblyKey: Assembly] = [:]
+    private var finishedBursts: [AssemblyKey: FinishedBurst] = [:]
 
-    init(context: any ChatLiveVoiceContext) {
+    init(context: any ChatLiveVoiceContext, fileStore: BLEIncomingFileStore = BLEIncomingFileStore()) {
         self.context = context
+        self.fileStore = fileStore
+        // Orphaned partial captures from a previous session (live-only bursts
+        // whose finalized note never arrived) are dead weight outside the
+        // quota's accounting — sweep them on startup. Under test, only a
+        // store pointed at its own base directory is swept, so coordinators
+        // sharing the real application-support directory stay hermetic.
+        if !TestEnvironment.isRunningTests || fileStore.hasCustomBaseDirectory {
+            sweepStaleLiveCaptures()
+        }
     }
 
     // MARK: - Inbound frames
@@ -160,11 +182,12 @@ final class ChatLiveVoiceCoordinator {
             return
         }
 
-        if let assembly = assemblies[packet.burstID] {
-            // The sender is authenticated (Noise session or packet
-            // signature); a different peer or scope reusing the same burst
-            // ID is a collision or a replay — drop it.
-            guard assembly.peerID == peerID, assembly.scope == scope else { return }
+        // The sender is authenticated (Noise session or packet signature),
+        // and the key binds the burst ID to that (peer, scope): a colliding
+        // START from another peer opens its own assembly instead of
+        // capturing this one's frames.
+        let key = AssemblyKey(peerID: peerID, scope: scope, burstID: packet.burstID)
+        if let assembly = assemblies[key] {
             apply(packet, to: assembly)
             return
         }
@@ -178,7 +201,7 @@ final class ChatLiveVoiceCoordinator {
                 return
             }
             guard let assembly = makeAssembly(burstID: packet.burstID, peerID: peerID, scope: scope, nickname: nickname, timestamp: timestamp) else { return }
-            assemblies[packet.burstID] = assembly
+            assemblies[key] = assembly
             updatePublicTalkerIndicator()
             apply(packet, to: assembly)
         case .end, .canceled:
@@ -203,17 +226,25 @@ final class ChatLiveVoiceCoordinator {
               let burstID = Self.burstID(fromVoiceFileName: String(message.content.dropFirst(prefix.count)))
         else { return false }
 
+        // Bind the note to the burst's authenticated sender and scope: an
+        // attacker's burst reusing the same ID lives under its own key and
+        // never matches the real sender's note (registry is capped at
+        // `finishedBurstsCap`, so the linear scan is cheap).
+        func matches(_ key: AssemblyKey) -> Bool {
+            key.burstID == burstID
+                && (message.senderPeerID == nil || key.peerID == message.senderPeerID)
+                && message.isPrivate == (key.scope == .directMessage)
+        }
+
         // The note usually lands after END, but a lost END or a fast transfer
         // can beat it — close out the live assembly first.
-        if let assembly = assemblies[burstID] {
+        if let assembly = assemblies.first(where: { matches($0.key) })?.value {
             finalize(assembly)
         }
 
         pruneFinishedBursts()
-        guard let finished = finishedBursts[burstID] else { return false }
-        // Bind the note to the burst's authenticated sender and scope.
-        guard message.senderPeerID == nil || message.senderPeerID == finished.peerID else { return false }
-        guard message.isPrivate == (finished.scope == .directMessage) else { return false }
+        guard let entry = finishedBursts.first(where: { matches($0.key) }) else { return false }
+        let finished = entry.value
 
         let replacement = BitchatMessage(
             id: finished.messageID,
@@ -238,7 +269,7 @@ final class ChatLiveVoiceCoordinator {
         // The complete .m4a replaces the partial live capture.
         WaveformCache.shared.purge(url: finished.fileURL)
         try? FileManager.default.removeItem(at: finished.fileURL)
-        finishedBursts.removeValue(forKey: burstID)
+        finishedBursts.removeValue(forKey: entry.key)
 
         context.notifyUIChanged()
         SecureLogger.debug("PTT: absorbed finalized note for burst \(burstID.hexEncodedString())", category: .session)
@@ -248,10 +279,17 @@ final class ChatLiveVoiceCoordinator {
     // MARK: - Assembly lifecycle
 
     private func makeAssembly(burstID: Data, peerID: PeerID, scope: VoiceBurstScope, nickname: String, timestamp: Date) -> Assembly? {
-        guard let fileURL = Self.makeIncomingURL(burstID: burstID) else {
+        guard let fileURL = makeIncomingURL(burstID: burstID, peerID: peerID) else {
             SecureLogger.error("PTT: cannot resolve incoming media directory for burst \(burstID.hexEncodedString())", category: .session)
             return nil
         }
+        // BCH-01-002: live captures share the incoming-media quota with
+        // finalized transfers; reserve the burst's worst case up front and
+        // never evict a partial that is still streaming in.
+        fileStore.enforceQuota(
+            reservingBytes: TransportConfig.pttMaxBurstBytes,
+            excluding: Set(assemblies.values.map(\.fileURL))
+        )
         FileManager.default.createFile(atPath: fileURL.path, contents: nil)
         guard let handle = try? FileHandle(forWritingTo: fileURL) else {
             SecureLogger.error("PTT: cannot open capture file for burst \(burstID.hexEncodedString())", category: .session)
@@ -413,7 +451,7 @@ final class ChatLiveVoiceCoordinator {
         }
         try? assembly.fileHandle?.close()
         assembly.fileHandle = nil
-        assemblies.removeValue(forKey: assembly.burstID)
+        assemblies.removeValue(forKey: assembly.key)
         updatePublicTalkerIndicator()
 
         guard assembly.deliveredFrames > 0 else {
@@ -432,7 +470,7 @@ final class ChatLiveVoiceCoordinator {
         republishBubble(of: assembly)
 
         pruneFinishedBursts()
-        finishedBursts[assembly.burstID] = FinishedBurst(
+        finishedBursts[assembly.key] = FinishedBurst(
             messageID: assembly.messageID,
             peerID: assembly.peerID,
             scope: assembly.scope,
@@ -468,7 +506,7 @@ final class ChatLiveVoiceCoordinator {
         assembly.player?.stop()
         try? assembly.fileHandle?.close()
         assembly.fileHandle = nil
-        assemblies.removeValue(forKey: assembly.burstID)
+        assemblies.removeValue(forKey: assembly.key)
         updatePublicTalkerIndicator()
         removeBubble(of: assembly)
         WaveformCache.shared.purge(url: assembly.fileURL)
@@ -480,10 +518,10 @@ final class ChatLiveVoiceCoordinator {
 
     private func rescheduleIdleTimeout(for assembly: Assembly) {
         assembly.idleTimeout?.cancel()
-        let burstID = assembly.burstID
+        let key = assembly.key
         assembly.idleTimeout = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(TransportConfig.pttBurstEndTimeoutSeconds * 1_000_000_000))
-            guard !Task.isCancelled, let self, let assembly = self.assemblies[burstID] else { return }
+            guard !Task.isCancelled, let self, let assembly = self.assemblies[key] else { return }
             // Talker went silent/out of range without an END.
             self.finalize(assembly)
         }
@@ -491,10 +529,10 @@ final class ChatLiveVoiceCoordinator {
 
     private func scheduleGapRedrain(for assembly: Assembly) {
         assembly.gapRedrain?.cancel()
-        let burstID = assembly.burstID
+        let key = assembly.key
         assembly.gapRedrain = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: UInt64((Self.gapSkipSeconds + 0.05) * 1_000_000_000))
-            guard !Task.isCancelled, let self, let assembly = self.assemblies[burstID] else { return }
+            guard !Task.isCancelled, let self, let assembly = self.assemblies[key] else { return }
             self.drainInOrder(assembly)
             self.finalizeIfComplete(assembly)
         }
@@ -521,21 +559,29 @@ final class ChatLiveVoiceCoordinator {
         return Data(hexString: hex)
     }
 
-    private static func makeIncomingURL(burstID: Data) -> URL? {
-        guard let base = try? FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        ) else { return nil }
-        let directory = base
-            .appendingPathComponent("files", isDirectory: true)
-            .appendingPathComponent("\(MimeType.Category.audio.mediaDir)/incoming", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
-        } catch {
-            return nil
+    private static let incomingSubdirectory = "\(MimeType.Category.audio.mediaDir)/incoming"
+
+    /// The peer ID in the name keeps colliding burst IDs from different
+    /// senders on distinct files; `burstID(fromVoiceFileName:)` still rejects
+    /// every `voice_live_*` name, so live captures can never absorb a note.
+    private func makeIncomingURL(burstID: Data, peerID: PeerID) -> URL? {
+        guard let directory = try? fileStore.incomingDirectory(subdirectory: Self.incomingSubdirectory) else { return nil }
+        return directory.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peerID.id).aac")
+    }
+
+    /// Deletes partial live captures left behind by a previous session.
+    /// In-session cleanup needs no sweep: absorb, cancel, and empty-finalize
+    /// all delete their capture file.
+    private func sweepStaleLiveCaptures() {
+        guard let directory = try? fileStore.incomingDirectory(subdirectory: Self.incomingSubdirectory),
+              let contents = try? FileManager.default.contentsOfDirectory(
+                  at: directory,
+                  includingPropertiesForKeys: nil,
+                  options: [.skipsHiddenFiles]
+              )
+        else { return }
+        for url in contents where url.lastPathComponent.hasPrefix("voice_live_") && url.pathExtension == "aac" {
+            try? FileManager.default.removeItem(at: url)
         }
-        return directory.appendingPathComponent("voice_live_\(burstID.hexEncodedString()).aac")
     }
 }

--- a/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
+++ b/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
@@ -136,18 +136,23 @@ final class ChatLiveVoiceCoordinator {
 
     private unowned let context: any ChatLiveVoiceContext
     private let fileStore: BLEIncomingFileStore
+    /// Captures live in the store's directories, so file operations go
+    /// through the store's (injectable) file manager.
+    private var fileManager: FileManager { fileStore.fileManager }
     private var assemblies: [AssemblyKey: Assembly] = [:]
     private var finishedBursts: [AssemblyKey: FinishedBurst] = [:]
 
-    init(context: any ChatLiveVoiceContext, fileStore: BLEIncomingFileStore = BLEIncomingFileStore()) {
+    /// `sweepsOnInit` exists for tests whose coordinator shares the real
+    /// application-support directory: they pass `false` so parallel test
+    /// runs never sweep each other's in-flight capture files.
+    init(context: any ChatLiveVoiceContext, fileStore: BLEIncomingFileStore = BLEIncomingFileStore(), sweepsOnInit: Bool = true) {
         self.context = context
         self.fileStore = fileStore
         // Orphaned partial captures from a previous session (live-only bursts
-        // whose finalized note never arrived) are dead weight outside the
-        // quota's accounting — sweep them on startup. Under test, only a
-        // store pointed at its own base directory is swept, so coordinators
-        // sharing the real application-support directory stay hermetic.
-        if !TestEnvironment.isRunningTests || fileStore.hasCustomBaseDirectory {
+        // whose finalized note never arrived) are dead weight the quota can
+        // never reclaim (eviction skips voice_live_* by design) — sweep them
+        // on startup.
+        if sweepsOnInit {
             sweepStaleLiveCaptures()
         }
     }
@@ -268,7 +273,7 @@ final class ChatLiveVoiceCoordinator {
 
         // The complete .m4a replaces the partial live capture.
         WaveformCache.shared.purge(url: finished.fileURL)
-        try? FileManager.default.removeItem(at: finished.fileURL)
+        try? fileManager.removeItem(at: finished.fileURL)
         finishedBursts.removeValue(forKey: entry.key)
 
         context.notifyUIChanged()
@@ -279,21 +284,19 @@ final class ChatLiveVoiceCoordinator {
     // MARK: - Assembly lifecycle
 
     private func makeAssembly(burstID: Data, peerID: PeerID, scope: VoiceBurstScope, nickname: String, timestamp: Date) -> Assembly? {
-        guard let fileURL = makeIncomingURL(burstID: burstID, peerID: peerID) else {
+        guard let fileURL = makeIncomingURL(burstID: burstID, peerID: peerID, scope: scope) else {
             SecureLogger.error("PTT: cannot resolve incoming media directory for burst \(burstID.hexEncodedString())", category: .session)
             return nil
         }
         // BCH-01-002: live captures share the incoming-media quota with
-        // finalized transfers; reserve the burst's worst case up front and
-        // never evict a partial that is still streaming in.
-        fileStore.enforceQuota(
-            reservingBytes: TransportConfig.pttMaxBurstBytes,
-            excluding: Set(assemblies.values.map(\.fileURL))
-        )
-        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+        // finalized transfers; reserve the burst's worst case up front.
+        // Eviction skips voice_live_* names, so partials still streaming in
+        // are safe no matter which caller triggers enforcement.
+        fileStore.enforceQuota(reservingBytes: TransportConfig.pttMaxBurstBytes)
+        fileManager.createFile(atPath: fileURL.path, contents: nil)
         guard let handle = try? FileHandle(forWritingTo: fileURL) else {
             SecureLogger.error("PTT: cannot open capture file for burst \(burstID.hexEncodedString())", category: .session)
-            try? FileManager.default.removeItem(at: fileURL)
+            try? fileManager.removeItem(at: fileURL)
             return nil
         }
 
@@ -457,7 +460,7 @@ final class ChatLiveVoiceCoordinator {
         guard assembly.deliveredFrames > 0 else {
             // Nothing audible ever arrived — drop the empty bubble.
             removeBubble(of: assembly)
-            try? FileManager.default.removeItem(at: assembly.fileURL)
+            try? fileManager.removeItem(at: assembly.fileURL)
             context.notifyUIChanged()
             return
         }
@@ -510,7 +513,7 @@ final class ChatLiveVoiceCoordinator {
         updatePublicTalkerIndicator()
         removeBubble(of: assembly)
         WaveformCache.shared.purge(url: assembly.fileURL)
-        try? FileManager.default.removeItem(at: assembly.fileURL)
+        try? fileManager.removeItem(at: assembly.fileURL)
         context.notifyUIChanged()
     }
 
@@ -561,12 +564,15 @@ final class ChatLiveVoiceCoordinator {
 
     private static let incomingSubdirectory = "\(MimeType.Category.audio.mediaDir)/incoming"
 
-    /// The peer ID in the name keeps colliding burst IDs from different
-    /// senders on distinct files; `burstID(fromVoiceFileName:)` still rejects
-    /// every `voice_live_*` name, so live captures can never absorb a note.
-    private func makeIncomingURL(burstID: Data, peerID: PeerID) -> URL? {
+    /// The peer ID and scope in the name mirror the assembly key: colliding
+    /// burst IDs from different senders — or from the same sender across DM
+    /// and public — land on distinct files instead of truncating each other.
+    /// `burstID(fromVoiceFileName:)` still rejects every `voice_live_*` name,
+    /// so live captures can never absorb a note.
+    private func makeIncomingURL(burstID: Data, peerID: PeerID, scope: VoiceBurstScope) -> URL? {
         guard let directory = try? fileStore.incomingDirectory(subdirectory: Self.incomingSubdirectory) else { return nil }
-        return directory.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peerID.id).aac")
+        let scopeTag = scope == .directMessage ? "dm" : "mesh"
+        return directory.appendingPathComponent("\(BLEIncomingFileStore.liveCapturePrefix)\(burstID.hexEncodedString())_\(peerID.id)_\(scopeTag).aac")
     }
 
     /// Deletes partial live captures left behind by a previous session.
@@ -574,14 +580,14 @@ final class ChatLiveVoiceCoordinator {
     /// all delete their capture file.
     private func sweepStaleLiveCaptures() {
         guard let directory = try? fileStore.incomingDirectory(subdirectory: Self.incomingSubdirectory),
-              let contents = try? FileManager.default.contentsOfDirectory(
+              let contents = try? fileManager.contentsOfDirectory(
                   at: directory,
                   includingPropertiesForKeys: nil,
                   options: [.skipsHiddenFiles]
               )
         else { return }
-        for url in contents where url.lastPathComponent.hasPrefix("voice_live_") && url.pathExtension == "aac" {
-            try? FileManager.default.removeItem(at: url)
+        for url in contents where url.lastPathComponent.hasPrefix(BLEIncomingFileStore.liveCapturePrefix) && url.pathExtension == "aac" {
+            try? fileManager.removeItem(at: url)
         }
     }
 }

--- a/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
+++ b/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
@@ -63,17 +63,36 @@ struct ChatLiveVoiceCoordinatorTests {
         coordinator.handleVoiceFramePayload(from: peerID, payload: packet.encode(), timestamp: Date())
     }
 
-    private func liveCaptureName(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> String {
-        "voice_live_\(burstID.hexEncodedString())_\(peerID.id)_\(scope == .directMessage ? "dm" : "mesh").aac"
+    private func captureSuffix(burstID: Data, peerID: PeerID, scope: VoiceBurstScope) -> String {
+        "\(burstID.hexEncodedString())_\(peerID.id)_\(scope == .directMessage ? "dm" : "mesh").aac"
     }
 
-    private func incomingFileURL(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> URL? {
+    /// Name of a capture still streaming in.
+    private func liveCaptureName(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> String {
+        "voice_live_" + captureSuffix(burstID: burstID, peerID: peerID, scope: scope)
+    }
+
+    /// Name a finished capture is promoted to when it becomes the bubble's
+    /// replayable fallback.
+    private func fallbackName(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> String {
+        "voice_" + captureSuffix(burstID: burstID, peerID: peerID, scope: scope)
+    }
+
+    private func incomingFileURL(named name: String) -> URL? {
         guard let base = try? FileManager.default.url(
             for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false
         ) else { return nil }
         return base
             .appendingPathComponent("files/voicenotes/incoming", isDirectory: true)
-            .appendingPathComponent(liveCaptureName(burstID: burstID, peerID: peerID, scope: scope))
+            .appendingPathComponent(name)
+    }
+
+    private func incomingFileURL(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> URL? {
+        incomingFileURL(named: liveCaptureName(burstID: burstID, peerID: peerID, scope: scope))
+    }
+
+    private func fallbackFileURL(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> URL? {
+        incomingFileURL(named: fallbackName(burstID: burstID, peerID: peerID, scope: scope))
     }
 
     /// Fresh store rooted in its own temp directory so quota/sweep tests
@@ -94,7 +113,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xA1)
-        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
+        defer { fallbackFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
         let frame1 = Data(repeating: 0x01, count: 60)
         let frame2 = Data(repeating: 0x02, count: 60)
@@ -113,15 +132,20 @@ struct ChatLiveVoiceCoordinatorTests {
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([frame1]))), to: coordinator, from: peer)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 3, kind: .end(totalDataPackets: 2, durationMs: 128))), to: coordinator, from: peer)
 
-        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        // The finished capture is promoted off its voice_live_ name.
+        let url = try #require(fallbackFileURL(burstID: burstID, peerID: peer))
         let written = try Data(contentsOf: url)
         var expected = ADTSFramer.frame(frame1)
         expected.append(ADTSFramer.frame(frame2))
         #expect(written == expected)
+        let liveURL = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        #expect(!FileManager.default.fileExists(atPath: liveURL.path))
 
-        // Burst ended: no longer live, bubble republished for re-render.
+        // Burst ended: no longer live, bubble republished pointing at the
+        // promoted file.
         #expect(!coordinator.isLiveVoiceMessage(bubble))
-        #expect(context.upsertedMessages.contains { $0.message.id == bubble.id })
+        let republished = try #require(context.upsertedMessages.last { $0.message.id == bubble.id })
+        #expect(republished.message.content == "[voice] \(fallbackName(burstID: burstID, peerID: peer))")
         #expect(context.removedMessageIDs.isEmpty)
     }
 
@@ -152,7 +176,8 @@ struct ChatLiveVoiceCoordinatorTests {
         #expect(replacement.message.id == bubble.id)
         #expect(replacement.message.content == note.content)
         #expect(replacement.peerID == peer)
-        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        // The promoted partial capture is deleted in favor of the note.
+        let url = try #require(fallbackFileURL(burstID: burstID, peerID: peer))
         #expect(!FileManager.default.fileExists(atPath: url.path))
 
         // Absorption is one-shot.
@@ -268,7 +293,10 @@ struct ChatLiveVoiceCoordinatorTests {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x71)
-        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
+        defer {
+            incomingFileURL(burstID: burstID, peerID: peer, scope: .publicMesh).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: peer, scope: .publicMesh).map { try? FileManager.default.removeItem(at: $0) }
+        }
 
         func sendPublic(_ packet: VoiceBurstPacket) {
             coordinator.handlePublicVoiceFramePayload(from: peer, nickname: "bob", payload: packet.encode(), timestamp: Date())
@@ -306,7 +334,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x72)
-        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
+        defer { fallbackFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
         // A DM burst...
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 4, count: 40)]))), to: coordinator, from: peer)
@@ -339,7 +367,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let burstID = makeBurstID(0x73)
         let attacker = PeerID(str: "ddddeeeeffff0002")
         defer {
-            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
             incomingFileURL(burstID: burstID, peerID: attacker).map { try? FileManager.default.removeItem(at: $0) }
         }
 
@@ -360,7 +388,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let victimFrame = Data(repeating: 0x0A, count: 60)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([victimFrame]))), to: coordinator, from: peer)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
-        let victimURL = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        let victimURL = try #require(fallbackFileURL(burstID: burstID, peerID: peer))
         #expect(try Data(contentsOf: victimURL) == ADTSFramer.frame(victimFrame))
         let attackerURL = try #require(incomingFileURL(burstID: burstID, peerID: attacker))
         #expect((try? Data(contentsOf: attackerURL))?.isEmpty == true)
@@ -373,8 +401,8 @@ struct ChatLiveVoiceCoordinatorTests {
         let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x74)
         defer {
-            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
-            incomingFileURL(burstID: burstID, peerID: peer, scope: .publicMesh).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: peer, scope: .publicMesh).map { try? FileManager.default.removeItem(at: $0) }
         }
 
         // A DM burst and a public burst reusing the same burst ID open
@@ -408,9 +436,9 @@ struct ChatLiveVoiceCoordinatorTests {
 
         // The scope in the file name keeps the two captures on distinct
         // paths: both survive with intact contents instead of one truncating
-        // or deleting the other.
-        let dmURL = try #require(incomingFileURL(burstID: burstID, peerID: peer))
-        let publicURL = try #require(incomingFileURL(burstID: burstID, peerID: peer, scope: .publicMesh))
+        // or deleting the other (both promoted off their live names by now).
+        let dmURL = try #require(fallbackFileURL(burstID: burstID, peerID: peer))
+        let publicURL = try #require(fallbackFileURL(burstID: burstID, peerID: peer, scope: .publicMesh))
         #expect(dmURL != publicURL)
         #expect(try Data(contentsOf: dmURL) == ADTSFramer.frame(dmFrame))
         #expect(try Data(contentsOf: publicURL) == ADTSFramer.frame(publicFrame))
@@ -431,8 +459,8 @@ struct ChatLiveVoiceCoordinatorTests {
         let hex = burstID.hexEncodedString()
         let attacker = PeerID(str: "ddddeeeeffff0002")
         defer {
-            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
-            incomingFileURL(burstID: burstID, peerID: attacker).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            fallbackFileURL(burstID: burstID, peerID: attacker).map { try? FileManager.default.removeItem(at: $0) }
         }
 
         // The attacker's colliding burst finishes FIRST, then the victim's.
@@ -526,17 +554,69 @@ struct ChatLiveVoiceCoordinatorTests {
         let (store, incoming, cleanup) = try makeTempStore()
         defer { cleanup() }
 
-        // A partial capture orphaned by a previous session and a finalized
-        // note that must survive the sweep.
+        // A partial capture orphaned by a previous session; a finalized note
+        // and a promoted fallback capture that must both survive the sweep.
         let stale = incoming.appendingPathComponent("voice_live_00aa00aa00aa00aa_ddddeeeeffff0002_dm.aac")
         let finalized = incoming.appendingPathComponent("voice_00112233445566ff.m4a")
+        let promoted = incoming.appendingPathComponent("voice_00bb00bb00bb00bb_ddddeeeeffff0002_dm.aac")
         try Data([0x01]).write(to: stale)
         try Data([0x02]).write(to: finalized)
+        try Data([0x03]).write(to: promoted)
 
         let context = MockChatLiveVoiceContext()
         _ = ChatLiveVoiceCoordinator(context: context, fileStore: store)
 
         #expect(!FileManager.default.fileExists(atPath: stale.path))
         #expect(FileManager.default.fileExists(atPath: finalized.path))
+        #expect(FileManager.default.fileExists(atPath: promoted.path))
+    }
+
+    @Test func finalizedFallbackSurvivesNextStartupSweep() throws {
+        let (store, incoming, cleanup) = try makeTempStore()
+        defer { cleanup() }
+
+        // A burst finishes without its finalized note (live-only burst or
+        // sender out of range): the capture is the row's only audio.
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context, fileStore: store)
+        let burstID = makeBurstID(0x79)
+        let frame = Data(repeating: 0x0B, count: 60)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([frame]))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
+
+        // The republished row points at the promoted (non-live) name, and
+        // that file holds the burst's audio.
+        let republished = try #require(context.upsertedMessages.last)
+        #expect(republished.message.content == "[voice] \(fallbackName(burstID: burstID, peerID: peer))")
+        let fallbackURL = incoming.appendingPathComponent(fallbackName(burstID: burstID, peerID: peer))
+        #expect(try Data(contentsOf: fallbackURL) == ADTSFramer.frame(frame))
+
+        // A later coordinator startup (same store) sweeps in-flight partials
+        // only: the row's fallback audio must survive and stay playable.
+        _ = ChatLiveVoiceCoordinator(context: MockChatLiveVoiceContext(), fileStore: store)
+        #expect(try Data(contentsOf: fallbackURL) == ADTSFramer.frame(frame))
+    }
+
+    @Test func promotedFallbackIsQuotaEvictable() throws {
+        let (store, incoming, cleanup) = try makeTempStore()
+        defer { cleanup() }
+
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context, fileStore: store)
+        let burstID = makeBurstID(0x7A)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 0x0C, count: 60)]))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
+        let fallbackURL = incoming.appendingPathComponent(fallbackName(burstID: burstID, peerID: peer))
+        #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
+
+        // Once promoted, the capture is ordinary finalized media: as the
+        // LRU-oldest file it is evicted, not skipped, when quota pressure
+        // arrives.
+        try setModificationDate(Date(timeIntervalSinceNow: -7200), at: fallbackURL)
+        let bigURL = incoming.appendingPathComponent("voice_big.m4a")
+        try Data(count: 105 * 1024 * 1024).write(to: bigURL)
+        store.enforceQuota(reservingBytes: 0)
+
+        #expect(!FileManager.default.fileExists(atPath: fallbackURL.path))
     }
 }

--- a/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
+++ b/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
@@ -63,20 +63,34 @@ struct ChatLiveVoiceCoordinatorTests {
         coordinator.handleVoiceFramePayload(from: peerID, payload: packet.encode(), timestamp: Date())
     }
 
-    private func incomingFileURL(burstID: Data) -> URL? {
+    private func incomingFileURL(burstID: Data, peerID: PeerID) -> URL? {
         guard let base = try? FileManager.default.url(
             for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false
         ) else { return nil }
         return base
             .appendingPathComponent("files/voicenotes/incoming", isDirectory: true)
-            .appendingPathComponent("voice_live_\(burstID.hexEncodedString()).aac")
+            .appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peerID.id).aac")
+    }
+
+    /// Fresh store rooted in its own temp directory so quota/sweep tests
+    /// never touch the shared application-support media directories.
+    private func makeTempStore() throws -> (store: BLEIncomingFileStore, incoming: URL, cleanup: () -> Void) {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ptt-store-\(UUID().uuidString)", isDirectory: true)
+        let store = BLEIncomingFileStore(baseDirectory: base)
+        let incoming = try store.incomingDirectory(subdirectory: "voicenotes/incoming")
+        return (store, incoming, { try? FileManager.default.removeItem(at: base) })
+    }
+
+    private func setModificationDate(_ date: Date, at url: URL) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
     }
 
     @Test func burstCreatesBubbleAndPersistsFramesInOrder() throws {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context)
         let burstID = makeBurstID(0xA1)
-        defer { incomingFileURL(burstID: burstID).map { try? FileManager.default.removeItem(at: $0) } }
+        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
         let frame1 = Data(repeating: 0x01, count: 60)
         let frame2 = Data(repeating: 0x02, count: 60)
@@ -86,7 +100,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let bubble = try #require(context.handledPrivateMessages.first)
         #expect(bubble.isPrivate)
         #expect(bubble.senderPeerID == peer)
-        #expect(bubble.content == "[voice] voice_live_\(burstID.hexEncodedString()).aac")
+        #expect(bubble.content == "[voice] voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
         #expect(coordinator.isLiveVoiceMessage(bubble))
 
         // Deliver out of order: seq 2 buffers behind the seq-1 hole, then
@@ -95,7 +109,7 @@ struct ChatLiveVoiceCoordinatorTests {
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([frame1]))), to: coordinator, from: peer)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 3, kind: .end(totalDataPackets: 2, durationMs: 128))), to: coordinator, from: peer)
 
-        let url = try #require(incomingFileURL(burstID: burstID))
+        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
         let written = try Data(contentsOf: url)
         var expected = ADTSFramer.frame(frame1)
         expected.append(ADTSFramer.frame(frame2))
@@ -134,7 +148,7 @@ struct ChatLiveVoiceCoordinatorTests {
         #expect(replacement.message.id == bubble.id)
         #expect(replacement.message.content == note.content)
         #expect(replacement.peerID == peer)
-        let url = try #require(incomingFileURL(burstID: burstID))
+        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
         #expect(!FileManager.default.fileExists(atPath: url.path))
 
         // Absorption is one-shot.
@@ -175,7 +189,7 @@ struct ChatLiveVoiceCoordinatorTests {
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .canceled)), to: coordinator, from: peer)
 
         #expect(context.removedMessageIDs == [bubble.id])
-        let url = try #require(incomingFileURL(burstID: burstID))
+        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
         #expect(!FileManager.default.fileExists(atPath: url.path))
         #expect(!coordinator.isLiveVoiceMessage(bubble))
     }
@@ -215,7 +229,7 @@ struct ChatLiveVoiceCoordinatorTests {
         var cleanup: [Data] = []
         defer {
             for burstID in cleanup {
-                incomingFileURL(burstID: burstID).map { try? FileManager.default.removeItem(at: $0) }
+                incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
             }
         }
         for i in 0..<TransportConfig.pttMaxConcurrentAssemblies {
@@ -242,7 +256,7 @@ struct ChatLiveVoiceCoordinatorTests {
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 5, count: 40)]))), to: coordinator, from: peer)
         #expect(context.handledPrivateMessages.isEmpty)
-        let url = try #require(incomingFileURL(burstID: burstID))
+        let url = try #require(incomingFileURL(burstID: burstID, peerID: peer))
         #expect(!FileManager.default.fileExists(atPath: url.path))
     }
 
@@ -250,7 +264,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context)
         let burstID = makeBurstID(0x71)
-        defer { incomingFileURL(burstID: burstID).map { try? FileManager.default.removeItem(at: $0) } }
+        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
         func sendPublic(_ packet: VoiceBurstPacket) {
             coordinator.handlePublicVoiceFramePayload(from: peer, nickname: "bob", payload: packet.encode(), timestamp: Date())
@@ -288,7 +302,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let context = MockChatLiveVoiceContext()
         let coordinator = ChatLiveVoiceCoordinator(context: context)
         let burstID = makeBurstID(0x72)
-        defer { incomingFileURL(burstID: burstID).map { try? FileManager.default.removeItem(at: $0) } }
+        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
         // A DM burst...
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 4, count: 40)]))), to: coordinator, from: peer)
@@ -308,6 +322,201 @@ struct ChatLiveVoiceCoordinatorTests {
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_00112233445566ff (1).m4a") == Data(hexString: "00112233445566ff"))
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_20260708_120000.m4a") == nil)
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff.aac") == nil)
+        // Per-peer live capture names must stay unabsorbable too.
+        #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff_aaaabbbbcccc0001.aac") == nil)
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "other.m4a") == nil)
+    }
+
+    @Test func collidingBurstIDFromAnotherPeerCannotHijackAssembly() throws {
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let burstID = makeBurstID(0x73)
+        let attacker = PeerID(str: "ddddeeeeffff0002")
+        defer {
+            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            incomingFileURL(burstID: burstID, peerID: attacker).map { try? FileManager.default.removeItem(at: $0) }
+        }
+
+        // The victim starts a burst; the attacker races a START reusing the
+        // observed burst ID from a different peer.
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: attacker)
+
+        // Two distinct bubbles on two distinct files — no capture.
+        #expect(context.handledPrivateMessages.count == 2)
+        let victimBubble = try #require(context.handledPrivateMessages.first)
+        let attackerBubble = try #require(context.handledPrivateMessages.last)
+        #expect(victimBubble.id != attackerBubble.id)
+        #expect(victimBubble.content != attackerBubble.content)
+
+        // The victim's frames still land in the victim's file, untouched by
+        // the attacker's assembly.
+        let victimFrame = Data(repeating: 0x0A, count: 60)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([victimFrame]))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
+        let victimURL = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        #expect(try Data(contentsOf: victimURL) == ADTSFramer.frame(victimFrame))
+        let attackerURL = try #require(incomingFileURL(burstID: burstID, peerID: attacker))
+        #expect((try? Data(contentsOf: attackerURL))?.isEmpty == true)
+        #expect(!coordinator.isLiveVoiceMessage(victimBubble))
+        #expect(coordinator.isLiveVoiceMessage(attackerBubble))
+    }
+
+    @Test func sameBurstIDCoexistsAcrossScopes() throws {
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let burstID = makeBurstID(0x74)
+        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
+
+        // A DM burst and a public burst reusing the same burst ID open
+        // independent assemblies instead of colliding.
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 6, count: 50)]))), to: coordinator, from: peer)
+        coordinator.handlePublicVoiceFramePayload(
+            from: peer,
+            nickname: "bob",
+            payload: try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 7, count: 50)]))).encode(),
+            timestamp: Date()
+        )
+        #expect(context.handledPrivateMessages.count == 1)
+        #expect(context.appendedPublicMessages.count == 1)
+        let dmBubble = try #require(context.handledPrivateMessages.first)
+        let publicBubble = try #require(context.appendedPublicMessages.first)
+
+        // Ending the public burst leaves the DM assembly live.
+        coordinator.handlePublicVoiceFramePayload(
+            from: peer,
+            nickname: "bob",
+            payload: try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))).encode(),
+            timestamp: Date()
+        )
+        #expect(!coordinator.isLiveVoiceMessage(publicBubble))
+        #expect(coordinator.isLiveVoiceMessage(dmBubble))
+
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
+        #expect(!coordinator.isLiveVoiceMessage(dmBubble))
+
+        // Absorption still routes each note by its scope.
+        let dmNote = BitchatMessage(
+            sender: "alice", content: "[voice] voice_\(burstID.hexEncodedString()).m4a", timestamp: Date(),
+            isRelay: false, isPrivate: true, recipientNickname: "me", senderPeerID: peer
+        )
+        #expect(coordinator.absorbFinalizedVoiceNote(dmNote))
+        #expect(try #require(context.upsertedMessages.last).message.id == dmBubble.id)
+    }
+
+    @Test func finalizedNoteBindsToItsAuthenticatedSender() throws {
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let burstID = makeBurstID(0x75)
+        let hex = burstID.hexEncodedString()
+        let attacker = PeerID(str: "ddddeeeeffff0002")
+        defer {
+            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            incomingFileURL(burstID: burstID, peerID: attacker).map { try? FileManager.default.removeItem(at: $0) }
+        }
+
+        // The attacker's colliding burst finishes FIRST, then the victim's.
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 1, count: 40)]))), to: coordinator, from: attacker)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: attacker)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 2, count: 40)]))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
+        #expect(context.handledPrivateMessages.count == 2)
+        let attackerBubble = try #require(context.handledPrivateMessages.first)
+        let victimBubble = try #require(context.handledPrivateMessages.last)
+
+        // The real sender's note absorbs into the real sender's bubble.
+        let note = BitchatMessage(
+            sender: "alice", content: "[voice] voice_\(hex).m4a", timestamp: Date(),
+            isRelay: false, isPrivate: true, recipientNickname: "me", senderPeerID: peer
+        )
+        #expect(coordinator.absorbFinalizedVoiceNote(note))
+        let replacement = try #require(context.upsertedMessages.last)
+        #expect(replacement.message.id == victimBubble.id)
+        #expect(replacement.peerID == peer)
+
+        // The attacker's note can only ever claim the attacker's own bubble.
+        let attackerNote = BitchatMessage(
+            sender: "mallory", content: "[voice] voice_\(hex).m4a", timestamp: Date(),
+            isRelay: false, isPrivate: true, recipientNickname: "me", senderPeerID: attacker
+        )
+        #expect(coordinator.absorbFinalizedVoiceNote(attackerNote))
+        let attackerReplacement = try #require(context.upsertedMessages.last)
+        #expect(attackerReplacement.message.id == attackerBubble.id)
+        #expect(attackerReplacement.peerID == attacker)
+
+        // Both registry entries are consumed — nothing left to hijack.
+        #expect(!coordinator.absorbFinalizedVoiceNote(note))
+    }
+
+    @Test func liveBurstEnforcesIncomingMediaQuota() throws {
+        let (store, incoming, cleanup) = try makeTempStore()
+        defer { cleanup() }
+
+        // Pre-seed enough finalized media that the burst's reservation pushes
+        // usage over the 100 MB quota: the oldest file must be evicted.
+        let oldURL = incoming.appendingPathComponent("voice_old.m4a")
+        let newURL = incoming.appendingPathComponent("voice_new.m4a")
+        try Data(count: 60 * 1024 * 1024).write(to: oldURL)
+        try Data(count: 45 * 1024 * 1024).write(to: newURL)
+        try setModificationDate(Date(timeIntervalSinceNow: -3600), at: oldURL)
+        try setModificationDate(Date(timeIntervalSinceNow: -60), at: newURL)
+
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context, fileStore: store)
+        let burstID = makeBurstID(0x76)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
+
+        // Oldest evicted, newer survivor + reservation fit under the quota,
+        // and the capture file lives under the injected store's base.
+        #expect(!FileManager.default.fileExists(atPath: oldURL.path))
+        #expect(FileManager.default.fileExists(atPath: newURL.path))
+        let liveURL = incoming.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
+        #expect(FileManager.default.fileExists(atPath: liveURL.path))
+        let remaining = try FileManager.default.contentsOfDirectory(at: incoming, includingPropertiesForKeys: [.fileSizeKey])
+            .compactMap { try $0.resourceValues(forKeys: [.fileSizeKey]).fileSize }
+            .reduce(0, +)
+        #expect(remaining + TransportConfig.pttMaxBurstBytes <= 100 * 1024 * 1024)
+    }
+
+    @Test func inFlightLiveCaptureIsNeverEvicted() throws {
+        let (store, incoming, cleanup) = try makeTempStore()
+        defer { cleanup() }
+
+        let context = MockChatLiveVoiceContext()
+        let coordinator = ChatLiveVoiceCoordinator(context: context, fileStore: store)
+        let burstID = makeBurstID(0x77)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 8, count: 60)]))), to: coordinator, from: peer)
+        let liveURL = incoming.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
+        #expect(FileManager.default.fileExists(atPath: liveURL.path))
+
+        // Make the streaming partial the LRU-oldest candidate, then blow the
+        // quota and open a second burst to trigger eviction.
+        try setModificationDate(Date(timeIntervalSinceNow: -7200), at: liveURL)
+        let bigURL = incoming.appendingPathComponent("voice_big.m4a")
+        try Data(count: 105 * 1024 * 1024).write(to: bigURL)
+        send(try #require(VoiceBurstPacket(burstID: makeBurstID(0x78), seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
+
+        // Eviction skipped the in-flight partial and deleted the big file.
+        #expect(FileManager.default.fileExists(atPath: liveURL.path))
+        #expect(!FileManager.default.fileExists(atPath: bigURL.path))
+    }
+
+    @Test func startupSweepRemovesStaleLiveCapturesOnly() throws {
+        let (store, incoming, cleanup) = try makeTempStore()
+        defer { cleanup() }
+
+        // A partial capture orphaned by a previous session and a finalized
+        // note that must survive the sweep.
+        let stale = incoming.appendingPathComponent("voice_live_00aa00aa00aa00aa_ddddeeeeffff0002.aac")
+        let finalized = incoming.appendingPathComponent("voice_00112233445566ff.m4a")
+        try Data([0x01]).write(to: stale)
+        try Data([0x02]).write(to: finalized)
+
+        let context = MockChatLiveVoiceContext()
+        _ = ChatLiveVoiceCoordinator(context: context, fileStore: store)
+
+        #expect(!FileManager.default.fileExists(atPath: stale.path))
+        #expect(FileManager.default.fileExists(atPath: finalized.path))
     }
 }

--- a/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
+++ b/bitchatTests/ChatLiveVoiceCoordinatorTests.swift
@@ -63,13 +63,17 @@ struct ChatLiveVoiceCoordinatorTests {
         coordinator.handleVoiceFramePayload(from: peerID, payload: packet.encode(), timestamp: Date())
     }
 
-    private func incomingFileURL(burstID: Data, peerID: PeerID) -> URL? {
+    private func liveCaptureName(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> String {
+        "voice_live_\(burstID.hexEncodedString())_\(peerID.id)_\(scope == .directMessage ? "dm" : "mesh").aac"
+    }
+
+    private func incomingFileURL(burstID: Data, peerID: PeerID, scope: VoiceBurstScope = .directMessage) -> URL? {
         guard let base = try? FileManager.default.url(
             for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false
         ) else { return nil }
         return base
             .appendingPathComponent("files/voicenotes/incoming", isDirectory: true)
-            .appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peerID.id).aac")
+            .appendingPathComponent(liveCaptureName(burstID: burstID, peerID: peerID, scope: scope))
     }
 
     /// Fresh store rooted in its own temp directory so quota/sweep tests
@@ -88,7 +92,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func burstCreatesBubbleAndPersistsFramesInOrder() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xA1)
         defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
@@ -100,7 +104,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let bubble = try #require(context.handledPrivateMessages.first)
         #expect(bubble.isPrivate)
         #expect(bubble.senderPeerID == peer)
-        #expect(bubble.content == "[voice] voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
+        #expect(bubble.content == "[voice] voice_live_\(burstID.hexEncodedString())_\(peer.id)_dm.aac")
         #expect(coordinator.isLiveVoiceMessage(bubble))
 
         // Deliver out of order: seq 2 buffers behind the seq-1 hole, then
@@ -123,7 +127,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func absorbsFinalizedNoteIntoLiveBubble() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xB2)
         let hex = burstID.hexEncodedString()
 
@@ -157,7 +161,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func absorbIgnoresUnrelatedVoiceNotes() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
 
         // A classic voice note (date-stamped name) and a live-capture name
         // must both pass through untouched.
@@ -181,7 +185,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func canceledBurstRemovesBubbleAndFile() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xC3)
 
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 9, count: 40)]))), to: coordinator, from: peer)
@@ -196,7 +200,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func emptyBurstLeavesNoBubble() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xD4)
 
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
@@ -209,7 +213,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func ignoresBlockedPeersAndUnknownControlPackets() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
 
         context.blockedPeers = [peer]
         send(try #require(VoiceBurstPacket(burstID: makeBurstID(0xE5), seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
@@ -224,7 +228,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func concurrentAssemblyCapDropsExtraBursts() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
 
         var cleanup: [Data] = []
         defer {
@@ -249,7 +253,7 @@ struct ChatLiveVoiceCoordinatorTests {
         defer { PTTSettings.liveVoiceEnabled = previous }
 
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0xE8)
 
         // Off means classic-notes-only: no live bubble, no partial file.
@@ -262,7 +266,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func publicBurstCreatesMeshBubbleAndTracksTalker() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x71)
         defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
@@ -300,7 +304,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func absorbEnforcesScopeBinding() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x72)
         defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
 
@@ -322,14 +326,16 @@ struct ChatLiveVoiceCoordinatorTests {
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_00112233445566ff (1).m4a") == Data(hexString: "00112233445566ff"))
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_20260708_120000.m4a") == nil)
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff.aac") == nil)
-        // Per-peer live capture names must stay unabsorbable too.
+        // Per-peer, per-scope live capture names must stay unabsorbable too.
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff_aaaabbbbcccc0001.aac") == nil)
+        #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff_aaaabbbbcccc0001_dm.aac") == nil)
+        #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "voice_live_00112233445566ff_aaaabbbbcccc0001_mesh.aac") == nil)
         #expect(ChatLiveVoiceCoordinator.burstID(fromVoiceFileName: "other.m4a") == nil)
     }
 
     @Test func collidingBurstIDFromAnotherPeerCannotHijackAssembly() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x73)
         let attacker = PeerID(str: "ddddeeeeffff0002")
         defer {
@@ -364,17 +370,22 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func sameBurstIDCoexistsAcrossScopes() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x74)
-        defer { incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) } }
+        defer {
+            incomingFileURL(burstID: burstID, peerID: peer).map { try? FileManager.default.removeItem(at: $0) }
+            incomingFileURL(burstID: burstID, peerID: peer, scope: .publicMesh).map { try? FileManager.default.removeItem(at: $0) }
+        }
 
         // A DM burst and a public burst reusing the same burst ID open
         // independent assemblies instead of colliding.
-        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 6, count: 50)]))), to: coordinator, from: peer)
+        let dmFrame = Data(repeating: 6, count: 50)
+        let publicFrame = Data(repeating: 7, count: 50)
+        send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([dmFrame]))), to: coordinator, from: peer)
         coordinator.handlePublicVoiceFramePayload(
             from: peer,
             nickname: "bob",
-            payload: try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 7, count: 50)]))).encode(),
+            payload: try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([publicFrame]))).encode(),
             timestamp: Date()
         )
         #expect(context.handledPrivateMessages.count == 1)
@@ -395,6 +406,15 @@ struct ChatLiveVoiceCoordinatorTests {
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 2, kind: .end(totalDataPackets: 1, durationMs: 64))), to: coordinator, from: peer)
         #expect(!coordinator.isLiveVoiceMessage(dmBubble))
 
+        // The scope in the file name keeps the two captures on distinct
+        // paths: both survive with intact contents instead of one truncating
+        // or deleting the other.
+        let dmURL = try #require(incomingFileURL(burstID: burstID, peerID: peer))
+        let publicURL = try #require(incomingFileURL(burstID: burstID, peerID: peer, scope: .publicMesh))
+        #expect(dmURL != publicURL)
+        #expect(try Data(contentsOf: dmURL) == ADTSFramer.frame(dmFrame))
+        #expect(try Data(contentsOf: publicURL) == ADTSFramer.frame(publicFrame))
+
         // Absorption still routes each note by its scope.
         let dmNote = BitchatMessage(
             sender: "alice", content: "[voice] voice_\(burstID.hexEncodedString()).m4a", timestamp: Date(),
@@ -406,7 +426,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
     @Test func finalizedNoteBindsToItsAuthenticatedSender() throws {
         let context = MockChatLiveVoiceContext()
-        let coordinator = ChatLiveVoiceCoordinator(context: context)
+        let coordinator = ChatLiveVoiceCoordinator(context: context, sweepsOnInit: false)
         let burstID = makeBurstID(0x75)
         let hex = burstID.hexEncodedString()
         let attacker = PeerID(str: "ddddeeeeffff0002")
@@ -470,7 +490,7 @@ struct ChatLiveVoiceCoordinatorTests {
         // and the capture file lives under the injected store's base.
         #expect(!FileManager.default.fileExists(atPath: oldURL.path))
         #expect(FileManager.default.fileExists(atPath: newURL.path))
-        let liveURL = incoming.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
+        let liveURL = incoming.appendingPathComponent(liveCaptureName(burstID: burstID, peerID: peer))
         #expect(FileManager.default.fileExists(atPath: liveURL.path))
         let remaining = try FileManager.default.contentsOfDirectory(at: incoming, includingPropertiesForKeys: [.fileSizeKey])
             .compactMap { try $0.resourceValues(forKeys: [.fileSizeKey]).fileSize }
@@ -487,7 +507,7 @@ struct ChatLiveVoiceCoordinatorTests {
         let burstID = makeBurstID(0x77)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 0, kind: .start(codec: .aacLC16kMono))), to: coordinator, from: peer)
         send(try #require(VoiceBurstPacket(burstID: burstID, seq: 1, kind: .frames([Data(repeating: 8, count: 60)]))), to: coordinator, from: peer)
-        let liveURL = incoming.appendingPathComponent("voice_live_\(burstID.hexEncodedString())_\(peer.id).aac")
+        let liveURL = incoming.appendingPathComponent(liveCaptureName(burstID: burstID, peerID: peer))
         #expect(FileManager.default.fileExists(atPath: liveURL.path))
 
         // Make the streaming partial the LRU-oldest candidate, then blow the
@@ -508,7 +528,7 @@ struct ChatLiveVoiceCoordinatorTests {
 
         // A partial capture orphaned by a previous session and a finalized
         // note that must survive the sweep.
-        let stale = incoming.appendingPathComponent("voice_live_00aa00aa00aa00aa_ddddeeeeffff0002.aac")
+        let stale = incoming.appendingPathComponent("voice_live_00aa00aa00aa00aa_ddddeeeeffff0002_dm.aac")
         let finalized = incoming.appendingPathComponent("voice_00112233445566ff.m4a")
         try Data([0x01]).write(to: stale)
         try Data([0x02]).write(to: finalized)

--- a/bitchatTests/Services/BLEFileTransferHandlerTests.swift
+++ b/bitchatTests/Services/BLEFileTransferHandlerTests.swift
@@ -343,24 +343,28 @@ struct BLEFileTransferHandlerTests {
     }
 
     @Test
-    func quotaEvictionSkipsExcludedInFlightFiles() throws {
+    func quotaEvictionForFinalizedArrivalSkipsInFlightLiveCaptures() throws {
         let base = FileManager.default.temporaryDirectory
-            .appendingPathComponent("quota-excluding-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("quota-live-capture-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: base) }
         let store = BLEIncomingFileStore(baseDirectory: base)
         let incoming = try store.incomingDirectory(subdirectory: "voicenotes/incoming")
 
         // The in-flight partial is the LRU-oldest eviction candidate; without
-        // the exclusion it would be deleted first.
-        let inFlight = incoming.appendingPathComponent("voice_live_00112233445566ff_1122334455667788.aac")
+        // the voice_live_ pattern guard it would be deleted first, unlinking
+        // the inode under the coordinator's open FileHandle.
+        let inFlight = incoming.appendingPathComponent("voice_live_00112233445566ff_1122334455667788_dm.aac")
         let evictable = incoming.appendingPathComponent("voice_old.m4a")
         try Data(count: 51 * 1024 * 1024).write(to: inFlight)
         try Data(count: 51 * 1024 * 1024).write(to: evictable)
         try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -7200)], ofItemAtPath: inFlight.path)
         try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -60)], ofItemAtPath: evictable.path)
 
-        // 102 MB used against the 100 MB quota forces one eviction.
-        store.enforceQuota(reservingBytes: 0, excluding: [inFlight])
+        // 102 MB used against the 100 MB quota forces one eviction. This is
+        // the finalized-file arrival path (BLEFileTransferHandler via
+        // BLEService), which knows nothing about in-flight captures — the
+        // store itself must protect them.
+        store.enforceQuota(reservingBytes: 0)
 
         #expect(FileManager.default.fileExists(atPath: inFlight.path))
         #expect(!FileManager.default.fileExists(atPath: evictable.path))

--- a/bitchatTests/Services/BLEFileTransferHandlerTests.swift
+++ b/bitchatTests/Services/BLEFileTransferHandlerTests.swift
@@ -342,6 +342,30 @@ struct BLEFileTransferHandlerTests {
         #expect(recorder.deliveredMessages.isEmpty)
     }
 
+    @Test
+    func quotaEvictionSkipsExcludedInFlightFiles() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-excluding-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let store = BLEIncomingFileStore(baseDirectory: base)
+        let incoming = try store.incomingDirectory(subdirectory: "voicenotes/incoming")
+
+        // The in-flight partial is the LRU-oldest eviction candidate; without
+        // the exclusion it would be deleted first.
+        let inFlight = incoming.appendingPathComponent("voice_live_00112233445566ff_1122334455667788.aac")
+        let evictable = incoming.appendingPathComponent("voice_old.m4a")
+        try Data(count: 51 * 1024 * 1024).write(to: inFlight)
+        try Data(count: 51 * 1024 * 1024).write(to: evictable)
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -7200)], ofItemAtPath: inFlight.path)
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -60)], ofItemAtPath: evictable.path)
+
+        // 102 MB used against the 100 MB quota forces one eviction.
+        store.enforceQuota(reservingBytes: 0, excluding: [inFlight])
+
+        #expect(FileManager.default.fileExists(atPath: inFlight.path))
+        #expect(!FileManager.default.fileExists(atPath: evictable.path))
+    }
+
     private func expectNoSideEffects(_ recorder: Recorder) {
         #expect(recorder.signedNameQueries.isEmpty)
         #expect(recorder.trackedPackets.isEmpty)


### PR DESCRIPTION
Follow-up to the 1.7.0 quality pass (see #1418). Two confirmed push-to-talk issues, both pure logic (no hardware needed).

## Fix C — burst-ID collision hijack
`ChatLiveVoiceCoordinator` keyed `assemblies`/`finishedBursts` by `burstID` alone in one global namespace across peers and scopes; a packet for an existing burstID from a **different** peer was dropped. Since a burst ID is public the moment a START relays, an attacker could race their own START with the observed burstID, bind the assembly to their peerID, and silently drop the real talker's frames.

Fix: key by a composite `AssemblyKey { peerID, scope, burstID }` (mirrors what `absorbFinalizedVoiceNote` already enforces). A colliding START from another peer now opens its **own** capped assembly and cannot capture the victim's frames. Live-capture filenames mirror the assembly key — `voice_live_<burstHex>_<peerID>_<dm|mesh>.aac` — so colliding bursts land on distinct files whether the collision is cross-peer or the same peer across DM and public scope (`FileManager.createFile` truncates, so a shared path would have corrupted whichever capture was still streaming). Note-absorb matching preserved (burstID + optional sender binding + scope↔isPrivate); live names remain unabsorbable.

## Fix B — live-burst files bypass the incoming-media quota
`makeIncomingURL` wrote progressive `.aac` captures straight into the incoming media dir via a raw `FileHandle`, never invoking the quota enforcement the finalized-note path uses (`BLEIncomingFileStore.enforceQuota`, 100 MB LRU). A stream of live-only bursts whose finalized note never arrived grew disk unbounded outside accounting.

Fix: inject `BLEIncomingFileStore`; `makeAssembly` calls `enforceQuota(reservingBytes: pttMaxBurstBytes)` before creating the file. In-flight protection is layer-independent: `enforceQuota` itself never evicts `voice_live_*` names (they still count toward usage), so a finalized transfer arriving at quota — a path that knows nothing about in-flight captures — can't unlink a capture under the coordinator's open `FileHandle`. The coordinator's file I/O routes through the store's injectable `FileManager`, and its init takes `sweepsOnInit:` instead of branching on `TestEnvironment` in prod code.

**Fallback promotion (Codex P1 follow-up):** `voice_live_` is scoped to *genuinely in-flight* captures only. When a burst finalizes with audio but its `.m4a` note never arrives, the capture is the bubble's replayable fallback — `finalize` now renames it to a plain `voice_` name and republishes the row pointing at it (the finished-burst registry tracks the promoted URL, so a late-arriving note still absorbs and deletes it). Promoted fallbacks are therefore ordinary quota-evictable media instead of quota-immune for the rest of the session, and the startup sweep — which reaps `voice_live_*` orphans a crashed process left mid-burst — can never delete a referenced fallback. (Verified while tracing: chat rows are in-memory only, `ConversationStore` never persists and the gossip archive replays `MessageType.message` packets only, so crash-orphan sweeping never strands a persisted row; the invariant now also holds if row persistence ever lands.)

## Tests
Coordinator tests: cross-peer hijack blocked, same-burstID DM+public coexist **with both capture files intact**, authenticated-sender note-absorb even when an attacker burst finished first, quota eviction + in-flight protection, startup sweep (removes orphans, spares promoted fallbacks and finalized notes), finalize-as-fallback promotion survives a later coordinator's sweep with the row repointed, promoted fallbacks are LRU-evictable. Store test: finalized-arrival quota enforcement (no exclusion knowledge) skips an LRU-oldest `voice_live_*` partial. Full suite: 1476 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)