### PR TITLE
Make panic wipe deterministic and device-bound

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -17,8 +17,8 @@ bitchat is designed for private, account-free communication. This policy describ
 
 1. **Identity and cryptographic keys**
    - Noise, signing, group, prekey, and optional Nostr identity material is generated locally.
-   - Secret keys are stored in the system keychain. Public keys are shared when required for messaging, verification, groups, or Nostr events.
-   - Keys remain until they are rotated, removed by the relevant feature, erased with panic wipe, or removed with the app.
+   - Secret keys are stored in the system keychain as device-only items. Public keys are shared when required for messaging, verification, groups, or Nostr events.
+   - Keys remain until they are rotated, removed by the relevant feature, or erased with panic wipe. Because operating-system keychains can outlive an uninstall, bitchat records a non-secret install marker and deletes surviving app keys before use after a later reinstall.
 
 2. **Nickname, preferences, and relationships**
    - Your nickname, settings, favorites, petnames, read-receipt identifiers, and bounded operational metadata are stored locally.
@@ -121,7 +121,7 @@ No cryptographic system can protect content after a recipient reads, copies, scr
 
 ## Your Controls
 
-- **Panic wipe:** Triple-tap the logo to clear local keys, sessions, preferences, groups, queues, carried mail, public archives, board data, and media managed by the app.
+- **Panic wipe:** Triple-tap the logo to synchronously cancel in-flight media work and clear local keys, sessions, preferences, groups, queues, carried mail, public archives, board data, and media managed by the app.
 - **Feature controls:** Location channels, mesh bridge, internet gateway, and related internet behaviors can be disabled in the app. Some already-published relay data cannot be recalled.
 - **System permissions:** Bluetooth, location, microphone, camera, and photo-library access can be revoked in system settings.
 - **No account:** The project operates no account record for you to request or export.

--- a/bitchat/App/AppChromeModel.swift
+++ b/bitchat/App/AppChromeModel.swift
@@ -21,6 +21,9 @@ final class AppChromeModel: ObservableObject {
 
     private let chatViewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
+    /// The composer owns capture state above ChatViewModel. ContentView
+    /// installs this hook so both panic entry points synchronously stop it.
+    private var prepareForPanic: (@MainActor () -> Void)?
 
     /// Bulletin-board coordinator, created on first use of the board sheet.
     private(set) lazy var boardManager = BoardManager(transport: chatViewModel.meshService)
@@ -97,7 +100,12 @@ final class AppChromeModel: ObservableObject {
         showScreenshotPrivacyWarning = true
     }
 
+    func setPanicPreparation(_ preparation: (@MainActor () -> Void)?) {
+        prepareForPanic = preparation
+    }
+
     func panicClearAllData() {
+        prepareForPanic?()
         chatViewModel.panicClearAllData()
     }
 

--- a/bitchat/App/AppRuntime.swift
+++ b/bitchat/App/AppRuntime.swift
@@ -107,12 +107,15 @@ final class AppRuntime: ObservableObject {
             )
         )
 
-        GeoRelayDirectory.shared.prefetchIfNeeded()
+        if chatViewModel.networkActivationAllowed {
+            GeoRelayDirectory.shared.prefetchIfNeeded()
+        }
         bindRuntimeObservers()
         NotificationDelegate.shared.runtime = self
     }
 
     func start() {
+        guard chatViewModel.networkActivationAllowed else { return }
         guard !started else {
             checkForSharedContent()
             return
@@ -151,12 +154,14 @@ final class AppRuntime: ObservableObject {
     }
 
     func handleDidBecomeActiveNotification() {
+        guard chatViewModel.networkActivationAllowed else { return }
         chatViewModel.handleDidBecomeActive()
         checkForSharedContent()
     }
 
     #if os(macOS)
     func handleMacDidBecomeActiveNotification() {
+        guard chatViewModel.networkActivationAllowed else { return }
         record(.scenePhaseChanged(.active))
         chatViewModel.handleDidBecomeActive()
         checkForSharedContent()
@@ -175,6 +180,7 @@ final class AppRuntime: ObservableObject {
             didEnterBackground = true
 
         case .active:
+            guard chatViewModel.networkActivationAllowed else { return }
             record(.scenePhaseChanged(.active))
             chatViewModel.meshService.startServices()
             TorManager.shared.setAppForeground(true)
@@ -222,6 +228,7 @@ final class AppRuntime: ObservableObject {
         actionIdentifier: String = UNNotificationDefaultActionIdentifier,
         userInfo: [AnyHashable: Any]
     ) {
+        guard chatViewModel.networkActivationAllowed else { return }
         if actionIdentifier == NotificationService.waveActionID {
             chatViewModel.sendMeshWave()
             return
@@ -273,6 +280,8 @@ private extension AppRuntime {
         NotificationCenter.default.publisher(for: .TorWillRestart)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                guard self?.chatViewModel.networkActivationAllowed == true
+                else { return }
                 self?.record(.torLifecycleChanged(.willRestart))
                 self?.chatViewModel.handleTorWillRestart()
             }
@@ -281,6 +290,8 @@ private extension AppRuntime {
         NotificationCenter.default.publisher(for: .TorDidBecomeReady)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                guard self?.chatViewModel.networkActivationAllowed == true
+                else { return }
                 self?.record(.torLifecycleChanged(.didBecomeReady))
                 self?.chatViewModel.handleTorDidBecomeReady()
             }
@@ -289,6 +300,8 @@ private extension AppRuntime {
         NotificationCenter.default.publisher(for: .TorWillStart)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                guard self?.chatViewModel.networkActivationAllowed == true
+                else { return }
                 self?.record(.torLifecycleChanged(.willStart))
                 self?.chatViewModel.handleTorWillStart()
             }
@@ -297,6 +310,8 @@ private extension AppRuntime {
         NotificationCenter.default.publisher(for: .TorUserPreferenceChanged)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
+                guard self?.chatViewModel.networkActivationAllowed == true
+                else { return }
                 self?.record(.torLifecycleChanged(.preferenceChanged))
                 self?.chatViewModel.handleTorPreferenceChanged(notification)
             }
@@ -313,6 +328,7 @@ private extension AppRuntime {
     }
 
     func checkForSharedContent() {
+        guard chatViewModel.networkActivationAllowed else { return }
         guard let userDefaults = UserDefaults(suiteName: BitchatApp.groupID) else { return }
         let clearSharedContent = {
             userDefaults.removeObject(forKey: "sharedContent")
@@ -359,7 +375,9 @@ private extension AppRuntime {
         let becameConnected = isConnected && !lastNostrRelayConnectedState
         lastNostrRelayConnectedState = isConnected
 
-        guard started, becameConnected else { return }
+        guard chatViewModel.networkActivationAllowed,
+              started,
+              becameConnected else { return }
 
         let isInitialConnection = !didHandleInitialNostrConnection
         didHandleInitialNostrConnection = true

--- a/bitchat/Features/voice/VoiceCaptureSession.swift
+++ b/bitchat/Features/voice/VoiceCaptureSession.swift
@@ -26,6 +26,8 @@ protocol VoiceCaptureSession: AnyObject {
     /// nothing valid was captured.
     func finish() async -> URL?
     func cancel() async
+    /// Stops capture and suppresses every later send before returning.
+    func panicCancelSynchronously()
 }
 
 /// The classic record-then-send backend, wrapping the shared `VoiceRecorder`.
@@ -54,6 +56,10 @@ final class VoiceNoteCaptureSession: VoiceCaptureSession {
 
     func cancel() async {
         await recorder.cancelRecording(owner: owner)
+    }
+
+    func panicCancelSynchronously() {
+        recorder.panicCancelSynchronously(owner: owner)
     }
 }
 
@@ -214,6 +220,13 @@ final class PTTLiveVoiceSession: VoiceCaptureSession {
         if !alreadyCompleted {
             sendControlPacket(.canceled)
         }
+    }
+
+    func panicCancelSynchronously() {
+        // Do not emit a canceled packet: it would itself be pre-panic
+        // conversation data racing the emergency transport reset.
+        completed = true
+        capture.cancel()
     }
 
     private func sendControlPacket(_ kind: VoiceBurstPacket.Kind) {

--- a/bitchat/Features/voice/VoiceRecorder.swift
+++ b/bitchat/Features/voice/VoiceRecorder.swift
@@ -246,6 +246,21 @@ actor VoiceRecorder {
         currentURL = nil
     }
 
+    /// Panic is a synchronous security boundary: the caller must know the
+    /// microphone, audio-session lease, and partial file are gone before it
+    /// rotates identities or deletes the media tree. VoiceRecorder is an
+    /// independent actor and this cleanup path never hops to MainActor, so a
+    /// short semaphore join is safe even when invoked by the UI actor.
+    nonisolated
+    func panicCancelSynchronously(owner: RecordingOwner) {
+        let finished = DispatchSemaphore(value: 0)
+        Task {
+            await cancelRecording(owner: owner)
+            finished.signal()
+        }
+        finished.wait()
+    }
+
     /// The audio session was interrupted (call, Siri) or reconfigured: stop
     /// the recorder but keep `recorder`/`currentURL` so the caller's pending
     /// `stopRecording()` still returns the partial note.

--- a/bitchat/Services/BLE/BLEIncomingFileStore.swift
+++ b/bitchat/Services/BLE/BLEIncomingFileStore.swift
@@ -4,6 +4,14 @@ import Foundation
 
 struct BLEIncomingFileStore {
     private static let quotaBytes: Int64 = 100 * 1024 * 1024
+    private static let mediaSubdirectories = [
+        "voicenotes/incoming",
+        "voicenotes/outgoing",
+        "images/incoming",
+        "images/outgoing",
+        "files/incoming",
+        "files/outgoing"
+    ]
 
     /// Name prefix of in-flight live voice captures (progressively written by
     /// `ChatLiveVoiceCoordinator`). Quota eviction skips them by pattern —
@@ -22,6 +30,23 @@ struct BLEIncomingFileStore {
         self.fileManager = fileManager
         self.baseDirectory = baseDirectory
         self.dateProvider = dateProvider
+    }
+
+    /// Panic-wipe every managed incoming and outgoing media artifact before
+    /// returning. Recreating the directory tree keeps later capture/receive
+    /// paths usable without allowing a detached cleanup task to race them.
+    func panicWipe() throws {
+        let filesDirectory = try rootDirectory().appendingPathComponent("files", isDirectory: true)
+        if fileManager.fileExists(atPath: filesDirectory.path) {
+            try fileManager.removeItem(at: filesDirectory)
+        }
+        for subdirectory in Self.mediaSubdirectories {
+            try fileManager.createDirectory(
+                at: filesDirectory.appendingPathComponent(subdirectory, isDirectory: true),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
     }
 
     /// Resolves (and creates) an incoming-media directory for callers that
@@ -113,15 +138,18 @@ struct BLEIncomingFileStore {
     }
 
     private func filesDirectory() throws -> URL {
-        let root = try baseDirectory ?? fileManager.url(
+        let filesDir = try rootDirectory().appendingPathComponent("files", isDirectory: true)
+        try fileManager.createDirectory(at: filesDir, withIntermediateDirectories: true, attributes: nil)
+        return filesDir
+    }
+
+    private func rootDirectory() throws -> URL {
+        try baseDirectory ?? fileManager.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
         )
-        let filesDir = root.appendingPathComponent("files", isDirectory: true)
-        try fileManager.createDirectory(at: filesDir, withIntermediateDirectories: true, attributes: nil)
-        return filesDir
     }
 
     private func sanitizedFileName(_ name: String?, defaultName: String, fallbackExtension: String?) -> String {

--- a/bitchat/Services/BLE/BLEIncomingFileStore.swift
+++ b/bitchat/Services/BLE/BLEIncomingFileStore.swift
@@ -2,8 +2,116 @@ import BitLogger
 import BitFoundation
 import Foundation
 
+struct PanicRecoveryIntent {
+    let fileMarkerEstablished: Bool
+    let externalMarkerEstablished: Bool
+
+    var hasDurableMarker: Bool {
+        fileMarkerEstablished || externalMarkerEstablished
+    }
+}
+
+/// Small, dependency-injectable transaction surface used by ChatViewModel.
+/// Production persists the same intent in two independent locations before
+/// any application state is erased. Tests can inject an ephemeral operation
+/// set without touching the developer's Application Support directory.
+struct PanicRecoveryOperations {
+    let isPending: () throws -> Bool
+    let begin: () -> PanicRecoveryIntent
+    let wipeMedia: (PanicRecoveryIntent) throws -> Void
+    let complete: () throws -> Void
+
+    static func ephemeral(
+        wipeMedia: @escaping () throws -> Void = {}
+    ) -> PanicRecoveryOperations {
+        PanicRecoveryOperations(
+            isPending: { false },
+            begin: {
+                PanicRecoveryIntent(
+                    fileMarkerEstablished: false,
+                    externalMarkerEstablished: false
+                )
+            },
+            wipeMedia: { _ in try wipeMedia() },
+            complete: {}
+        )
+    }
+
+    static func live(
+        fileStore: BLEIncomingFileStore = BLEIncomingFileStore(),
+        defaults: UserDefaults = .standard
+    ) -> PanicRecoveryOperations {
+        let defaultsKey = "bitchat.panicResetPending"
+        return PanicRecoveryOperations(
+            isPending: {
+                if defaults.bool(forKey: defaultsKey) {
+                    return true
+                }
+                return try fileStore.isPanicRecoveryPending()
+            },
+            begin: {
+                defaults.set(true, forKey: defaultsKey)
+                let externalMarkerEstablished =
+                    defaults.synchronize()
+                    && defaults.bool(forKey: defaultsKey)
+
+                let fileMarkerEstablished: Bool
+                do {
+                    try fileStore.markPanicRecoveryPending()
+                    fileMarkerEstablished = true
+                } catch {
+                    fileMarkerEstablished = false
+                    SecureLogger.error(
+                        "Failed to persist file panic-recovery marker: \(error)",
+                        category: .security
+                    )
+                }
+
+                return PanicRecoveryIntent(
+                    fileMarkerEstablished: fileMarkerEstablished,
+                    externalMarkerEstablished: externalMarkerEstablished
+                )
+            },
+            wipeMedia: { intent in
+                try fileStore.panicWipe(
+                    hasDurablePendingMarker: intent.hasDurableMarker
+                )
+            },
+            complete: {
+                // Keep the independent defaults latch until the file marker
+                // has definitely cleared. Any failure therefore remains
+                // visible to the next launch.
+                try fileStore.completePanicRecovery()
+                defaults.removeObject(forKey: defaultsKey)
+                guard defaults.synchronize(),
+                      !defaults.bool(forKey: defaultsKey) else {
+                    throw BLEIncomingFileStore.PanicRecoveryError
+                        .externalMarkerCommitFailed
+                }
+            }
+        )
+    }
+}
+
 struct BLEIncomingFileStore {
+    enum PanicRecoveryError: Error {
+        case externalMarkerCommitFailed
+        case markerWriteFailed(Error)
+        case markerWriteAndMediaWipeFailed(
+            markerError: Error,
+            mediaError: Error
+        )
+    }
+
     private static let quotaBytes: Int64 = 100 * 1024 * 1024
+    /// Kept outside `files/` so deleting the media tree cannot erase the
+    /// fail-closed startup decision before the full panic has committed.
+    private static let panicRecoveryPendingMarkerFileName =
+        ".panic-recovery-pending"
+    /// Compatibility with a short-lived development build that used the
+    /// media-specific name for the same full-transaction latch.
+    private static let legacyPanicRecoveryPendingMarkerFileName =
+        ".panic-media-wipe-pending"
     private static let mediaSubdirectories = [
         "voicenotes/incoming",
         "voicenotes/outgoing",
@@ -25,27 +133,95 @@ struct BLEIncomingFileStore {
     let fileManager: FileManager
     private let baseDirectory: URL?
     private let dateProvider: () -> Date
+    private let panicMarkerWriter: (Data, URL) throws -> Void
 
-    init(fileManager: FileManager = .default, baseDirectory: URL? = nil, dateProvider: @escaping () -> Date = Date.init) {
+    init(
+        fileManager: FileManager = .default,
+        baseDirectory: URL? = nil,
+        dateProvider: @escaping () -> Date = Date.init,
+        panicMarkerWriter: @escaping (Data, URL) throws -> Void = {
+            try $0.write(to: $1, options: .atomic)
+        }
+    ) {
         self.fileManager = fileManager
         self.baseDirectory = baseDirectory
         self.dateProvider = dateProvider
+        self.panicMarkerWriter = panicMarkerWriter
     }
 
     /// Panic-wipe every managed incoming and outgoing media artifact before
     /// returning. Recreating the directory tree keeps later capture/receive
     /// paths usable without allowing a detached cleanup task to race them.
-    func panicWipe() throws {
-        let filesDirectory = try rootDirectory().appendingPathComponent("files", isDirectory: true)
-        if fileManager.fileExists(atPath: filesDirectory.path) {
-            try fileManager.removeItem(at: filesDirectory)
-        }
-        for subdirectory in Self.mediaSubdirectories {
-            try fileManager.createDirectory(
-                at: filesDirectory.appendingPathComponent(subdirectory, isDirectory: true),
-                withIntermediateDirectories: true,
-                attributes: nil
+    ///
+    /// Marker persistence and deletion are deliberately separate error
+    /// domains: even when both durable marker channels fail, deletion is
+    /// still attempted before this method reports the marker failure.
+    func panicWipe(
+        hasDurablePendingMarker: Bool = false
+    ) throws {
+        let markerError: Error?
+        do {
+            try markPanicRecoveryPending()
+            markerError = nil
+        } catch {
+            markerError = error
+            SecureLogger.error(
+                "Could not persist file panic-recovery marker; attempting media deletion anyway: \(error)",
+                category: .security
             )
+        }
+
+        do {
+            let filesDirectory = try rootDirectory()
+                .appendingPathComponent("files", isDirectory: true)
+            if fileManager.fileExists(atPath: filesDirectory.path) {
+                try fileManager.removeItem(at: filesDirectory)
+            }
+            for subdirectory in Self.mediaSubdirectories {
+                try fileManager.createDirectory(
+                    at: filesDirectory.appendingPathComponent(
+                        subdirectory,
+                        isDirectory: true
+                    ),
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
+            }
+        } catch {
+            if let markerError {
+                throw PanicRecoveryError.markerWriteAndMediaWipeFailed(
+                    markerError: markerError,
+                    mediaError: error
+                )
+            }
+            throw error
+        }
+
+        if let markerError, !hasDurablePendingMarker {
+            throw PanicRecoveryError.markerWriteFailed(markerError)
+        }
+    }
+
+    func markPanicRecoveryPending() throws {
+        let markerURL = try panicRecoveryPendingMarkerURL()
+        try fileManager.createDirectory(
+            at: markerURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try panicMarkerWriter(Data([1]), markerURL)
+    }
+
+    func isPanicRecoveryPending() throws -> Bool {
+        try panicRecoveryMarkerURLs().contains {
+            fileManager.fileExists(atPath: $0.path)
+        }
+    }
+
+    func completePanicRecovery() throws {
+        for markerURL in try panicRecoveryMarkerURLs()
+        where fileManager.fileExists(atPath: markerURL.path) {
+            try fileManager.removeItem(at: markerURL)
         }
     }
 
@@ -150,6 +326,27 @@ struct BLEIncomingFileStore {
             appropriateFor: nil,
             create: true
         )
+    }
+
+    private func panicRecoveryPendingMarkerURL() throws -> URL {
+        try rootDirectory().appendingPathComponent(
+            Self.panicRecoveryPendingMarkerFileName,
+            isDirectory: false
+        )
+    }
+
+    private func panicRecoveryMarkerURLs() throws -> [URL] {
+        let root = try rootDirectory()
+        return [
+            root.appendingPathComponent(
+                Self.panicRecoveryPendingMarkerFileName,
+                isDirectory: false
+            ),
+            root.appendingPathComponent(
+                Self.legacyPanicRecoveryPendingMarkerFileName,
+                isDirectory: false
+            )
+        ]
     }
 
     private func sanitizedFileName(_ name: String?, defaultName: String, fallbackExtension: String?) -> String {

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -155,6 +155,10 @@ final class BLEService: NSObject {
     private var centralManager: CBCentralManager?
     private var peripheralManager: CBPeripheralManager?
     private var characteristic: CBMutableCharacteristic?
+    private let shouldInitializeBluetoothManagers: Bool
+    private let panicLifecycleLock = NSLock()
+    private var _isPanicSuspended: Bool
+    private var panicLifecycleGeneration: UInt64 = 0
     
     // MARK: - Identity
     
@@ -275,10 +279,13 @@ final class BLEService: NSObject {
         keychain: KeychainManagerProtocol,
         idBridge: NostrIdentityBridge,
         identityManager: SecureIdentityStateManagerProtocol,
-        initializeBluetoothManagers: Bool = true
+        initializeBluetoothManagers: Bool = true,
+        startSuspendedForPanicRecovery: Bool = false
     ) {
         self.keychain = keychain
         self.idBridge = idBridge
+        self.shouldInitializeBluetoothManagers = initializeBluetoothManagers
+        self._isPanicSuspended = startSuspendedForPanicRecovery
         noiseService = NoiseEncryptionService(keychain: keychain)
         self.identityManager = identityManager
         super.init()
@@ -327,37 +334,90 @@ final class BLEService: NSObject {
         // any access from another queue (cross-queue reads use readLinkState).
         linkStateStore.assumeOwnership(of: bleQueue)
 
-        if initializeBluetoothManagers {
-            // Initialize BLE on background queue to prevent main thread blocking.
-            #if os(iOS)
-            let centralOptions: [String: Any] = [
-                CBCentralManagerOptionRestoreIdentifierKey: BLEService.centralRestorationID
-            ]
-            centralManager = CBCentralManager(delegate: self, queue: bleQueue, options: centralOptions)
-
-            let peripheralOptions: [String: Any] = [
-                CBPeripheralManagerOptionRestoreIdentifierKey: BLEService.peripheralRestorationID
-            ]
-            peripheralManager = CBPeripheralManager(delegate: self, queue: bleQueue, options: peripheralOptions)
-            #else
-            centralManager = CBCentralManager(delegate: self, queue: bleQueue)
-            peripheralManager = CBPeripheralManager(delegate: self, queue: bleQueue)
-            #endif
+        if !startSuspendedForPanicRecovery {
+            initializeBluetoothManagersIfNeeded()
         }
         
         // Single maintenance timer for all periodic tasks (dispatch-based for
         // determinism). Only run it when real Bluetooth managers exist.
         meshBackgroundEnabled = initializeBluetoothManagers
-        startMaintenanceTimer()
+        if !startSuspendedForPanicRecovery {
+            startMaintenanceTimer()
+        }
 
         // Publish initial empty state
         requestPeerDataPublish()
 
         // Initialize gossip sync manager
-        restartGossipManager()
+        if !startSuspendedForPanicRecovery {
+            restartGossipManager()
+        }
+    }
+
+    private var isPanicSuspended: Bool {
+        panicLifecycleLock.lock()
+        defer { panicLifecycleLock.unlock() }
+        return _isPanicSuspended
+    }
+
+    private func setPanicSuspended(_ suspended: Bool) {
+        panicLifecycleLock.lock()
+        if suspended {
+            panicLifecycleGeneration &+= 1
+        }
+        _isPanicSuspended = suspended
+        panicLifecycleLock.unlock()
+    }
+
+    private func capturePanicLifecycleGeneration() -> UInt64? {
+        panicLifecycleLock.lock()
+        defer { panicLifecycleLock.unlock() }
+        return _isPanicSuspended ? nil : panicLifecycleGeneration
+    }
+
+    private func isCurrentPanicLifecycleGeneration(_ generation: UInt64) -> Bool {
+        panicLifecycleLock.lock()
+        defer { panicLifecycleLock.unlock() }
+        return !_isPanicSuspended && panicLifecycleGeneration == generation
+    }
+
+    private func initializeBluetoothManagersIfNeeded() {
+        guard shouldInitializeBluetoothManagers,
+              centralManager == nil,
+              peripheralManager == nil,
+              !isPanicSuspended else { return }
+
+        // Initialize BLE on its dedicated delegate queue. On iOS, retain the
+        // restoration identifiers even when construction was deferred by a
+        // pending panic-recovery latch.
+        #if os(iOS)
+        let centralOptions: [String: Any] = [
+            CBCentralManagerOptionRestoreIdentifierKey:
+                BLEService.centralRestorationID
+        ]
+        centralManager = CBCentralManager(
+            delegate: self,
+            queue: bleQueue,
+            options: centralOptions
+        )
+
+        let peripheralOptions: [String: Any] = [
+            CBPeripheralManagerOptionRestoreIdentifierKey:
+                BLEService.peripheralRestorationID
+        ]
+        peripheralManager = CBPeripheralManager(
+            delegate: self,
+            queue: bleQueue,
+            options: peripheralOptions
+        )
+        #else
+        centralManager = CBCentralManager(delegate: self, queue: bleQueue)
+        peripheralManager = CBPeripheralManager(delegate: self, queue: bleQueue)
+        #endif
     }
     
     private func restartGossipManager() {
+        guard !isPanicSuspended else { return }
         // Stop existing
         gossipSyncManager?.stop()
         
@@ -416,7 +476,35 @@ final class BLEService: NSObject {
         #endif
     }
 
-    func resetIdentityForPanic(currentNickname: String) {
+    /// Close radio admission before application state starts disappearing.
+    /// CoreBluetooth callbacks consult the same gate and cannot restart scan
+    /// or advertising while the full panic transaction is incomplete.
+    func suspendForPanicReset() {
+        setPanicSuspended(true)
+        gossipSyncManager?.stop()
+        gossipSyncManager = nil
+        // Wait out sends that passed admission before the gate closed. Work
+        // queued behind this barrier observes `isPanicSuspended` and exits,
+        // so the radio stop below is a true synchronous boundary.
+        messageQueue.sync(flags: .barrier) {}
+        stopServicesImmediatelyForPanic()
+        clearEmergencySessionState()
+    }
+
+    /// Reopen the radio only after media deletion and recovery-marker commit.
+    func completePanicReset(restartServices: Bool) {
+        setPanicSuspended(false)
+        guard restartServices else { return }
+        startServices()
+        sendAnnounce(forceSend: true)
+    }
+
+    func resetIdentityForPanic(
+        currentNickname: String,
+        restartServices: Bool = true
+    ) {
+        gossipSyncManager?.stop()
+        gossipSyncManager = nil
         messageQueue.sync(flags: .barrier) {
             pendingNoiseSessionQueues.removeAll()
         }
@@ -460,16 +548,19 @@ final class BLEService: NSObject {
             configureNoiseServiceCallbacks(for: newNoise)
             refreshPeerIdentity()
         }
-        restartGossipManager()
-
-        setNickname(currentNickname)
-
+        // Keep the transport silent until the application-level transaction
+        // has also removed its media and committed both recovery markers.
+        myNickname = currentNickname
         messageDeduplicator.reset()
         messageQueue.async(flags: .barrier) { [weak self] in
             self?.selfBroadcastTracker.removeAll()
         }
         requestPeerDataPublish()
-        startServices()
+        if restartServices {
+            restartGossipManager()
+            startServices()
+            sendAnnounce(forceSend: true)
+        }
     }
     
     // Ensure this runs on message queue to avoid main thread blocking
@@ -481,6 +572,7 @@ final class BLEService: NSObject {
             }
             return
         }
+        guard !isPanicSuspended else { return }
         
         guard content.count <= maxMessageLength else {
             SecureLogger.error("Message too long: \(content.count) chars", category: .session)
@@ -562,7 +654,9 @@ final class BLEService: NSObject {
     /// `startServices()` — the latter matters after a panic reset, where
     /// `stopServices()` cancels and nils the timer.
     private func startMaintenanceTimer() {
-        guard meshBackgroundEnabled, maintenanceTimer == nil else { return }
+        guard !isPanicSuspended,
+              meshBackgroundEnabled,
+              maintenanceTimer == nil else { return }
         let timer = DispatchSource.makeTimerSource(queue: bleQueue)
         timer.schedule(deadline: .now() + TransportConfig.bleMaintenanceInterval,
                        repeating: TransportConfig.bleMaintenanceInterval,
@@ -575,6 +669,12 @@ final class BLEService: NSObject {
     }
 
     func startServices() {
+        guard let lifecycleGeneration =
+                capturePanicLifecycleGeneration() else { return }
+        initializeBluetoothManagersIfNeeded()
+        if gossipSyncManager == nil {
+            restartGossipManager()
+        }
         // Restart the maintenance timer if a prior stopServices() cancelled it
         // (e.g. the panic flow), otherwise periodic announces, peer reconciliation
         // and cache cleanup would never resume until app restart.
@@ -591,7 +691,11 @@ final class BLEService: NSObject {
         // Send initial announce after services are ready
         // Use longer delay to avoid conflicts with other announces
         messageQueue.asyncAfter(deadline: .now() + TransportConfig.bleInitialAnnounceDelaySeconds) { [weak self] in
-            self?.sendAnnounce(forceSend: true)
+            guard let self,
+                  self.isCurrentPanicLifecycleGeneration(
+                    lifecycleGeneration
+                  ) else { return }
+            self.sendAnnounce(forceSend: true)
         }
     }
     
@@ -659,10 +763,37 @@ final class BLEService: NSObject {
             centralManager?.cancelPeripheralConnection(state.peripheral)
         }
     }
+
+    /// Panic cannot spend its security boundary sending a signed LEAVE or
+    /// pumping the main run loop. Close the radio and timers immediately;
+    /// the identity/session cleanup follows synchronously.
+    private func stopServicesImmediatelyForPanic() {
+        collectionsQueue.sync(flags: .barrier) {
+            pendingNotifications.removeAll()
+        }
+
+        maintenanceTimer?.cancel()
+        maintenanceTimer = nil
+        scanDutyTimer?.cancel()
+        scanDutyTimer = nil
+
+        centralManager?.stopScan()
+        peripheralManager?.stopAdvertising()
+
+        let peripheralsToDisconnect = bleQueue.sync {
+            linkStateStore.peripheralStates
+        }
+        for state in peripheralsToDisconnect {
+            centralManager?.cancelPeripheralConnection(state.peripheral)
+        }
+    }
     
     func emergencyDisconnectAll() {
         stopServices()
+        clearEmergencySessionState()
+    }
 
+    private func clearEmergencySessionState() {
         // Clear all sessions and peers
         let cancelledTransfers: [(id: String, items: [DispatchWorkItem])] = collectionsQueue.sync(flags: .barrier) {
             let entries = outboundFragmentTransfers.removeAll().map { ($0.id, $0.workItems) }
@@ -899,6 +1030,7 @@ final class BLEService: NSObject {
     func sendFileBroadcast(_ filePacket: BitchatFilePacket, transferId: String) {
         messageQueue.async { [weak self] in
             guard let self = self else { return }
+            guard !self.isPanicSuspended else { return }
             guard let payload = filePacket.encode() else {
                 SecureLogger.error("❌ Failed to encode file packet for broadcast", category: .session)
                 return
@@ -935,6 +1067,7 @@ final class BLEService: NSObject {
     func sendFilePrivate(_ filePacket: BitchatFilePacket, to peerID: PeerID, transferId: String) {
         messageQueue.async { [weak self] in
             guard let self = self else { return }
+            guard !self.isPanicSuspended else { return }
             guard let payload = filePacket.encode() else {
                 SecureLogger.error("❌ Failed to encode file packet for private send", category: .session)
                 return
@@ -1088,6 +1221,7 @@ final class BLEService: NSObject {
     // MARK: - Packet Broadcasting
     
     private func broadcastPacket(_ packet: BitchatPacket, transferId: String? = nil) {
+        guard !isPanicSuspended else { return }
         // Apply route if recipient exists (centralized route application)
         let packetToSend: BitchatPacket
         if let recipientPeerID = PeerID(hexData: packet.recipientID) {
@@ -1169,8 +1303,10 @@ final class BLEService: NSObject {
     }
 
     private func enqueuePendingNotification(data: Data, centrals: [CBCentral]?, context: String, attempt: Int = 0) {
+        guard !isPanicSuspended else { return }
         collectionsQueue.async(flags: .barrier) { [weak self] in
             guard let self = self else { return }
+            guard !self.isPanicSuspended else { return }
             let result = self.pendingNotifications.enqueue(
                 data: data,
                 targets: centrals,
@@ -1271,6 +1407,7 @@ final class BLEService: NSObject {
         requireDirectPeerLink: Bool = false,
         requireNoiseAuthenticatedPeerLink: Bool = false
     ) -> Bool {
+        guard !isPanicSuspended else { return false }
         let ingressRecord = collectionsQueue.sync { ingressLinks.record(for: packet) }
         var excludedPeerLinks = links(to: ingressRecord?.peerID)
         if requireNoiseAuthenticatedPeerLink {
@@ -1421,6 +1558,7 @@ final class BLEService: NSObject {
     }
 
     private func flushDirectedSpool() {
+        guard !isPanicSuspended else { return }
         // Move items out and attempt broadcast; if still no links, they'll be re-spooled
         let toSend = collectionsQueue.sync(flags: .barrier) {
             pendingDirectedRelays.drainUnexpired(
@@ -1637,6 +1775,7 @@ final class BLEService: NSObject {
         }
     }
     private func sendAnnounce(forceSend: Bool = false) {
+        guard !isPanicSuspended else { return }
         // Throttle announces to prevent flooding
         if !announceThrottle.shouldSend(force: forceSend, now: Date()) {
             return
@@ -1846,6 +1985,13 @@ extension BLEService: CBCentralManagerDelegate {
     #if os(iOS)
     func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
         let restoredPeripherals = (dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral]) ?? []
+        guard !isPanicSuspended else {
+            central.stopScan()
+            restoredPeripherals.forEach {
+                central.cancelPeripheralConnection($0)
+            }
+            return
+        }
         let restoredServices = (dict[CBCentralManagerRestoredStateScanServicesKey] as? [CBUUID]) ?? []
         let restoredOptions = (dict[CBCentralManagerRestoredStateScanOptionsKey] as? [String: Any]) ?? [:]
         let allowDuplicates = restoredOptions[CBCentralManagerScanOptionAllowDuplicatesKey] as? Bool
@@ -1901,6 +2047,10 @@ extension BLEService: CBCentralManagerDelegate {
 
         switch central.state {
         case .poweredOn:
+            guard !isPanicSuspended else {
+                central.stopScan()
+                return
+            }
             // Links restored as connected have no characteristic in the new
             // process; without rediscovery they sit connected-but-unusable
             // until the peer disconnects. Runs here (not willRestoreState)
@@ -1957,7 +2107,8 @@ extension BLEService: CBCentralManagerDelegate {
     }
     
     private func startScanning() {
-        guard let central = centralManager,
+        guard !isPanicSuspended,
+              let central = centralManager,
               central.state == .poweredOn,
               !central.isScanning else { return }
         
@@ -1978,6 +2129,7 @@ extension BLEService: CBCentralManagerDelegate {
     }
     
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        guard !isPanicSuspended else { return }
         let peripheralID = peripheral.identifier.uuidString
         let advertisedName = advertisementData[CBAdvertisementDataLocalNameKey] as? String ?? (peripheralID.prefix(6) + "…")
         let isConnectable = (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? true
@@ -2019,6 +2171,10 @@ extension BLEService: CBCentralManagerDelegate {
     }
     
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        guard !isPanicSuspended else {
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
         let peripheralID = peripheral.identifier.uuidString
 
         #if os(iOS)
@@ -2169,7 +2325,9 @@ private extension CBPeripheralState {
 
 extension BLEService {
     private func tryConnectFromQueue() {
-        guard let central = centralManager, central.state == .poweredOn else { return }
+        guard !isPanicSuspended,
+              let central = centralManager,
+              central.state == .poweredOn else { return }
 
         let decision = connectionScheduler.nextCandidate(
             connectedOrConnectingCount: linkStateStore.connectedOrConnectingPeripheralCount,
@@ -2195,6 +2353,7 @@ extension BLEService {
         using central: CBCentralManager,
         logPrefix: String
     ) {
+        guard !isPanicSuspended else { return }
         let peripheral = candidate.peripheral
         let peripheralID = candidate.peripheralID
         linkStateStore.beginConnecting(to: peripheral, at: Date())
@@ -2376,6 +2535,7 @@ extension BLEService {
 
 extension BLEService: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard !isPanicSuspended else { return }
         if let error = error {
             SecureLogger.error("❌ Error discovering services for \(peripheral.name ?? "Unknown"): \(error.localizedDescription)", category: .session)
             // Retry service discovery after a delay
@@ -2402,6 +2562,7 @@ extension BLEService: CBPeripheralDelegate {
     }
     
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        guard !isPanicSuspended else { return }
         if let error = error {
             SecureLogger.error("❌ Error discovering characteristics for \(peripheral.name ?? "Unknown"): \(error.localizedDescription)", category: .session)
             return
@@ -2449,6 +2610,7 @@ extension BLEService: CBPeripheralDelegate {
     }
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard !isPanicSuspended else { return }
         if let error = error {
             SecureLogger.error("❌ Error receiving notification: \(error.localizedDescription)", category: .session)
             return
@@ -2566,6 +2728,7 @@ extension BLEService: CBPeripheralDelegate {
     }
     
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        guard !isPanicSuspended else { return }
         // Resume queued writes for this peripheral - called when canSendWriteWithoutResponse becomes true again
         if logRateLimiter.shouldLog(key: "peripheral-ready:\(peripheral.identifier.uuidString)") {
             SecureLogger.debug("📤 Peripheral \(peripheral.name ?? peripheral.identifier.uuidString.prefix(8).description) ready for more writes", category: .session)
@@ -2574,6 +2737,7 @@ extension BLEService: CBPeripheralDelegate {
     }
     
     func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+        guard !isPanicSuspended else { return }
         SecureLogger.warning("⚠️ Services modified for \(peripheral.name ?? peripheral.identifier.uuidString)", category: .session)
 
         let shouldRediscover = BLEService.shouldRediscoverBitChatService(
@@ -2594,6 +2758,7 @@ extension BLEService: CBPeripheralDelegate {
     }
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        guard !isPanicSuspended else { return }
         if let error = error {
             SecureLogger.error("❌ Error updating notification state: \(error.localizedDescription)", category: .session)
         } else {
@@ -2617,6 +2782,12 @@ extension BLEService: CBPeripheralManagerDelegate {
 
         switch peripheral.state {
         case .poweredOn:
+            guard !isPanicSuspended else {
+                peripheral.stopAdvertising()
+                peripheral.removeAllServices()
+                characteristic = nil
+                return
+            }
             // Remove all services first to ensure clean state
             peripheral.removeAllServices()
 
@@ -2677,6 +2848,12 @@ extension BLEService: CBPeripheralManagerDelegate {
     
     #if os(iOS)
     func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        guard !isPanicSuspended else {
+            peripheral.stopAdvertising()
+            peripheral.removeAllServices()
+            characteristic = nil
+            return
+        }
         let restoredServices = (dict[CBPeripheralManagerRestoredStateServicesKey] as? [CBMutableService]) ?? []
         let restoredAdvertisement = (dict[CBPeripheralManagerRestoredStateAdvertisementDataKey] as? [String: Any]) ?? [:]
 
@@ -2703,6 +2880,10 @@ extension BLEService: CBPeripheralManagerDelegate {
     #endif
     
     func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        guard !isPanicSuspended else {
+            peripheral.stopAdvertising()
+            return
+        }
         if let error = error {
             SecureLogger.error("❌ Failed to add service: \(error.localizedDescription)", category: .session)
             return
@@ -2718,6 +2899,7 @@ extension BLEService: CBPeripheralManagerDelegate {
     }
     
     func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
+        guard !isPanicSuspended else { return }
         let centralUUID = central.identifier.uuidString
         SecureLogger.debug("📥 Central subscribed: \(centralUUID.prefix(8))…", category: .session)
         linkStateStore.addSubscribedCentral(central)
@@ -2759,7 +2941,7 @@ extension BLEService: CBPeripheralManagerDelegate {
         let removedPeerID = linkStateStore.removeSubscribedCentral(central)
         
         // Ensure we're still advertising for other devices to find us
-        if peripheral.isAdvertising == false {
+        if !isPanicSuspended, peripheral.isAdvertising == false {
             SecureLogger.debug("📡 Restarting advertising after central unsubscribed", category: .session)
             peripheral.startAdvertising(buildAdvertisementData())
         }
@@ -2796,6 +2978,7 @@ extension BLEService: CBPeripheralManagerDelegate {
     }
     
     func peripheralManagerIsReady(toUpdateSubscribers peripheral: CBPeripheralManager) {
+        guard !isPanicSuspended else { return }
         drainPendingNotifications(logPrefix: "✅ Sent")
     }
 
@@ -2856,6 +3039,7 @@ extension BLEService: CBPeripheralManagerDelegate {
         for request in requests {
             peripheral.respond(to: request, withResult: .success)
         }
+        guard !isPanicSuspended else { return }
         
         // Process writes. For long writes, CoreBluetooth may deliver multiple CBATTRequest values with offsets.
         // Combine per-central request values by offset before decoding.
@@ -4138,6 +4322,7 @@ extension BLEService {
         let uuid = peripheral.identifier.uuidString
         bleQueue.async { [weak self] in
             guard let self = self else { return }
+            guard !self.isPanicSuspended else { return }
             guard let state = self.linkStateStore.state(forPeripheralID: uuid), let ch = state.characteristic else { return }
 
             // Atomically take all pending items from the queue to avoid race conditions
@@ -4228,7 +4413,10 @@ extension BLEService {
         slotReserve: Int = TransportConfig.bleBackgroundPendingConnectSlotReserve
     ) {
         bleQueue.async { [weak self] in
-            guard let self, let central = self.centralManager, central.state == .poweredOn else { return }
+            guard let self,
+                  !self.isPanicSuspended,
+                  let central = self.centralManager,
+                  central.state == .poweredOn else { return }
             let budget = TransportConfig.bleMaxCentralLinks
                 - slotReserve
                 - self.linkStateStore.connectedOrConnectingPeripheralCount
@@ -5535,6 +5723,7 @@ extension BLEService {
     // MARK: Consolidated Maintenance
     
     private func performMaintenance() {
+        guard !isPanicSuspended else { return }
         maintenanceCounter += 1
         lastMaintenanceAt = Date()
 

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -104,6 +104,10 @@ final class BLEService: NSObject {
     // Test-only tap on the outbound pipeline so multi-node tests can ferry
     // packets between in-process service instances.
     var _test_onOutboundPacket: ((BitchatPacket) -> Void)?
+    /// May block a synthetic CoreBluetooth receive callback immediately
+    /// before it hands a packet to `messageQueue`.
+    var _test_beforeReceivePacketHandoff: (() -> Void)?
+    var _test_onReceivePacketHandoff: (() -> Void)?
     #endif
     private var selfBroadcastTracker = BLESelfBroadcastTracker()
     private let meshTopology = MeshTopologyTracker()
@@ -119,6 +123,7 @@ final class BLEService: NSObject {
     private struct PendingMeshPing {
         let peerID: PeerID
         let sentAt: Date
+        let lifecycleGeneration: UInt64
         let completion: @MainActor (MeshPingResult?) -> Void
         let timeout: DispatchWorkItem
     }
@@ -483,11 +488,15 @@ final class BLEService: NSObject {
         setPanicSuspended(true)
         gossipSyncManager?.stop()
         gossipSyncManager = nil
-        // Wait out sends that passed admission before the gate closed. Work
-        // queued behind this barrier observes `isPanicSuspended` and exits,
-        // so the radio stop below is a true synchronous boundary.
-        messageQueue.sync(flags: .barrier) {}
+        // Stop the radio and drain CoreBluetooth's delegate queue first. A
+        // callback may already have passed its initial suspension check; the
+        // bleQueue drain forces its final messageQueue handoff to happen
+        // before the receive barrier below.
         stopServicesImmediatelyForPanic()
+        // Drain every receive/send submitted by callbacks that finished ahead
+        // of the radio stop. Later callbacks observe the closed lifecycle, and
+        // generation-bound handoffs that raced this barrier reject themselves.
+        messageQueue.sync(flags: .barrier) {}
         clearEmergencySessionState()
     }
 
@@ -795,21 +804,30 @@ final class BLEService: NSObject {
 
     private func clearEmergencySessionState() {
         // Clear all sessions and peers
-        let cancelledTransfers: [(id: String, items: [DispatchWorkItem])] = collectionsQueue.sync(flags: .barrier) {
-            let entries = outboundFragmentTransfers.removeAll().map { ($0.id, $0.workItems) }
+        let cancelled = collectionsQueue.sync(flags: .barrier) {
+            let entries = outboundFragmentTransfers.removeAll().map {
+                (id: $0.id, items: $0.workItems)
+            }
+            let pingTimeouts = pendingMeshPings.values.map(\.timeout)
+            pendingMeshPings.removeAll()
+            meshPingResponseLimiter = SyncResponseRateLimiter(
+                maxResponses: TransportConfig.meshPingInboundMaxPerLink,
+                window: TransportConfig.meshPingInboundWindowSeconds
+            )
             peerRegistry.removeAll()
             fragmentAssemblyBuffer.removeAll()
             sourceRouteFailures = BLESourceRouteFailureCache()
             // Also clear pending message queues to avoid stale state across sessions
             pendingNoiseSessionQueues.removeAll()
             pendingDirectedRelays.removeAll()
-            return entries
+            return (transfers: entries, pingTimeouts: pingTimeouts)
         }
 
-        for entry in cancelledTransfers {
+        for entry in cancelled.transfers {
             entry.items.forEach { $0.cancel() }
             TransferProgressManager.shared.cancel(id: entry.id)
         }
+        cancelled.pingTimeouts.forEach { $0.cancel() }
 
         // Clear processed messages
         messageDeduplicator.reset()
@@ -1602,22 +1620,40 @@ final class BLEService: NSObject {
     }
 
     func collectArchivedPublicMessages(completion: @escaping @MainActor ([ArchivedPublicMessage]) -> Void) {
+        guard let generation = capturePanicLifecycleGeneration() else {
+            return
+        }
         guard let sync = gossipSyncManager else {
-            Task { @MainActor in completion([]) }
+            notifyUI { [weak self] in
+                guard let self,
+                      self.isCurrentPanicLifecycleGeneration(generation) else {
+                    return
+                }
+                completion([])
+            }
             return
         }
         sync.collectPublicMessagePackets { [weak self] packets in
-            guard let self = self else {
-                Task { @MainActor in completion([]) }
+            guard let self,
+                  self.isCurrentPanicLifecycleGeneration(generation) else {
                 return
             }
             // Signature verification and registry lookups run on messageQueue
             // like the live receive path.
             self.messageQueue.async {
+                guard self.isCurrentPanicLifecycleGeneration(generation) else {
+                    return
+                }
                 let decoded = packets
                     .compactMap { self.decodeArchivedPublicMessage($0) }
                     .sorted { $0.timestamp < $1.timestamp }
-                Task { @MainActor in completion(decoded) }
+                self.notifyUI { [weak self] in
+                    guard let self,
+                          self.isCurrentPanicLifecycleGeneration(generation) else {
+                        return
+                    }
+                    completion(decoded)
+                }
             }
         }
     }
@@ -2414,6 +2450,28 @@ private extension BLEService {
 #if DEBUG
 // Test-only helper to inject packets into the receive pipeline
 extension BLEService {
+    /// Queues an event through the same MainActor hop as production receive
+    /// handlers so panic-boundary tests can deterministically invalidate it.
+    func _test_emitTransportEvent(_ event: TransportEvent) {
+        emitTransportEvent(event)
+    }
+
+    var _test_isPanicIngressOpen: Bool {
+        capturePanicLifecycleGeneration() != nil
+    }
+
+    /// Models a CoreBluetooth delegate callback without requiring a physical
+    /// peripheral. The callback itself runs on `bleQueue`, exactly where the
+    /// panic radio-stop barrier must linearize it.
+    func _test_handlePacketFromBLEQueue(
+        _ packet: BitchatPacket,
+        fromPeerID: PeerID
+    ) {
+        bleQueue.async { [weak self] in
+            self?.handleReceivedPacket(packet, from: fromPeerID)
+        }
+    }
+
     func _test_handlePacket(_ packet: BitchatPacket, fromPeerID: PeerID, preseedPeer: Bool = true, signingPublicKey: Data? = nil) {
         if preseedPeer {
             // Ensure the synthetic peer is known and marked verified for public-message tests
@@ -3149,8 +3207,18 @@ extension BLEService {
     
     /// Notify UI on the MainActor to satisfy Swift concurrency isolation
     private func notifyUI(_ block: @escaping @MainActor () -> Void) {
-        // Always hop onto the MainActor so calls to @MainActor delegates are safe
-        Task { @MainActor in
+        // Capture the panic lifecycle before queueing the MainActor hop. A
+        // receive callback can enqueue UI delivery immediately before panic
+        // clears application state; rechecking here prevents that stale work
+        // from repopulating the wiped conversation store afterward.
+        guard let generation = capturePanicLifecycleGeneration() else {
+            return
+        }
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.isCurrentPanicLifecycleGeneration(generation) else {
+                return
+            }
             block()
         }
     }
@@ -3315,14 +3383,24 @@ extension BLEService {
     /// The completion fires exactly once on the main actor: with RTT/hops
     /// when the matching pong returns, or nil after the timeout window.
     func sendMeshPing(to peerID: PeerID, completion: @escaping @MainActor (MeshPingResult?) -> Void) {
+        guard let generation = capturePanicLifecycleGeneration() else {
+            return
+        }
         messageQueue.async { [weak self] in
             guard let self,
+                  self.isCurrentPanicLifecycleGeneration(generation),
                   let recipientData = peerID.toShort().routingData,
                   let payload = MeshPingPayload(
                     nonce: Data((0..<MeshPingPayload.nonceLength).map { _ in UInt8.random(in: .min ... .max) }),
                     originTTL: self.messageTTL
                   ) else {
-                Task { @MainActor in completion(nil) }
+                self?.notifyUI { [weak self] in
+                    guard let self,
+                          self.isCurrentPanicLifecycleGeneration(generation) else {
+                        return
+                    }
+                    completion(nil)
+                }
                 return
             }
             let nonce = payload.nonce
@@ -3341,12 +3419,21 @@ extension BLEService {
                     self.pendingMeshPings.removeValue(forKey: nonce)
                 }
                 guard let expired else { return }
-                Task { @MainActor in expired.completion(nil) }
+                self.notifyUI { [weak self] in
+                    guard let self,
+                          self.isCurrentPanicLifecycleGeneration(
+                              expired.lifecycleGeneration
+                          ) else {
+                        return
+                    }
+                    expired.completion(nil)
+                }
             }
             self.collectionsQueue.sync(flags: .barrier) {
                 self.pendingMeshPings[nonce] = PendingMeshPing(
                     peerID: PeerID(hexData: recipientData),
                     sentAt: Date(),
+                    lifecycleGeneration: generation,
                     completion: completion,
                     timeout: timeout
                 )
@@ -3413,7 +3500,15 @@ extension BLEService {
             rttMs: max(0, rttMs),
             hops: MeshPingPayload.hopCount(originTTL: pong.originTTL, receivedTTL: packet.ttl)
         )
-        Task { @MainActor in pending.completion(result) }
+        notifyUI { [weak self] in
+            guard let self,
+                  self.isCurrentPanicLifecycleGeneration(
+                      pending.lifecycleGeneration
+                  ) else {
+                return
+            }
+            pending.completion(result)
+        }
     }
 
     /// Estimated intermediate hops toward `peerID`, BFS over gossiped
@@ -3897,7 +3992,7 @@ extension BLEService {
         let store = courierStore
         let policy = courierDepositPolicy
         let metrics = sfMetrics
-        Task { @MainActor in
+        notifyUI {
             guard let tier = policy(depositorKey, isVerifiedPeer) else {
                 SecureLogger.debug("📦 Courier deposit from \(peerID.id.prefix(8))… rejected (neither favorite nor verified)", category: .session)
                 return
@@ -3977,7 +4072,7 @@ extension BLEService {
             }
         }
         let policy = courierDepositPolicy
-        Task { @MainActor in
+        notifyUI {
             // Same trust gate as deposits: don't hand mail to a peer who
             // would reject it from us.
             guard policy(noiseKey, isVerifiedPeer) != nil else { return }
@@ -4869,8 +4964,24 @@ extension BLEService {
     private func handleReceivedPacket(_ packet: BitchatPacket, from peerID: PeerID) {
         // Call directly if already on messageQueue, otherwise dispatch
         if DispatchQueue.getSpecific(key: messageQueueKey) == nil {
+            guard let lifecycleGeneration =
+                    capturePanicLifecycleGeneration() else {
+                return
+            }
+            #if DEBUG
+            _test_beforeReceivePacketHandoff?()
+            #endif
             messageQueue.async { [weak self] in
-                self?.handleReceivedPacket(packet, from: peerID)
+                guard let self,
+                      self.isCurrentPanicLifecycleGeneration(
+                          lifecycleGeneration
+                      ) else {
+                    return
+                }
+                #if DEBUG
+                self._test_onReceivePacketHandoff?()
+                #endif
+                self.handleReceivedPacket(packet, from: peerID)
             }
             return
         }
@@ -5714,8 +5825,7 @@ extension BLEService {
         let transportPeers: [TransportPeerSnapshot] = collectionsQueue.sync {
             peerRegistry.transportSnapshots(selfNickname: myNickname)
         }
-        // Notify UI on MainActor via delegate
-        Task { @MainActor [weak self] in
+        notifyUI { [weak self] in
             self?.peerEventsDelegate?.didUpdatePeerSnapshots(transportPeers)
         }
     }

--- a/bitchat/Services/GeohashPresenceService.swift
+++ b/bitchat/Services/GeohashPresenceService.swift
@@ -45,6 +45,9 @@ final class GeohashPresenceService: ObservableObject {
 
     private var subscriptions = Set<AnyCancellable>()
     private var heartbeatTimer: GeohashPresenceTimerProtocol?
+    private var pendingBroadcastTasks: [UUID: Task<Void, Never>] = [:]
+    private var heartbeatGeneration: UInt64 = 0
+    private var started = false
     private let availableChannelsProvider: () -> [GeohashChannel]
     private let locationChanges: AnyPublisher<[GeohashChannel], Never>
     private let torReadyPublisher: AnyPublisher<Void, Never>
@@ -147,8 +150,23 @@ final class GeohashPresenceService: ObservableObject {
     
     /// Start the service (safe to call multiple times)
     func start() {
+        guard !started else { return }
+        started = true
+        heartbeatGeneration &+= 1
         SecureLogger.info("Presence: service starting...", category: .session)
         scheduleNextHeartbeat()
+    }
+
+    /// Stops the timer and every decorrelation task synchronously at the panic
+    /// boundary. Generation checks also protect against custom sleepers that
+    /// ignore task cancellation and return later.
+    func stopForPanic() {
+        started = false
+        heartbeatGeneration &+= 1
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
+        pendingBroadcastTasks.values.forEach { $0.cancel() }
+        pendingBroadcastTasks.removeAll(keepingCapacity: false)
     }
 
     private func setupObservers() {
@@ -169,20 +187,26 @@ final class GeohashPresenceService: ObservableObject {
     }
 
     func handleLocationChange() {
+        guard started else { return }
         // When location changes, we trigger an immediate (but slightly delayed) heartbeat
         // to announce presence in the new zone, then reset the loop.
         SecureLogger.debug("Presence: location changed, scheduling update", category: .session)
         heartbeatTimer?.invalidate()
         
         // Small delay to allow location state to settle
+        let generation = heartbeatGeneration
         heartbeatTimer = scheduleTimer(5.0) { [weak self] in
             Task { @MainActor [weak self] in
-                self?.performHeartbeat()
+                guard let self,
+                      self.started,
+                      self.heartbeatGeneration == generation else { return }
+                self.performHeartbeat()
             }
         }
     }
     
     func handleConnectivityChange() {
+        guard started else { return }
         SecureLogger.debug("Presence: connectivity restored, triggering heartbeat", category: .session)
         // If we were waiting for network, do it now
         if heartbeatTimer == nil || !heartbeatTimer!.isValid {
@@ -191,18 +215,29 @@ final class GeohashPresenceService: ObservableObject {
     }
 
     func scheduleNextHeartbeat() {
+        guard started else { return }
         heartbeatTimer?.invalidate()
         let interval = TimeInterval.random(in: loopMinInterval...loopMaxInterval)
+        let generation = heartbeatGeneration
         heartbeatTimer = scheduleTimer(interval) { [weak self] in
             Task { @MainActor [weak self] in
-                self?.performHeartbeat()
+                guard let self,
+                      self.started,
+                      self.heartbeatGeneration == generation else { return }
+                self.performHeartbeat()
             }
         }
     }
 
     func performHeartbeat() {
+        guard started else { return }
+        let generation = heartbeatGeneration
         // Always schedule next loop first ensures continuity even if this one fails/skips
-        defer { scheduleNextHeartbeat() }
+        defer {
+            if started, heartbeatGeneration == generation {
+                scheduleNextHeartbeat()
+            }
+        }
 
         // 1. Check preconditions
         guard torIsReady() else {
@@ -228,14 +263,27 @@ final class GeohashPresenceService: ObservableObject {
             }
             
             // Launch independent task for each channel's delay
-            Task { @MainActor in
+            let taskID = UUID()
+            let sleeper = self.sleeper
+            let delay = TimeInterval.random(
+                in: burstMinDelay...burstMaxDelay
+            )
+            let nanoseconds = UInt64(delay * 1_000_000_000)
+            let task = Task { @MainActor [weak self] in
                 // Random delay for decorrelation
-                let delay = TimeInterval.random(in: self.burstMinDelay...self.burstMaxDelay)
-                let nanoseconds = UInt64(delay * 1_000_000_000)
-                await self.sleeper(nanoseconds)
-                
+                await sleeper(nanoseconds)
+
+                guard let self else { return }
+                guard !Task.isCancelled,
+                      self.started,
+                      self.heartbeatGeneration == generation else {
+                    self.pendingBroadcastTasks.removeValue(forKey: taskID)
+                    return
+                }
+                self.pendingBroadcastTasks.removeValue(forKey: taskID)
                 self.broadcastPresence(for: channel.geohash)
             }
+            pendingBroadcastTasks[taskID] = task
         }
     }
 

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -11,6 +11,13 @@ import BitFoundation
 import Foundation
 import Security
 
+enum KeychainInstallLifecycleAction: Equatable {
+    case markerPresent
+    case bootstrapMarker
+    case clearStaleKeys
+    case retryLater
+}
+
 final class KeychainManager: KeychainManagerProtocol {
     /// Default keychain for components that construct their own rather than
     /// having one injected. Under test this is an in-memory keychain: the
@@ -41,27 +48,80 @@ final class KeychainManager: KeychainManagerProtocol {
     // Use consistent service name for all keychain items
     private let service = BitchatApp.bundleID
     private let appGroup = "group.\(BitchatApp.bundleID)"
+    private static let installMarkerAccount = "install_lifecycle_marker"
+    private static let installMarkerDefaultsKey = "keychain.installLifecycleMarker.present"
 
     // AfterFirstUnlock, not WhenUnlocked: the mesh keeps running with the
     // device locked (identity-cache saves failed with -25308 throughout
     // locked-phone testing), and a wake-on-proximity relaunch via BLE state
     // restoration must be able to read the noise keys before the user
-    // unlocks. Backup/sync semantics are unchanged (not ThisDeviceOnly).
-    private static let itemAccessibility = kSecAttrAccessibleAfterFirstUnlock
+    // unlocks. ThisDeviceOnly prevents private identities and group keys from
+    // migrating through device backups onto a second device.
+    private static let itemAccessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
     init() {
         #if os(iOS)
+        reconcileInstallLifecycle()
         migrateAccessibilityIfNeeded()
         #endif
     }
 
+    static func installLifecycleAction(
+        containerKnowsMarker: Bool,
+        markerRead: KeychainReadResult
+    ) -> KeychainInstallLifecycleAction {
+        switch markerRead {
+        case .success:
+            return containerKnowsMarker ? .markerPresent : .clearStaleKeys
+        case .itemNotFound:
+            return .bootstrapMarker
+        case .accessDenied, .deviceLocked, .authenticationFailed, .otherError:
+            return .retryLater
+        }
+    }
+
     #if os(iOS)
+
+    /// Keychain items can survive app removal while the app container and its
+    /// UserDefaults do not. The first version carrying this marker bootstraps
+    /// without deleting existing users' identities. On a later reinstall, a
+    /// surviving keychain marker plus a missing defaults marker proves the app
+    /// container was replaced, so stale secrets are removed before use.
+    private func reconcileInstallLifecycle() {
+        let defaults = UserDefaults.standard
+        let containerKnowsMarker = defaults.bool(forKey: Self.installMarkerDefaultsKey)
+
+        let markerRead = retrieveDataWithResult(forKey: Self.installMarkerAccount)
+        switch Self.installLifecycleAction(
+            containerKnowsMarker: containerKnowsMarker,
+            markerRead: markerRead
+        ) {
+        case .markerPresent:
+            defaults.set(true, forKey: Self.installMarkerDefaultsKey)
+
+        case .bootstrapMarker:
+            if case .success = saveDataWithResult(Data([1]), forKey: Self.installMarkerAccount) {
+                defaults.set(true, forKey: Self.installMarkerDefaultsKey)
+            }
+
+        case .clearStaleKeys:
+            _ = deleteAllKeychainData()
+            defaults.set(true, forKey: Self.installMarkerDefaultsKey)
+
+        case .retryLater:
+            // Do not guess that a temporarily unreadable marker is absent.
+            // Leaving the defaults flag unchanged lets a later construction
+            // retry once protected keychain data is available.
+            break
+        }
+    }
+
     /// One-time upgrade of items created under WhenUnlocked. New saves get
     /// the right class on their own (saves are delete-then-add), but the
     /// long-lived identity keys are written once and would otherwise stay
     /// unreadable while the device is locked.
     private func migrateAccessibilityIfNeeded() {
-        let flag = "keychain.accessibility.afterFirstUnlock.migrated"
+        let flag = "keychain.accessibility.afterFirstUnlockThisDeviceOnly.migrated"
         guard !UserDefaults.standard.bool(forKey: flag) else { return }
 
         let query: [String: Any] = [
@@ -76,7 +136,7 @@ final class KeychainManager: KeychainManagerProtocol {
         case errSecSuccess, errSecItemNotFound:
             // Nothing to migrate on a fresh install; both are terminal.
             UserDefaults.standard.set(true, forKey: flag)
-            SecureLogger.info("Keychain accessibility migrated to AfterFirstUnlock (status \(status))", category: .keychain)
+            SecureLogger.info("Keychain accessibility migrated to AfterFirstUnlockThisDeviceOnly (status \(status))", category: .keychain)
         default:
             // Likely errSecInteractionNotAllowed (relaunched while locked) —
             // leave the flag unset so the next launch retries.
@@ -491,6 +551,15 @@ final class KeychainManager: KeychainManagerProtocol {
         }
         
         SecureLogger.warning("Panic mode cleanup completed. Total items deleted: \(totalDeleted)", category: .keychain)
+
+        #if os(iOS)
+        // The non-secret marker is intentionally recreated after a panic so a
+        // later uninstall/reinstall can still be distinguished from an in-place
+        // upgrade. It never restores any wiped identity or relationship data.
+        if case .success = saveDataWithResult(Data([1]), forKey: Self.installMarkerAccount) {
+            UserDefaults.standard.set(true, forKey: Self.installMarkerDefaultsKey)
+        }
+        #endif
         
         return totalDeleted > 0
     }
@@ -526,18 +595,39 @@ final class KeychainManager: KeychainManagerProtocol {
 
     /// Save data with a custom service name
     func save(key: String, data: Data, service customService: String, accessible: CFString?) {
-        var query: [String: Any] = [
+        let primaryKeyQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: customService,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data
+            kSecAttrAccount as String: key
         ]
-        if let accessible = accessible {
-            query[kSecAttrAccessible as String] = accessible
-        }
+        var addQuery = primaryKeyQuery
+        addQuery.merge([
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: accessible ?? Self.itemAccessibility,
+            kSecAttrSynchronizable as String: false
+        ]) { _, new in new }
 
-        SecItemDelete(query as CFDictionary)
-        SecItemAdd(query as CFDictionary, nil)
+        // Delete by the item's primary key only. Value/accessibility fields
+        // are add attributes, not valid selectors for replacing an existing
+        // item; including them can leave the old item in place and make the
+        // subsequent add fail as a duplicate.
+        let deleteStatus = SecItemDelete(primaryKeyQuery as CFDictionary)
+        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+            SecureLogger.error(
+                NSError(domain: "Keychain", code: Int(deleteStatus)),
+                context: "Unable to replace custom-service keychain item",
+                category: .keychain
+            )
+            return
+        }
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess {
+            SecureLogger.error(
+                NSError(domain: "Keychain", code: Int(addStatus)),
+                context: "Unable to save custom-service keychain item",
+                category: .keychain
+            )
+        }
     }
 
     /// Load data from a custom service

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -48,9 +48,6 @@ final class KeychainManager: KeychainManagerProtocol {
     // Use consistent service name for all keychain items
     private let service = BitchatApp.bundleID
     private let appGroup = "group.\(BitchatApp.bundleID)"
-    private static let installMarkerAccount = "install_lifecycle_marker"
-    private static let installMarkerDefaultsKey = "keychain.installLifecycleMarker.present"
-
     // AfterFirstUnlock, not WhenUnlocked: the mesh keeps running with the
     // device locked (identity-cache saves failed with -25308 throughout
     // locked-phone testing), and a wake-on-proximity relaunch via BLE state
@@ -81,6 +78,9 @@ final class KeychainManager: KeychainManagerProtocol {
     }
 
     #if os(iOS)
+
+    private static let installMarkerAccount = "install_lifecycle_marker"
+    private static let installMarkerDefaultsKey = "keychain.installLifecycleMarker.present"
 
     /// Keychain items can survive app removal while the app container and its
     /// UserDefaults do not. The first version carrying this marker bootstraps

--- a/bitchat/Services/KeychainManager.swift
+++ b/bitchat/Services/KeychainManager.swift
@@ -18,6 +18,47 @@ enum KeychainInstallLifecycleAction: Equatable {
     case retryLater
 }
 
+/// Process-local fail-closed gate for an unresolved install lifecycle.
+///
+/// A blocked caller may perform one synchronous reconciliation attempt.
+/// Concurrent callers fail closed instead of reading while that cleanup is
+/// in flight. Once reconciliation succeeds, access remains open.
+final class KeychainInstallAccessGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var blocked = false
+    private var reconciliationInProgress = false
+
+    func block() {
+        lock.lock()
+        blocked = true
+        lock.unlock()
+    }
+
+    func allowsAccess(reconcile: () -> Bool) -> Bool {
+        lock.lock()
+        if !blocked {
+            lock.unlock()
+            return true
+        }
+        guard !reconciliationInProgress else {
+            lock.unlock()
+            return false
+        }
+        reconciliationInProgress = true
+        lock.unlock()
+
+        let completed = reconcile()
+
+        lock.lock()
+        if completed {
+            blocked = false
+        }
+        reconciliationInProgress = false
+        lock.unlock()
+        return completed
+    }
+}
+
 final class KeychainManager: KeychainManagerProtocol {
     /// Default keychain for components that construct their own rather than
     /// having one injected. Under test this is an in-memory keychain: the
@@ -48,6 +89,24 @@ final class KeychainManager: KeychainManagerProtocol {
     // Use consistent service name for all keychain items
     private let service = BitchatApp.bundleID
     private let appGroup = "group.\(BitchatApp.bundleID)"
+    #if os(iOS)
+    private let installAccessGate = KeychainInstallAccessGate()
+    #endif
+    /// Every generic-password service owned by this app, including names used
+    /// by older releases. Keep custom services here so one-time security
+    /// migrations and panic deletion cannot silently miss them.
+    private static let additionalApplicationOwnedServices = [
+        "chat.bitchat.nostr",
+        "chat.bitchat.favorites",
+        "chat.bitchat.outbox",
+        "com.bitchat.passwords",
+        "com.bitchat.deviceidentity",
+        "com.bitchat.noise.identity",
+        "chat.bitchat.passwords",
+        "bitchat.keychain",
+        "bitchat",
+        "com.bitchat"
+    ]
     // AfterFirstUnlock, not WhenUnlocked: the mesh keeps running with the
     // device locked (identity-cache saves failed with -25308 throughout
     // locked-phone testing), and a wake-on-proximity relaunch via BLE state
@@ -58,15 +117,27 @@ final class KeychainManager: KeychainManagerProtocol {
 
     init() {
         #if os(iOS)
-        reconcileInstallLifecycle()
-        migrateAccessibilityIfNeeded()
+        if reconcileInstallLifecycle() {
+            migrateAccessibilityIfNeeded()
+        } else {
+            installAccessGate.block()
+        }
         #endif
     }
 
     static func installLifecycleAction(
         containerKnowsMarker: Bool,
+        cleanupPending: Bool = false,
         markerRead: KeychainReadResult
     ) -> KeychainInstallLifecycleAction {
+        // Once a reinstall cleanup has started, its container-local latch
+        // must win even if the keychain marker was deleted before a later
+        // keychain operation failed. Otherwise the next launch could mistake
+        // a partial cleanup for a fresh bootstrap and preserve stale secrets.
+        if cleanupPending {
+            return .clearStaleKeys
+        }
+
         switch markerRead {
         case .success:
             return containerKnowsMarker ? .markerPresent : .clearStaleKeys
@@ -77,42 +148,158 @@ final class KeychainManager: KeychainManagerProtocol {
         }
     }
 
+    static func applicationOwnedKeychainServices(primaryService: String) -> [String] {
+        var seen = Set<String>()
+        return ([primaryService] + additionalApplicationOwnedServices).filter {
+            seen.insert($0).inserted
+        }
+    }
+
+    /// Runs every service update even after one failure. Successful updates
+    /// are idempotent, while returning false keeps the one-time flag unset so
+    /// a later unlocked launch retries the incomplete migration.
+    static func migrateAccessibilityForApplicationOwnedServices(
+        primaryService: String,
+        updateService: (String) -> OSStatus
+    ) -> Bool {
+        var completed = true
+        for serviceName in applicationOwnedKeychainServices(
+            primaryService: primaryService
+        ) {
+            let status = updateService(serviceName)
+            if status != errSecSuccess && status != errSecItemNotFound {
+                completed = false
+            }
+        }
+        return completed
+    }
+
+    /// Deletes every declared service even after one failure. An empty scope
+    /// is already clean, while any other status leaves the cleanup
+    /// incomplete so its durable retry marker remains set.
+    static func deleteApplicationOwnedKeychainServices(
+        primaryService: String,
+        deleteService: (String) -> OSStatus
+    ) -> Bool {
+        var completed = true
+        for serviceName in applicationOwnedKeychainServices(
+            primaryService: primaryService
+        ) {
+            let status = deleteService(serviceName)
+            if status != errSecSuccess && status != errSecItemNotFound {
+                completed = false
+            }
+        }
+        return completed
+    }
+
+    /// The app currently has an application-group entitlement, not a
+    /// keychain-access-group entitlement. Keep the historical group cleanup
+    /// probe as best effort without making its expected -34018 response block
+    /// panic recovery forever.
+    static func completedApplicationGroupDelete(status: OSStatus) -> Bool {
+        status == errSecSuccess
+            || status == errSecItemNotFound
+            || status == -34018
+    }
+
     #if os(iOS)
 
     private static let installMarkerAccount = "install_lifecycle_marker"
     private static let installMarkerDefaultsKey = "keychain.installLifecycleMarker.present"
+    private static let installCleanupPendingDefaultsKey =
+        "keychain.installLifecycleCleanup.pending"
 
     /// Keychain items can survive app removal while the app container and its
     /// UserDefaults do not. The first version carrying this marker bootstraps
     /// without deleting existing users' identities. On a later reinstall, a
     /// surviving keychain marker plus a missing defaults marker proves the app
     /// container was replaced, so stale secrets are removed before use.
-    private func reconcileInstallLifecycle() {
+    @discardableResult
+    private func reconcileInstallLifecycle() -> Bool {
         let defaults = UserDefaults.standard
         let containerKnowsMarker = defaults.bool(forKey: Self.installMarkerDefaultsKey)
+        let cleanupPending = defaults.bool(
+            forKey: Self.installCleanupPendingDefaultsKey
+        )
 
         let markerRead = retrieveDataWithResult(forKey: Self.installMarkerAccount)
         switch Self.installLifecycleAction(
             containerKnowsMarker: containerKnowsMarker,
+            cleanupPending: cleanupPending,
             markerRead: markerRead
         ) {
         case .markerPresent:
             defaults.set(true, forKey: Self.installMarkerDefaultsKey)
+            return true
 
         case .bootstrapMarker:
             if case .success = saveDataWithResult(Data([1]), forKey: Self.installMarkerAccount) {
                 defaults.set(true, forKey: Self.installMarkerDefaultsKey)
             }
+            // A missing marker is the intentional bootstrap path for both a
+            // fresh install and the first marker-carrying upgrade. Preserve
+            // existing users' identities even if marker creation must retry
+            // on a later construction.
+            return true
 
         case .clearStaleKeys:
-            _ = deleteAllKeychainData()
+            // Establish a container-local retry latch before deleting the
+            // surviving keychain marker. If the process exits or any keychain
+            // operation fails, the next launch retries even when that marker
+            // can no longer be read.
+            defaults.set(true, forKey: Self.installCleanupPendingDefaultsKey)
+            guard defaults.synchronize(),
+                  defaults.bool(forKey: Self.installCleanupPendingDefaultsKey)
+            else {
+                SecureLogger.error(
+                    "Could not persist reinstall keychain-cleanup intent",
+                    category: .security
+                )
+                return false
+            }
+
+            guard deleteAllKeychainData() else {
+                SecureLogger.error(
+                    "Reinstall keychain cleanup incomplete; retry remains pending",
+                    category: .security
+                )
+                return false
+            }
+
             defaults.set(true, forKey: Self.installMarkerDefaultsKey)
+            defaults.removeObject(
+                forKey: Self.installCleanupPendingDefaultsKey
+            )
+            guard defaults.synchronize(),
+                  defaults.bool(forKey: Self.installMarkerDefaultsKey),
+                  !defaults.bool(
+                    forKey: Self.installCleanupPendingDefaultsKey
+                  )
+            else {
+                // Preserve the fail-closed state in memory and make one more
+                // best-effort persistence attempt before startup continues.
+                defaults.set(
+                    true,
+                    forKey: Self.installCleanupPendingDefaultsKey
+                )
+                _ = defaults.synchronize()
+                SecureLogger.error(
+                    "Could not commit reinstall keychain-cleanup state; retry remains pending",
+                    category: .security
+                )
+                return false
+            }
+            return true
 
         case .retryLater:
             // Do not guess that a temporarily unreadable marker is absent.
-            // Leaving the defaults flag unchanged lets a later construction
-            // retry once protected keychain data is available.
-            break
+            // An established container may keep using ordinary protected-data
+            // semantics: reads fail while locked and recover after unlock. A
+            // container that has not committed the marker must stay blocked
+            // until the marker becomes readable and this state machine can
+            // distinguish bootstrap from reinstall.
+            return containerKnowsMarker
         }
     }
 
@@ -124,30 +311,59 @@ final class KeychainManager: KeychainManagerProtocol {
         let flag = "keychain.accessibility.afterFirstUnlockThisDeviceOnly.migrated"
         guard !UserDefaults.standard.bool(forKey: flag) else { return }
 
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service
-        ]
         let update: [String: Any] = [
             kSecAttrAccessible as String: Self.itemAccessibility
         ]
-        let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
-        switch status {
-        case errSecSuccess, errSecItemNotFound:
-            // Nothing to migrate on a fresh install; both are terminal.
+        let completed = Self.migrateAccessibilityForApplicationOwnedServices(
+            primaryService: service
+        ) { serviceName in
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: serviceName
+            ]
+            return SecItemUpdate(
+                query as CFDictionary,
+                update as CFDictionary
+            )
+        }
+        if completed {
+            // Missing services on a fresh install are terminal, but the flag is
+            // set only after every application-owned service was considered.
             UserDefaults.standard.set(true, forKey: flag)
-            SecureLogger.info("Keychain accessibility migrated to AfterFirstUnlockThisDeviceOnly (status \(status))", category: .keychain)
-        default:
+            SecureLogger.info(
+                "Keychain accessibility migrated to AfterFirstUnlockThisDeviceOnly",
+                category: .keychain
+            )
+        } else {
             // Likely errSecInteractionNotAllowed (relaunched while locked) —
             // leave the flag unset so the next launch retries.
-            SecureLogger.warning("Keychain accessibility migration deferred (status \(status))", category: .keychain)
+            SecureLogger.warning(
+                "Keychain accessibility migration deferred for at least one application-owned service",
+                category: .keychain
+            )
         }
     }
     #endif
 
+    private func installAccessAllowed() -> Bool {
+        #if os(iOS)
+        return installAccessGate.allowsAccess { [self] in
+            guard reconcileInstallLifecycle() else { return false }
+            migrateAccessibilityIfNeeded()
+            return true
+        }
+        #else
+        return true
+        #endif
+    }
+
     // MARK: - Identity Keys
     
     func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool {
+        guard installAccessAllowed() else {
+            SecureLogger.logKeyOperation(.save, keyType: key, success: false)
+            return false
+        }
         let fullKey = "identity_\(key)"
         let result = saveData(keyData, forKey: fullKey)
         SecureLogger.logKeyOperation(.save, keyType: key, success: result)
@@ -155,11 +371,16 @@ final class KeychainManager: KeychainManagerProtocol {
     }
     
     func getIdentityKey(forKey key: String) -> Data? {
+        guard installAccessAllowed() else { return nil }
         let fullKey = "identity_\(key)"
         return retrieveData(forKey: fullKey)
     }
     
     func deleteIdentityKey(forKey key: String) -> Bool {
+        guard installAccessAllowed() else {
+            SecureLogger.logKeyOperation(.delete, keyType: key, success: false)
+            return false
+        }
         let result = delete(forKey: "identity_\(key)")
         SecureLogger.logKeyOperation(.delete, keyType: key, success: result)
         return result
@@ -170,12 +391,14 @@ final class KeychainManager: KeychainManagerProtocol {
     /// Get identity key with detailed result for proper error handling
     /// Distinguishes between missing keys (expected) and critical failures
     func getIdentityKeyWithResult(forKey key: String) -> KeychainReadResult {
+        guard installAccessAllowed() else { return .accessDenied }
         let fullKey = "identity_\(key)"
         return retrieveDataWithResult(forKey: fullKey)
     }
 
     /// Save identity key with detailed result and retry logic for transient errors
     func saveIdentityKeyWithResult(_ keyData: Data, forKey key: String) -> KeychainSaveResult {
+        guard installAccessAllowed() else { return .accessDenied }
         let fullKey = "identity_\(key)"
         return saveDataWithResult(keyData, forKey: fullKey)
     }
@@ -445,123 +668,165 @@ final class KeychainManager: KeychainManagerProtocol {
     // Delete ALL keychain data for panic mode
     func deleteAllKeychainData() -> Bool {
         SecureLogger.warning("Panic mode - deleting all keychain data", category: .security)
-        
-        var totalDeleted = 0
-        
-        // Search without service restriction to catch all items
+
+        let ownedServices = Set(
+            Self.applicationOwnedKeychainServices(
+                primaryService: service
+            )
+        )
+        var enumerationCompleted = true
         let searchQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnAttributes as String: true
         ]
-        
         var result: AnyObject?
-        let searchStatus = SecItemCopyMatching(searchQuery as CFDictionary, &result)
-        
-        if searchStatus == errSecSuccess, let items = result as? [[String: Any]] {
+        let searchStatus = SecItemCopyMatching(
+            searchQuery as CFDictionary,
+            &result
+        )
+        switch searchStatus {
+        case errSecSuccess:
+            guard let items = result as? [[String: Any]] else {
+                enumerationCompleted = false
+                SecureLogger.error(
+                    "Unable to decode application-owned keychain inventory",
+                    category: .security
+                )
+                break
+            }
+
+            // Preserve the access-group sweep for custom services that are
+            // not yet in the declared legacy-service list.
             for item in items {
-                var shouldDelete = false
-                let account = item[kSecAttrAccount as String] as? String ?? ""
-                let service = item[kSecAttrService as String] as? String ?? ""
-                let accessGroup = item[kSecAttrAccessGroup as String] as? String
-                
-                // More precise deletion criteria:
-                // 1. Check for our specific app group
-                // 2. OR check for our exact service name
-                // 3. OR check for known legacy service names
-                if accessGroup == appGroup {
-                    shouldDelete = true
-                } else if service == self.service {
-                    shouldDelete = true
-                } else if [
-                    "com.bitchat.passwords",
-                    "com.bitchat.deviceidentity",
-                    "com.bitchat.noise.identity",
-                    "chat.bitchat.passwords",
-                    "bitchat.keychain",
-                    "bitchat",
-                    "com.bitchat"
-                ].contains(service) {
-                    shouldDelete = true
+                let account =
+                    item[kSecAttrAccount as String] as? String ?? ""
+                let itemService =
+                    item[kSecAttrService as String] as? String ?? ""
+                let accessGroup =
+                    item[kSecAttrAccessGroup as String] as? String
+                guard accessGroup == appGroup
+                        || ownedServices.contains(itemService)
+                else {
+                    continue
                 }
-                
-                if shouldDelete {
-                    // Build delete query with all available attributes for precise deletion
-                    var deleteQuery: [String: Any] = [
-                        kSecClass as String: kSecClassGenericPassword
-                    ]
-                    
-                    if !account.isEmpty {
-                        deleteQuery[kSecAttrAccount as String] = account
-                    }
-                    if !service.isEmpty {
-                        deleteQuery[kSecAttrService as String] = service
-                    }
-                    
-                    // Add access group if present
-                    if let accessGroup = item[kSecAttrAccessGroup as String] as? String,
-                       !accessGroup.isEmpty && accessGroup != "test" {
-                        deleteQuery[kSecAttrAccessGroup as String] = accessGroup
-                    }
-                    
-                    let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
-                    if deleteStatus == errSecSuccess {
-                        totalDeleted += 1
-                        SecureLogger.info("Deleted keychain item: \(account) from \(service)", category: .keychain)
-                    }
+
+                var deleteQuery: [String: Any] = [
+                    kSecClass as String: kSecClassGenericPassword
+                ]
+                if !account.isEmpty {
+                    deleteQuery[kSecAttrAccount as String] = account
+                }
+                if !itemService.isEmpty {
+                    deleteQuery[kSecAttrService as String] = itemService
+                }
+                if let accessGroup,
+                   !accessGroup.isEmpty,
+                   accessGroup != "test" {
+                    deleteQuery[kSecAttrAccessGroup as String] = accessGroup
+                }
+
+                let status = SecItemDelete(deleteQuery as CFDictionary)
+                if status != errSecSuccess && status != errSecItemNotFound {
+                    enumerationCompleted = false
+                    SecureLogger.error(
+                        NSError(domain: "Keychain", code: Int(status)),
+                        context: "Unable to delete enumerated application-owned keychain item",
+                        category: .keychain
+                    )
                 }
             }
+
+        case errSecItemNotFound:
+            break
+
+        default:
+            enumerationCompleted = false
+            SecureLogger.error(
+                NSError(domain: "Keychain", code: Int(searchStatus)),
+                context: "Unable to enumerate application-owned keychain items",
+                category: .keychain
+            )
         }
-        
-        // Also try to delete by known service names and app group
-        // This catches any items that might have been missed above
-        let knownServices = [
-            self.service,  // Current service name
-            "com.bitchat.passwords",
-            "com.bitchat.deviceidentity", 
-            "com.bitchat.noise.identity",
-            "chat.bitchat.passwords",
-            "chat.bitchat.nostr",
-            "bitchat.keychain",
-            "bitchat",
-            "com.bitchat"
-        ]
-        
-        for serviceName in knownServices {
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: serviceName
-            ]
-            
-            let status = SecItemDelete(query as CFDictionary)
-            if status == errSecSuccess {
-                totalDeleted += 1
+
+        // Bulk deletion by every application-owned service is authoritative
+        // and idempotent. It also verifies that every known service scope is
+        // empty even when the inventory pass found no items.
+        let servicesCompleted =
+            Self.deleteApplicationOwnedKeychainServices(
+                primaryService: service
+            ) { serviceName in
+                let query: [String: Any] = [
+                    kSecClass as String: kSecClassGenericPassword,
+                    kSecAttrService as String: serviceName
+                ]
+                let status = SecItemDelete(query as CFDictionary)
+                if status != errSecSuccess && status != errSecItemNotFound {
+                    SecureLogger.error(
+                        NSError(domain: "Keychain", code: Int(status)),
+                        context: "Unable to delete application-owned keychain service \(serviceName)",
+                        category: .keychain
+                    )
+                }
+                return status
             }
-        }
-        
-        // Also delete by app group to ensure complete cleanup
+
+        // Historical builds attempted this application-group identifier as a
+        // keychain access group. It is not currently entitled, so -34018
+        // means the scope is inapplicable rather than partially deleted.
         let groupQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccessGroup as String: appGroup
         ]
-        
         let groupStatus = SecItemDelete(groupQuery as CFDictionary)
-        if groupStatus == errSecSuccess {
-            totalDeleted += 1
+        let groupCompleted = Self.completedApplicationGroupDelete(
+            status: groupStatus
+        )
+        if !groupCompleted {
+            SecureLogger.error(
+                NSError(domain: "Keychain", code: Int(groupStatus)),
+                context: "Unable to delete historical application-group keychain items",
+                category: .keychain
+            )
         }
-        
-        SecureLogger.warning("Panic mode cleanup completed. Total items deleted: \(totalDeleted)", category: .keychain)
 
+        var markerCompleted = true
         #if os(iOS)
         // The non-secret marker is intentionally recreated after a panic so a
         // later uninstall/reinstall can still be distinguished from an in-place
-        // upgrade. It never restores any wiped identity or relationship data.
-        if case .success = saveDataWithResult(Data([1]), forKey: Self.installMarkerAccount) {
-            UserDefaults.standard.set(true, forKey: Self.installMarkerDefaultsKey)
+        // upgrade. Do not commit the container-side marker here: reinstall
+        // reconciliation may still need to retry an incomplete cleanup.
+        if case .success = saveDataWithResult(
+            Data([1]),
+            forKey: Self.installMarkerAccount
+        ) {
+            markerCompleted = true
+        } else {
+            markerCompleted = false
+            SecureLogger.error(
+                "Unable to restore install-lifecycle keychain marker",
+                category: .security
+            )
         }
         #endif
-        
-        return totalDeleted > 0
+
+        let completed =
+            enumerationCompleted
+            && servicesCompleted
+            && groupCompleted
+            && markerCompleted
+        if completed {
+            SecureLogger.warning(
+                "Panic mode keychain cleanup completed",
+                category: .keychain
+            )
+        } else {
+            SecureLogger.error(
+                "Panic mode keychain cleanup incomplete",
+                category: .security
+            )
+        }
+        return completed
     }
     
     // MARK: - Security Utilities
@@ -587,6 +852,7 @@ final class KeychainManager: KeychainManagerProtocol {
     // MARK: - Debug
 
     func verifyIdentityKeyExists() -> Bool {
+        guard installAccessAllowed() else { return false }
         let key = "identity_noiseStaticKey"
         return retrieveData(forKey: key) != nil
     }
@@ -595,6 +861,7 @@ final class KeychainManager: KeychainManagerProtocol {
 
     /// Save data with a custom service name
     func save(key: String, data: Data, service customService: String, accessible: CFString?) {
+        guard installAccessAllowed() else { return }
         let primaryKeyQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: customService,
@@ -641,6 +908,7 @@ final class KeychainManager: KeychainManagerProtocol {
     /// Load custom-service data without collapsing `itemNotFound` and
     /// protected-data/keychain failures into the same nil result.
     func loadWithResult(key: String, service customService: String) -> KeychainReadResult {
+        guard installAccessAllowed() else { return .accessDenied }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: customService,
@@ -655,6 +923,7 @@ final class KeychainManager: KeychainManagerProtocol {
 
     /// Delete data from a custom service
     func delete(key: String, service customService: String) {
+        guard installAccessAllowed() else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: customService,
@@ -666,6 +935,7 @@ final class KeychainManager: KeychainManagerProtocol {
 
     /// Delete every item stored under a custom service
     func deleteAll(service customService: String) {
+        guard installAccessAllowed() else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: customService,

--- a/bitchat/Services/NetworkActivationService.swift
+++ b/bitchat/Services/NetworkActivationService.swift
@@ -154,6 +154,19 @@ final class NetworkActivationService: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// Stops all internet-facing work at the synchronous panic boundary.
+    /// `start()` may be called again only after the full wipe commits.
+    func stopForPanic() {
+        cancellables.removeAll()
+        started = false
+        reachabilityMonitor.stop()
+        activationAllowed = false
+        torAutoStartDesired = false
+        relayController.disconnect()
+        torController.setAutoStartAllowed(false)
+        applyTorState(torDesired: false)
+    }
+
     func setUserTorEnabled(_ enabled: Bool) {
         guard enabled != userTorEnabled else { return }
         userTorEnabled = enabled
@@ -167,6 +180,7 @@ final class NetworkActivationService: ObservableObject {
     }
 
     private func reevaluate() {
+        guard started else { return }
         let allowed = effectiveAllowed()
         let torDesired = allowed && userTorEnabled
         let statusChanged = allowed != activationAllowed

--- a/bitchat/Services/NetworkReachabilityMonitor.swift
+++ b/bitchat/Services/NetworkReachabilityMonitor.swift
@@ -27,6 +27,8 @@ protocol NetworkReachabilityMonitoring: AnyObject {
     var reachabilityPublisher: AnyPublisher<Bool, Never> { get }
     /// Begin monitoring. Idempotent.
     func start()
+    /// Stop monitoring and discard pending debounce work. Idempotent.
+    func stop()
 }
 
 /// Pure debounce/decision logic for reachability, split out so it can be
@@ -88,18 +90,6 @@ struct ReachabilityDebounce {
     }
 }
 
-/// Always-reachable stub. Used as the default in tests and as the fallback on
-/// platforms without the Network framework, so reachability never suppresses
-/// startup by itself.
-@MainActor
-final class AlwaysReachableMonitor: NetworkReachabilityMonitoring {
-    var isReachable: Bool { true }
-    var reachabilityPublisher: AnyPublisher<Bool, Never> {
-        Empty(completeImmediately: false).eraseToAnyPublisher()
-    }
-    func start() {}
-}
-
 /// `NWPathMonitor`-backed reachability. All state lives on the main actor; the
 /// background path callback hops here before touching the debounce.
 @MainActor
@@ -143,6 +133,18 @@ final class NWPathReachabilityMonitor: NetworkReachabilityMonitoring {
         monitor.start(queue: monitorQueue)
         #else
         // No Network framework: never suppress startup.
+        #endif
+    }
+
+    func stop() {
+        guard started else { return }
+        started = false
+        flushWorkItem?.cancel()
+        flushWorkItem = nil
+        #if canImport(Network)
+        monitor?.pathUpdateHandler = nil
+        monitor?.cancel()
+        monitor = nil
         #endif
     }
 

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -114,7 +114,6 @@ enum TransportConfig {
     // UI sleeps/delays
     static let uiStartupInitialDelaySeconds: TimeInterval = 1.0
     static let uiStartupPhaseDurationSeconds: TimeInterval = 2.0
-    static let uiAsyncShortSleepNs: UInt64 = 100_000_000
     static let uiReadReceiptRetryShortSeconds: TimeInterval = 0.1
     static let uiReadReceiptRetryLongSeconds: TimeInterval = 0.5
     static let uiBatchDispatchStaggerSeconds: TimeInterval = 0.15

--- a/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
+++ b/bitchat/ViewModels/ChatLiveVoiceCoordinator.swift
@@ -226,6 +226,21 @@ final class ChatLiveVoiceCoordinator {
         assemblies.values.contains { $0.messageID == message.id }
     }
 
+    /// Stop every live file handle/player before the panic media directory is
+    /// removed. This prevents an in-flight assembly from continuing to write
+    /// through an unlinked file after the wipe returns.
+    func resetForPanic() {
+        for assembly in Array(assemblies.values) {
+            cancelAssembly(assembly)
+        }
+        for player in drainingPlayers.values {
+            player.stop()
+        }
+        drainingPlayers.removeAll(keepingCapacity: false)
+        finishedBursts.removeAll(keepingCapacity: false)
+        updatePublicTalkerIndicator()
+    }
+
     /// Called for every inbound private message: when it is the finalized
     /// voice note of a burst we assembled (matched by burst ID in the file
     /// name), swap it into the existing live bubble and report `true` so the

--- a/bitchat/ViewModels/ChatMediaTransferCoordinator.swift
+++ b/bitchat/ViewModels/ChatMediaTransferCoordinator.swift
@@ -78,6 +78,7 @@ final class ChatMediaTransferCoordinator {
 
     private(set) var transferIdToMessageIDs: [String: [String]] = [:]
     private(set) var messageIDToTransferId: [String: String] = [:]
+    private var preparationGeneration: UInt64 = 0
 
     init(context: any ChatMediaTransferContext) {
         self.context = context
@@ -98,13 +99,14 @@ final class ChatMediaTransferCoordinator {
         )
         let messageID = message.id
         let transferId = makeTransferID(messageID: messageID)
+        let generation = preparationGeneration
 
         Task.detached(priority: .userInitiated) { [weak self] in
             do {
                 let packet = try ChatMediaPreparation.prepareVoiceNotePacket(at: url)
 
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else { return }
                     self.registerTransfer(transferId: transferId, messageID: messageID)
                     if let peerID = targetPeer {
                         self.context.sendFilePrivate(packet, to: peerID, transferId: transferId)
@@ -116,13 +118,13 @@ final class ChatMediaTransferCoordinator {
                 SecureLogger.warning("Voice note exceeds size limit (\(size) bytes)", category: .session)
                 try? FileManager.default.removeItem(at: url)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else { return }
                     self.handleMediaSendFailure(messageID: messageID, reason: String(localized: "content.delivery.reason.voice_too_large", comment: "Failure reason shown when a voice note exceeds the size limit"))
                 }
             } catch {
                 SecureLogger.error("Voice note send failed: \(error)", category: .session)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else { return }
                     self.handleMediaSendFailure(messageID: messageID, reason: String(localized: "content.delivery.reason.voice_send_failed", comment: "Failure reason shown when a voice note could not be sent"))
                 }
             }
@@ -132,11 +134,15 @@ final class ChatMediaTransferCoordinator {
     #if os(iOS)
     func processThenSendImage(_ image: UIImage?) {
         guard let image else { return }
+        let generation = preparationGeneration
         Task.detached { [weak self] in
             do {
                 let processedURL = try ImageUtils.processImage(image)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else {
+                        try? FileManager.default.removeItem(at: processedURL)
+                        return
+                    }
                     self.sendImage(from: processedURL)
                 }
             } catch {
@@ -147,11 +153,15 @@ final class ChatMediaTransferCoordinator {
     #elseif os(macOS)
     func processThenSendImage(from url: URL?) {
         guard let url else { return }
+        let generation = preparationGeneration
         Task.detached { [weak self] in
             do {
                 let processedURL = try ImageUtils.processImage(at: url)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else {
+                        try? FileManager.default.removeItem(at: processedURL)
+                        return
+                    }
                     self.sendImage(from: processedURL)
                 }
             } catch {
@@ -170,6 +180,7 @@ final class ChatMediaTransferCoordinator {
         }
 
         let targetPeer = context.selectedPrivateChatPeer
+        let generation = preparationGeneration
 
         do {
             try ImageUtils.validateImageSource(at: sourceURL)
@@ -184,7 +195,10 @@ final class ChatMediaTransferCoordinator {
                 let prepared = try ChatMediaPreparation.prepareImagePacket(from: sourceURL)
 
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else {
+                        try? FileManager.default.removeItem(at: prepared.outputURL)
+                        return
+                    }
                     let message = self.enqueueMediaMessage(
                         content: "\(MimeType.Category.image.messagePrefix)\(prepared.outputURL.lastPathComponent)",
                         targetPeer: targetPeer
@@ -201,13 +215,13 @@ final class ChatMediaTransferCoordinator {
             } catch ChatMediaPreparationError.imageTooLarge(let size) {
                 SecureLogger.warning("Processed image exceeds size limit (\(size) bytes)", category: .session)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else { return }
                     self.context.addSystemMessage("Image is too large to send.")
                 }
             } catch {
                 SecureLogger.error("Image send preparation failed: \(error)", category: .session)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.preparationGeneration == generation else { return }
                     self.context.addSystemMessage("Failed to prepare image for sending.")
                 }
             }
@@ -340,6 +354,19 @@ final class ChatMediaTransferCoordinator {
     func deleteMediaMessage(messageID: String) {
         clearTransferMapping(for: messageID)
         context.removeMessage(withID: messageID, cleanupFile: true)
+    }
+
+    /// Invalidates detached preparation work and cancels every transfer that
+    /// reached the transport. Stale tasks check the generation before they
+    /// can recreate a message or send after a panic wipe.
+    func resetForPanic() {
+        preparationGeneration &+= 1
+        let transferIDs = Set(transferIdToMessageIDs.keys)
+        transferIdToMessageIDs.removeAll(keepingCapacity: false)
+        messageIDToTransferId.removeAll(keepingCapacity: false)
+        for transferID in transferIDs {
+            context.cancelTransfer(transferID)
+        }
     }
 }
 

--- a/bitchat/ViewModels/ChatMediaTransferCoordinator.swift
+++ b/bitchat/ViewModels/ChatMediaTransferCoordinator.swift
@@ -72,16 +72,98 @@ extension ChatViewModel: ChatMediaTransferContext {
     }
 }
 
+/// Synchronous boundary between detached image writers and panic deletion.
+///
+/// Invalidation closes admission before waiting for writers that already
+/// entered. Those writers never need the main actor while inside the boundary,
+/// so a synchronous panic transaction can safely join them and then delete
+/// every output before reporting completion.
+private final class ImagePreparationBarrier: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var generation: UInt64 = 0
+    private var activeOperations = 0
+
+    var currentGeneration: UInt64 {
+        condition.lock()
+        defer { condition.unlock() }
+        return generation
+    }
+
+    func isCurrent(_ candidate: UInt64) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return generation == candidate
+    }
+
+    func performIfCurrent<T>(
+        generation candidate: UInt64,
+        operation: () throws -> T
+    ) rethrows -> T? {
+        condition.lock()
+        guard generation == candidate else {
+            condition.unlock()
+            return nil
+        }
+        activeOperations += 1
+        condition.unlock()
+
+        defer {
+            condition.lock()
+            activeOperations -= 1
+            if activeOperations == 0 {
+                condition.broadcast()
+            }
+            condition.unlock()
+        }
+        return try operation()
+    }
+
+    func invalidateAndWait() {
+        condition.lock()
+        generation &+= 1
+        while activeOperations > 0 {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+}
+
+/// Runs synchronous media encoding and file I/O on a dispatch worker.
+///
+/// These operations can legitimately block. Keeping them off Swift's
+/// cooperative executor preserves forward progress when several transfers or
+/// test doubles wait at the same time.
+private func runBlockingMediaPreparation<T>(
+    _ operation: @escaping @Sendable () throws -> T
+) async throws -> T {
+    try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                continuation.resume(returning: try operation())
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
 @MainActor
 final class ChatMediaTransferCoordinator {
     private unowned let context: any ChatMediaTransferContext
+    private let prepareImagePacket: @Sendable (URL) throws -> ChatPreparedImage
+    private let imagePreparationBarrier = ImagePreparationBarrier()
 
     private(set) var transferIdToMessageIDs: [String: [String]] = [:]
     private(set) var messageIDToTransferId: [String: String] = [:]
-    private var preparationGeneration: UInt64 = 0
 
-    init(context: any ChatMediaTransferContext) {
+    init(
+        context: any ChatMediaTransferContext,
+        prepareImagePacket: @escaping @Sendable (URL) throws -> ChatPreparedImage = {
+            try ChatMediaPreparation.prepareImagePacket(from: $0)
+        }
+    ) {
         self.context = context
+        self.prepareImagePacket = prepareImagePacket
     }
 
     func sendVoiceNote(at url: URL) {
@@ -99,14 +181,19 @@ final class ChatMediaTransferCoordinator {
         )
         let messageID = message.id
         let transferId = makeTransferID(messageID: messageID)
-        let generation = preparationGeneration
+        let generation = imagePreparationBarrier.currentGeneration
 
         Task.detached(priority: .userInitiated) { [weak self] in
             do {
-                let packet = try ChatMediaPreparation.prepareVoiceNotePacket(at: url)
+                let packet = try await runBlockingMediaPreparation {
+                    try ChatMediaPreparation.prepareVoiceNotePacket(at: url)
+                }
 
                 await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else { return }
+                    guard let self,
+                          self.imagePreparationBarrier.isCurrent(generation) else {
+                        return
+                    }
                     self.registerTransfer(transferId: transferId, messageID: messageID)
                     if let peerID = targetPeer {
                         self.context.sendFilePrivate(packet, to: peerID, transferId: transferId)
@@ -118,13 +205,19 @@ final class ChatMediaTransferCoordinator {
                 SecureLogger.warning("Voice note exceeds size limit (\(size) bytes)", category: .session)
                 try? FileManager.default.removeItem(at: url)
                 await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else { return }
+                    guard let self,
+                          self.imagePreparationBarrier.isCurrent(generation) else {
+                        return
+                    }
                     self.handleMediaSendFailure(messageID: messageID, reason: String(localized: "content.delivery.reason.voice_too_large", comment: "Failure reason shown when a voice note exceeds the size limit"))
                 }
             } catch {
                 SecureLogger.error("Voice note send failed: \(error)", category: .session)
                 await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else { return }
+                    guard let self,
+                          self.imagePreparationBarrier.isCurrent(generation) else {
+                        return
+                    }
                     self.handleMediaSendFailure(messageID: messageID, reason: String(localized: "content.delivery.reason.voice_send_failed", comment: "Failure reason shown when a voice note could not be sent"))
                 }
             }
@@ -134,12 +227,24 @@ final class ChatMediaTransferCoordinator {
     #if os(iOS)
     func processThenSendImage(_ image: UIImage?) {
         guard let image else { return }
-        let generation = preparationGeneration
-        Task.detached { [weak self] in
+        let generation = imagePreparationBarrier.currentGeneration
+        let barrier = imagePreparationBarrier
+        Task.detached(priority: .userInitiated) { [weak self, barrier] in
             do {
-                let processedURL = try ImageUtils.processImage(image)
-                await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else {
+                let processedURL = try await runBlockingMediaPreparation {
+                    try barrier.performIfCurrent(
+                        generation: generation,
+                        operation: {
+                            try ImageUtils.processImage(image)
+                        }
+                    )
+                }
+                guard let processedURL else {
+                    return
+                }
+                await MainActor.run { [weak self, barrier] in
+                    guard let self,
+                          barrier.isCurrent(generation) else {
                         try? FileManager.default.removeItem(at: processedURL)
                         return
                     }
@@ -153,12 +258,24 @@ final class ChatMediaTransferCoordinator {
     #elseif os(macOS)
     func processThenSendImage(from url: URL?) {
         guard let url else { return }
-        let generation = preparationGeneration
-        Task.detached { [weak self] in
+        let generation = imagePreparationBarrier.currentGeneration
+        let barrier = imagePreparationBarrier
+        Task.detached(priority: .userInitiated) { [weak self, barrier] in
             do {
-                let processedURL = try ImageUtils.processImage(at: url)
-                await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else {
+                let processedURL = try await runBlockingMediaPreparation {
+                    try barrier.performIfCurrent(
+                        generation: generation,
+                        operation: {
+                            try ImageUtils.processImage(at: url)
+                        }
+                    )
+                }
+                guard let processedURL else {
+                    return
+                }
+                await MainActor.run { [weak self, barrier] in
+                    guard let self,
+                          barrier.isCurrent(generation) else {
                         try? FileManager.default.removeItem(at: processedURL)
                         return
                     }
@@ -180,7 +297,7 @@ final class ChatMediaTransferCoordinator {
         }
 
         let targetPeer = context.selectedPrivateChatPeer
-        let generation = preparationGeneration
+        let generation = imagePreparationBarrier.currentGeneration
 
         do {
             try ImageUtils.validateImageSource(at: sourceURL)
@@ -190,12 +307,25 @@ final class ChatMediaTransferCoordinator {
             return
         }
 
-        Task.detached(priority: .userInitiated) { [weak self] in
+        let prepareImagePacket = self.prepareImagePacket
+        let barrier = imagePreparationBarrier
+        Task.detached(priority: .userInitiated) { [weak self, barrier] in
             do {
-                let prepared = try ChatMediaPreparation.prepareImagePacket(from: sourceURL)
+                let prepared = try await runBlockingMediaPreparation {
+                    try barrier.performIfCurrent(
+                        generation: generation,
+                        operation: {
+                            try prepareImagePacket(sourceURL)
+                        }
+                    )
+                }
+                guard let prepared else {
+                    return
+                }
 
-                await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else {
+                await MainActor.run { [weak self, barrier] in
+                    guard let self,
+                          barrier.isCurrent(generation) else {
                         try? FileManager.default.removeItem(at: prepared.outputURL)
                         return
                     }
@@ -214,14 +344,20 @@ final class ChatMediaTransferCoordinator {
                 }
             } catch ChatMediaPreparationError.imageTooLarge(let size) {
                 SecureLogger.warning("Processed image exceeds size limit (\(size) bytes)", category: .session)
-                await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else { return }
+                await MainActor.run { [weak self, barrier] in
+                    guard let self,
+                          barrier.isCurrent(generation) else {
+                        return
+                    }
                     self.context.addSystemMessage("Image is too large to send.")
                 }
             } catch {
                 SecureLogger.error("Image send preparation failed: \(error)", category: .session)
-                await MainActor.run { [weak self] in
-                    guard let self, self.preparationGeneration == generation else { return }
+                await MainActor.run { [weak self, barrier] in
+                    guard let self,
+                          barrier.isCurrent(generation) else {
+                        return
+                    }
                     self.context.addSystemMessage("Failed to prepare image for sending.")
                 }
             }
@@ -357,10 +493,11 @@ final class ChatMediaTransferCoordinator {
     }
 
     /// Invalidates detached preparation work and cancels every transfer that
-    /// reached the transport. Stale tasks check the generation before they
-    /// can recreate a message or send after a panic wipe.
+    /// reached the transport. Closing image-preparation admission and joining
+    /// active synchronous writers ensures the following panic media deletion
+    /// is the last filesystem mutation before the transaction can complete.
     func resetForPanic() {
-        preparationGeneration &+= 1
+        imagePreparationBarrier.invalidateAndWait()
         let transferIDs = Set(transferIdToMessageIDs.keys)
         transferIdToMessageIDs.removeAll(keepingCapacity: false)
         messageIDToTransferId.removeAll(keepingCapacity: false)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -177,7 +177,10 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
     lazy var privateConversationCoordinator = ChatPrivateConversationCoordinator(context: self)
     lazy var nostrCoordinator = ChatNostrCoordinator(context: self)
     lazy var mediaTransferCoordinator = ChatMediaTransferCoordinator(context: self)
-    lazy var liveVoiceCoordinator = ChatLiveVoiceCoordinator(context: self)
+    lazy var liveVoiceCoordinator = ChatLiveVoiceCoordinator(
+        context: self,
+        sweepsOnInit: !TestEnvironment.isRunningTests
+    )
     lazy var verificationCoordinator = ChatVerificationCoordinator(context: self)
     lazy var groupCoordinator = ChatGroupCoordinator(context: self)
     lazy var vouchCoordinator = ChatVouchCoordinator(context: self)
@@ -292,6 +295,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
     var nostrRelayManager: NostrRelayManager?
     private let userDefaults = UserDefaults.standard
     let keychain: KeychainManagerProtocol
+    private let panicMediaWipe: () throws -> Void
     /// Private group membership: keys in the keychain, metadata on disk.
     let groupStore: GroupStore
     private let nicknameKey = "bitchat.nickname"
@@ -799,7 +803,8 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         locationManager: LocationChannelManager = .shared,
         readReceiptsDefaults: UserDefaults? = nil,
         outboxStore: MessageOutboxStore? = nil,
-        sfMetrics: StoreAndForwardMetrics? = nil
+        sfMetrics: StoreAndForwardMetrics? = nil,
+        panicMediaWipe: (() throws -> Void)? = nil
     ) {
         let conversations = conversations ?? ConversationStore()
         let peerIdentityStore = peerIdentityStore ?? PeerIdentityStore()
@@ -814,6 +819,13 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         )
 
         self.keychain = keychain
+        self.panicMediaWipe = panicMediaWipe ?? {
+            // Unit tests share the developer's real Application Support
+            // directory. Production uses the managed store; tests that need
+            // to exercise the wipe inject a temporary-directory closure.
+            guard !TestEnvironment.isRunningTests else { return }
+            try BLEIncomingFileStore().panicWipe()
+        }
         self.groupStore = GroupStore(keychain: keychain)
         self.idBridge = idBridge
         self.identityManager = identityManager
@@ -1156,6 +1168,11 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
     func panicClearAllData() {
         // Messages are processed immediately - nothing to flush
 
+        // Invalidate detached media preparation and close live capture file
+        // handles before clearing state or removing the media directory.
+        mediaTransferCoordinator.resetForPanic()
+        liveVoiceCoordinator.resetForPanic()
+
         // Clear all messages (public timelines and private chats live in the
         // single-writer ConversationStore; the derived `messages` view and
         // the legacy mirror empty with it)
@@ -1279,43 +1296,23 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
             }
         }
 
-        // Delete ALL media files (incoming and outgoing) in background
-        Task.detached(priority: .utility) {
-            // Skipped under tests: the test process shares the user's real
-            // ~/Library/Application Support/files tree, and this detached
-            // utility-priority wipe fires at a nondeterministic time —
-            // deleting media that concurrently running tests (e.g. the
-            // sendImage flow) just wrote there, and the developer's real
-            // app data with it.
-            guard !TestEnvironment.isRunningTests else { return }
-            do {
-                let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-                let filesDir = base.appendingPathComponent("files", isDirectory: true)
-
-                // Delete the entire files directory and recreate it
-                if FileManager.default.fileExists(atPath: filesDir.path) {
-                    try FileManager.default.removeItem(at: filesDir)
-                    SecureLogger.info("🗑️ Deleted all media files during panic clear", category: .session)
-                }
-
-                // Recreate empty directory structure
-                try FileManager.default.createDirectory(at: filesDir, withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("voicenotes/incoming", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("voicenotes/outgoing", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("images/incoming", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("images/outgoing", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("files/incoming", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-                try FileManager.default.createDirectory(at: filesDir.appendingPathComponent("files/outgoing", isDirectory: true), withIntermediateDirectories: true, attributes: nil)
-            } catch {
-                SecureLogger.error("Failed to clear media files during panic: \(error)", category: .session)
-            }
-
-            // BCH-01-013: Clear iOS app switcher snapshots
-            // These are stored in Library/Caches/Snapshots/<bundle_id>/
-            #if os(iOS)
-            Self.clearAppSwitcherSnapshots()
-            #endif
+        // The wipe must finish before this security action returns. A detached
+        // task could otherwise lose a race with a new capture or app exit and
+        // leave pre-panic media behind.
+        do {
+            try panicMediaWipe()
+            SecureLogger.info("🗑️ Deleted all media files during panic clear", category: .session)
+        } catch {
+            SecureLogger.error("Failed to clear media files during panic: \(error)", category: .session)
         }
+
+        // BCH-01-013: Clear iOS app switcher snapshots. Keep tests away from
+        // the host user's real cache tree just as the default media wipe does.
+        #if os(iOS)
+        if !TestEnvironment.isRunningTests {
+            Self.clearAppSwitcherSnapshots()
+        }
+        #endif
 
         // Force immediate UI update for panic mode
         // UI updates immediately - no flushing needed

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -89,6 +89,26 @@ import UIKit
 #endif
 import UniformTypeIdentifiers
 
+struct PanicNetworkLifecycle {
+    let stop: @MainActor () -> Void
+    let restart: @MainActor () -> Void
+
+    static let noop = PanicNetworkLifecycle(stop: {}, restart: {})
+
+    static var live: PanicNetworkLifecycle {
+        PanicNetworkLifecycle(
+            stop: {
+                GeohashPresenceService.shared.stopForPanic()
+                NetworkActivationService.shared.stopForPanic()
+            },
+            restart: {
+                NetworkActivationService.shared.start()
+                GeohashPresenceService.shared.start()
+            }
+        )
+    }
+}
+
 /// Manages the application state and business logic for BitChat.
 /// Acts as the primary coordinator between UI components and backend services,
 /// implementing the BitchatDelegate protocol to handle network events.
@@ -142,6 +162,8 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
     @Published var currentColorScheme: ColorScheme = .light
     @Published var currentTheme: AppTheme = .matrix
     @Published var isConnected = false
+    @Published private(set) var panicRecoveryBlocked = false
+    var networkActivationAllowed: Bool { !panicRecoveryBlocked }
     @Published var nickname: String = "" {
         didSet {
             // Trim whitespace whenever nickname is set; whitespace-only becomes ""
@@ -151,7 +173,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
                 return
             }
             // Update mesh service nickname if it's initialized
-            if !meshService.myPeerID.isEmpty {
+            if !isPanicResetting, !meshService.myPeerID.isEmpty {
                 meshService.setNickname(nickname)
             }
         }
@@ -295,7 +317,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
     var nostrRelayManager: NostrRelayManager?
     private let userDefaults = UserDefaults.standard
     let keychain: KeychainManagerProtocol
-    private let panicMediaWipe: () throws -> Void
+    private let panicRecoveryOperations: PanicRecoveryOperations
+    private let panicNetworkLifecycle: PanicNetworkLifecycle
+    private var isPanicResetting = false
     /// Private group membership: keys in the keychain, metadata on disk.
     let groupStore: GroupStore
     private let nicknameKey = "bitchat.nickname"
@@ -773,7 +797,34 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         locationPresenceStore: LocationPresenceStore? = nil,
         locationManager: LocationChannelManager = .shared
     ) {
-        let meshService = BLEService(keychain: keychain, idBridge: idBridge, identityManager: identityManager)
+        let livePanicRecoveryOperations = PanicRecoveryOperations.live()
+        let startSuspendedForRecovery: Bool
+        do {
+            startSuspendedForRecovery =
+                try livePanicRecoveryOperations.isPending()
+        } catch {
+            startSuspendedForRecovery = true
+        }
+        // Preserve the preflight decision used to defer CoreBluetooth. A
+        // transiently successful second read must not skip recovery and leave
+        // the service permanently suspended without running the wipe.
+        let panicRecoveryOperations = PanicRecoveryOperations(
+            isPending: {
+                if startSuspendedForRecovery {
+                    return true
+                }
+                return try livePanicRecoveryOperations.isPending()
+            },
+            begin: livePanicRecoveryOperations.begin,
+            wipeMedia: livePanicRecoveryOperations.wipeMedia,
+            complete: livePanicRecoveryOperations.complete
+        )
+        let meshService = BLEService(
+            keychain: keychain,
+            idBridge: idBridge,
+            identityManager: identityManager,
+            startSuspendedForPanicRecovery: startSuspendedForRecovery
+        )
         meshService.sfMetrics = .shared
         self.init(
             keychain: keychain,
@@ -785,7 +836,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
             locationPresenceStore: locationPresenceStore ?? LocationPresenceStore(),
             locationManager: locationManager,
             outboxStore: MessageOutboxStore(keychain: keychain),
-            sfMetrics: .shared
+            sfMetrics: .shared,
+            panicRecoveryOperations: panicRecoveryOperations,
+            panicNetworkLifecycle: .live
         )
     }
 
@@ -804,7 +857,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         readReceiptsDefaults: UserDefaults? = nil,
         outboxStore: MessageOutboxStore? = nil,
         sfMetrics: StoreAndForwardMetrics? = nil,
-        panicMediaWipe: (() throws -> Void)? = nil
+        panicMediaWipe: (() throws -> Void)? = nil,
+        panicRecoveryOperations: PanicRecoveryOperations? = nil,
+        panicNetworkLifecycle: PanicNetworkLifecycle = .noop
     ) {
         let conversations = conversations ?? ConversationStore()
         let peerIdentityStore = peerIdentityStore ?? PeerIdentityStore()
@@ -819,13 +874,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         )
 
         self.keychain = keychain
-        self.panicMediaWipe = panicMediaWipe ?? {
-            // Unit tests share the developer's real Application Support
-            // directory. Production uses the managed store; tests that need
-            // to exercise the wipe inject a temporary-directory closure.
-            guard !TestEnvironment.isRunningTests else { return }
-            try BLEIncomingFileStore().panicWipe()
-        }
+        self.panicRecoveryOperations = panicRecoveryOperations
+            ?? .ephemeral(wipeMedia: panicMediaWipe ?? {})
+        self.panicNetworkLifecycle = panicNetworkLifecycle
         self.groupStore = GroupStore(keychain: keychain)
         self.idBridge = idBridge
         self.identityManager = identityManager
@@ -861,7 +912,31 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
             }
             .store(in: &cancellables)
 
-        ChatViewModelBootstrapper(viewModel: self).configure()
+        let recoveryRequired: Bool
+        do {
+            recoveryRequired = try self.panicRecoveryOperations.isPending()
+        } catch {
+            // Failure to read the latch cannot fail open. Re-run the complete
+            // transaction; a persistent storage failure leaves services
+            // blocked below.
+            recoveryRequired = true
+            SecureLogger.error(
+                "Could not read panic-recovery state; retrying the full wipe before startup: \(error)",
+                category: .security
+            )
+        }
+
+        if recoveryRequired {
+            SecureLogger.warning(
+                "Pending panic recovery detected; wiping before runtime services start",
+                category: .security
+            )
+            _ = panicClearAllData(restartServices: false)
+        }
+
+        if networkActivationAllowed {
+            ChatViewModelBootstrapper(viewModel: self).configure()
+        }
     }
 
     // MARK: - Deinitialization
@@ -1165,8 +1240,28 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
 
     // PANIC: Emergency data clearing for activist safety
     @MainActor
-    func panicClearAllData() {
-        // Messages are processed immediately - nothing to flush
+    @discardableResult
+    func panicClearAllData(restartServices: Bool = true) -> Bool {
+        panicRecoveryBlocked = true
+        isPanicResetting = true
+        defer { isPanicResetting = false }
+
+        // Stop internet and location-presence work before clearing identity or
+        // state. These services cancel their subscriptions and delayed tasks,
+        // so old callbacks cannot reconnect during the transaction.
+        panicNetworkLifecycle.stop()
+
+        // Establish both independent durable intents before erasing anything.
+        // `wipeMedia` will still attempt deletion if neither write succeeds.
+        let recoveryIntent = panicRecoveryOperations.begin()
+
+        // Quiesce the mesh before clearing stores. Identity replacement below
+        // deliberately stays stopped until media deletion and marker commit.
+        if let bleService = meshService as? BLEService {
+            bleService.suspendForPanicReset()
+        } else {
+            meshService.emergencyDisconnectAll()
+        }
 
         // Invalidate detached media preparation and close live capture file
         // handles before clearing state or removing the media directory.
@@ -1180,7 +1275,13 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         pendingGeohashSystemMessages.removeAll()
 
         // Delete all keychain data (including Noise and Nostr keys)
-        _ = keychain.deleteAllKeychainData()
+        let keychainWipeCompleted = keychain.deleteAllKeychainData()
+        if !keychainWipeCompleted {
+            SecureLogger.error(
+                "Panic keychain cleanup incomplete; recovery remains pending",
+                category: .security
+            )
+        }
 
         // Clear UserDefaults identity data
         userDefaults.removeObject(forKey: "bitchat.noiseIdentityKey")
@@ -1193,7 +1294,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
 
         // Reset nickname to anonymous
         nickname = "anon\(Int.random(in: 1000...9999))"
-        saveNickname()
+        userDefaults.set(nickname, forKey: nicknameKey)
 
         // Clear favorites and peer mappings
         // Clear through SecureIdentityStateManager instead of directly
@@ -1265,46 +1366,43 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         // Clear Nostr identity associations
         idBridge.clearAllAssociations()
 
-        // Disconnect from all peers and clear persistent identity
-        // This will force creation of a new identity (new fingerprint) on next launch
-        meshService.emergencyDisconnectAll()
+        // Replace the BLE identity while keeping the radio stopped. It may
+        // reopen only after the durable panic transaction commits.
         if let bleService = meshService as? BLEService {
-            bleService.resetIdentityForPanic(currentNickname: nickname)
-        }
-
-        // No need to force UserDefaults synchronization
-
-        // Reinitialize Nostr with new identity
-        // This will generate new Nostr keys derived from new Noise keys.
-        // Skipped under tests: connecting the shared relay singleton starts
-        // real network/reconnect work that never completes and would keep the
-        // test process alive (the singleton, unlike a discardable instance, is
-        // never deallocated to cancel it).
-        if !TestEnvironment.isRunningTests {
-            Task { @MainActor in
-                // Small delay to ensure cleanup completes
-                try? await Task.sleep(nanoseconds: TransportConfig.uiAsyncShortSleepNs) // 0.1 seconds
-
-                // Reinitialize Nostr relay manager with new identity. Reuse the
-                // shared singleton — every other component (NostrTransport, geohash
-                // subscriptions, AppRuntime observers) is bound to `.shared`, so
-                // creating a fresh instance here would split relay state and leave
-                // sends running against a disconnected manager.
-                nostrRelayManager = NostrRelayManager.shared
-                setupNostrMessageHandling()
-                nostrRelayManager?.connect()
-            }
+            bleService.resetIdentityForPanic(
+                currentNickname: nickname,
+                restartServices: false
+            )
+        } else {
+            meshService.setNickname(nickname)
         }
 
         // The wipe must finish before this security action returns. A detached
         // task could otherwise lose a race with a new capture or app exit and
         // leave pre-panic media behind.
+        let panicCompleted: Bool
         do {
-            try panicMediaWipe()
-            SecureLogger.info("🗑️ Deleted all media files during panic clear", category: .session)
+            try panicRecoveryOperations.wipeMedia(recoveryIntent)
+            if keychainWipeCompleted {
+                try panicRecoveryOperations.complete()
+                panicCompleted = true
+                SecureLogger.info(
+                    "🗑️ Deleted all media files during panic clear",
+                    category: .session
+                )
+            } else {
+                // Do not clear either durable recovery marker. Startup must
+                // retry the entire transaction before any transport restarts.
+                panicCompleted = false
+            }
         } catch {
-            SecureLogger.error("Failed to clear media files during panic: \(error)", category: .session)
+            panicCompleted = false
+            SecureLogger.error(
+                "Panic transaction did not commit; services remain stopped: \(error)",
+                category: .security
+            )
         }
+        panicRecoveryBlocked = !panicCompleted
 
         // BCH-01-013: Clear iOS app switcher snapshots. Keep tests away from
         // the host user's real cache tree just as the default media wipe does.
@@ -1314,9 +1412,31 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, TransportEventDele
         }
         #endif
 
-        // Force immediate UI update for panic mode
-        // UI updates immediately - no flushing needed
+        guard panicCompleted else { return false }
 
+        if let bleService = meshService as? BLEService {
+            // Startup recovery reopens admission but leaves actual service
+            // start to the bootstrapper immediately after this method.
+            bleService.completePanicReset(
+                restartServices: restartServices
+            )
+        }
+
+        if restartServices {
+            // All persistent state and media are gone. Bring each service back
+            // only now, under the new identity.
+            if !(meshService is BLEService) {
+                meshService.startServices()
+            }
+
+            if !TestEnvironment.isRunningTests {
+                nostrRelayManager = NostrRelayManager.shared
+                setupNostrMessageHandling()
+            }
+            panicNetworkLifecycle.restart()
+        }
+
+        return true
     }
 
     /// BCH-01-013: Clear iOS app switcher snapshots during panic mode

--- a/bitchat/ViewModels/VoiceRecordingViewModel.swift
+++ b/bitchat/ViewModels/VoiceRecordingViewModel.swift
@@ -188,8 +188,25 @@ final class VoiceRecordingViewModel: ObservableObject {
 
         Task {
             let finalDuration = Date().timeIntervalSince(startDate)
-            if let url = await session.finish(),
-               isValidRecording(at: url, duration: finalDuration) {
+            if let url = await session.finish() {
+                // Panic and a newer hold both invalidate this completion.
+                // Never route an old recording using a post-panic target.
+                guard generation == holdGeneration else {
+                    try? FileManager.default.removeItem(at: url)
+                    return
+                }
+                guard isValidRecording(
+                    at: url,
+                    duration: finalDuration
+                ) else {
+                    guard state == .idle else { return }
+                    state = .error(
+                        message: finalDuration < VoiceRecorder.minRecordingDuration
+                        ? "Recording is too short."
+                        : "Recording failed to save."
+                    )
+                    return
+                }
                 completion(url)
             } else {
                 guard generation == holdGeneration, state == .idle else { return }
@@ -204,6 +221,17 @@ final class VoiceRecordingViewModel: ObservableObject {
 
     func cancel() {
         finish(completion: nil)
+    }
+
+    /// Invalidates in-flight permission/start/finalize callbacks and tears
+    /// down an active microphone before the panic transaction continues.
+    func panicWipe() {
+        holdGeneration &+= 1
+        let session = activeSession
+        activeSession = nil
+        state = .idle
+        isLiveStreaming = false
+        session?.panicCancelSynchronously()
     }
 
     private func isValidRecording(at url: URL, duration: TimeInterval) -> Bool {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -79,6 +79,9 @@ struct ContentView: View {
                 voiceRecordingVM.sessionProvider = { [weak conversationUIModel] in
                     conversationUIModel?.makeVoiceCaptureSession() ?? VoiceNoteCaptureSession()
                 }
+                appChromeModel.setPanicPreparation { [weak voiceRecordingVM] in
+                    voiceRecordingVM?.panicWipe()
+                }
                 #if os(macOS)
                 DispatchQueue.main.async {
                     isNicknameFieldFocused = false
@@ -229,6 +232,7 @@ struct ContentView: View {
         }
         .onDisappear {
             autocompleteDebounceTimer?.invalidate()
+            appChromeModel.setPanicPreparation(nil)
         }
     }
 

--- a/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
+++ b/bitchat/_PreviewHelpers/PreviewKeychainManager.swift
@@ -14,11 +14,25 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     // every default-constructed component under test, which access it from
     // arbitrary threads.
     private let lock = NSLock()
+    private let installAccessGate: KeychainInstallAccessGate
+    private let reconcileInstallAccess: () -> Bool
     private var storage: [String: Data] = [:]
     private var serviceStorage: [String: [String: Data]] = [:]
-    init() {}
+
+    init(
+        installAccessGate: KeychainInstallAccessGate = KeychainInstallAccessGate(),
+        reconcileInstallAccess: @escaping () -> Bool = { true }
+    ) {
+        self.installAccessGate = installAccessGate
+        self.reconcileInstallAccess = reconcileInstallAccess
+    }
+
+    private func installAccessAllowed() -> Bool {
+        installAccessGate.allowsAccess(reconcile: reconcileInstallAccess)
+    }
 
     func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool {
+        guard installAccessAllowed() else { return false }
         lock.lock()
         defer { lock.unlock() }
         storage[key] = keyData
@@ -26,12 +40,14 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     }
 
     func getIdentityKey(forKey key: String) -> Data? {
+        guard installAccessAllowed() else { return nil }
         lock.lock()
         defer { lock.unlock() }
         return storage[key]
     }
 
     func deleteIdentityKey(forKey key: String) -> Bool {
+        guard installAccessAllowed() else { return false }
         lock.lock()
         defer { lock.unlock() }
         storage.removeValue(forKey: key)
@@ -51,6 +67,7 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     func secureClear(_ string: inout String) {}
 
     func verifyIdentityKeyExists() -> Bool {
+        guard installAccessAllowed() else { return false }
         lock.lock()
         defer { lock.unlock() }
         return storage["identity_noiseStaticKey"] != nil
@@ -58,6 +75,7 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
 
     // BCH-01-009: New methods with proper error classification
     func getIdentityKeyWithResult(forKey key: String) -> KeychainReadResult {
+        guard installAccessAllowed() else { return .accessDenied }
         lock.lock()
         defer { lock.unlock() }
         if let data = storage[key] {
@@ -67,6 +85,7 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     }
 
     func saveIdentityKeyWithResult(_ keyData: Data, forKey key: String) -> KeychainSaveResult {
+        guard installAccessAllowed() else { return .accessDenied }
         lock.lock()
         defer { lock.unlock() }
         storage[key] = keyData
@@ -76,24 +95,38 @@ final class PreviewKeychainManager: KeychainManagerProtocol {
     // MARK: - Generic Data Storage (consolidated from KeychainHelper)
 
     func save(key: String, data: Data, service: String, accessible: CFString?) {
+        guard installAccessAllowed() else { return }
         lock.lock()
         defer { lock.unlock() }
         serviceStorage[service, default: [:]][key] = data
     }
 
     func load(key: String, service: String) -> Data? {
+        guard case .success(let data) = loadWithResult(key: key, service: service) else {
+            return nil
+        }
+        return data
+    }
+
+    func loadWithResult(key: String, service: String) -> KeychainReadResult {
+        guard installAccessAllowed() else { return .accessDenied }
         lock.lock()
         defer { lock.unlock() }
-        return serviceStorage[service]?[key]
+        guard let data = serviceStorage[service]?[key] else {
+            return .itemNotFound
+        }
+        return .success(data)
     }
 
     func delete(key: String, service: String) {
+        guard installAccessAllowed() else { return }
         lock.lock()
         defer { lock.unlock() }
         serviceStorage[service]?.removeValue(forKey: key)
     }
 
     func deleteAll(service: String) {
+        guard installAccessAllowed() else { return }
         lock.lock()
         defer { lock.unlock() }
         serviceStorage.removeValue(forKey: service)

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -592,6 +592,88 @@ struct BLEServiceCoreTests {
         #expect(outbound.count(ofType: .message) == 1)
     }
 
+    @Test @MainActor
+    func panicSuspension_invalidatesQueuedMainActorIngress() async {
+        let ble = makeService()
+        let delegate = TransportEventCaptureDelegate()
+        ble.eventDelegate = delegate
+        let message = BitchatMessage(
+            id: "pre-panic-ingress",
+            sender: "Peer",
+            content: "must not survive panic",
+            timestamp: Date(),
+            isRelay: false,
+            isPrivate: true,
+            recipientNickname: "Me",
+            senderPeerID: PeerID(str: "1122334455667788")
+        )
+
+        // The test already owns MainActor, so this task cannot run until the
+        // synchronous panic boundary below has invalidated its generation.
+        ble._test_emitTransportEvent(.messageReceived(message))
+        ble.suspendForPanicReset()
+        await Task.yield()
+        #expect(delegate.messageIDs.isEmpty)
+
+        ble.completePanicReset(restartServices: false)
+        ble._test_emitTransportEvent(.messageReceived(message))
+        await Task.yield()
+        #expect(delegate.messageIDs == [message.id])
+    }
+
+    @Test @MainActor
+    func panicSuspension_rejectsPausedBLEReceiveBeforeMessageQueueHandoff() async {
+        let ble = makeService()
+        let gate = ReceivePacketHandoffGate()
+        ble._test_beforeReceivePacketHandoff = gate.pause
+        ble._test_onReceivePacketHandoff = gate.recordHandoff
+        defer {
+            gate.release()
+            ble._test_beforeReceivePacketHandoff = nil
+            ble._test_onReceivePacketHandoff = nil
+        }
+
+        let sender = PeerID(str: "1122334455667788")
+        let packet = makePublicPacket(
+            content: "must not cross panic",
+            sender: sender,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+        ble._test_handlePacketFromBLEQueue(packet, fromPeerID: sender)
+        #expect(await TestHelpers.waitUntil(
+            { gate.hasPaused },
+            timeout: TestConstants.longTimeout
+        ))
+
+        // Panic closes the lifecycle before waiting for the paused bleQueue
+        // callback. Releasing it afterward lets the callback enqueue its
+        // messageQueue handoff, where the captured generation must be rejected
+        // before packet processing starts.
+        let panicIngressObserver = PanicIngressObserver(service: ble)
+        let didObservePanicClosure = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let didObserveClosure = panicIngressObserver.waitUntilClosed(
+                    timeout: TestConstants.defaultTimeout
+                )
+                gate.release()
+                continuation.resume(returning: didObserveClosure)
+            }
+            ble.suspendForPanicReset()
+        }
+
+        #expect(didObservePanicClosure)
+        #expect(gate.handoffCount == 0)
+
+        // A packet captured under the reopened lifecycle still crosses the
+        // same handoff, proving the test did not merely disable the hook.
+        ble.completePanicReset(restartServices: false)
+        ble._test_handlePacketFromBLEQueue(packet, fromPeerID: sender)
+        #expect(await TestHelpers.waitUntil(
+            { gate.handoffCount == 1 },
+            timeout: TestConstants.longTimeout
+        ))
+    }
+
     @Test
     func modifiedServices_rediscoverWhenBitChatServiceIsInvalidated() async throws {
         let otherService = CBUUID(string: "0000180F-0000-1000-8000-00805F9B34FB")
@@ -686,6 +768,68 @@ private final class OutboundPacketTap {
     }
 }
 
+private final class ReceivePacketHandoffGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var paused = false
+    private var released = false
+    private var recordedHandoffCount = 0
+
+    var hasPaused: Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return paused
+    }
+
+    var handoffCount: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return recordedHandoffCount
+    }
+
+    func pause() {
+        condition.lock()
+        paused = true
+        condition.broadcast()
+        while !released {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func release() {
+        condition.lock()
+        released = true
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func recordHandoff() {
+        condition.lock()
+        recordedHandoffCount += 1
+        condition.unlock()
+    }
+}
+
+/// Lets a dedicated dispatch worker observe the lock-protected panic gate
+/// without treating the full BLE service as generally Sendable.
+private final class PanicIngressObserver: @unchecked Sendable {
+    private let service: BLEService
+
+    init(service: BLEService) {
+        self.service = service
+    }
+
+    func waitUntilClosed(timeout: TimeInterval) -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds
+            + UInt64(timeout * 1_000_000_000)
+        while service._test_isPanicIngressOpen,
+              DispatchTime.now().uptimeNanoseconds < deadline {
+            Thread.sleep(forTimeInterval: 0.001)
+        }
+        return !service._test_isPanicIngressOpen
+    }
+}
+
 private func makeService() -> BLEService {
     let keychain = MockKeychain()
     let identityManager = MockIdentityManager(keychain)
@@ -742,5 +886,15 @@ private final class PublicCaptureDelegate: BitchatDelegate {
         lock.lock()
         defer { lock.unlock() }
         return publicMessages
+    }
+}
+
+@MainActor
+private final class TransportEventCaptureDelegate: TransportEventDelegate {
+    private(set) var messageIDs: [String] = []
+
+    func didReceiveTransportEvent(_ event: TransportEvent) {
+        guard case .messageReceived(let message) = event else { return }
+        messageIDs.append(message.id)
     }
 }

--- a/bitchatTests/BLEServiceCoreTests.swift
+++ b/bitchatTests/BLEServiceCoreTests.swift
@@ -573,6 +573,26 @@ struct BLEServiceCoreTests {
     }
 
     @Test
+    func panicSuspension_dropsLateOutboundWorkUntilCommit() async {
+        let ble = makeService()
+        let outbound = OutboundPacketTap()
+        ble._test_onOutboundPacket = outbound.record
+        let packet = makePublicPacket(
+            content: "late callback",
+            sender: ble.myPeerID,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000)
+        )
+
+        ble.suspendForPanicReset()
+        ble.sendPacket(packet)
+        #expect(outbound.count(ofType: .message) == 0)
+
+        ble.completePanicReset(restartServices: false)
+        ble.sendPacket(packet)
+        #expect(outbound.count(ofType: .message) == 1)
+    }
+
+    @Test
     func modifiedServices_rediscoverWhenBitChatServiceIsInvalidated() async throws {
         let otherService = CBUUID(string: "0000180F-0000-1000-8000-00805F9B34FB")
 

--- a/bitchatTests/ChatMediaTransferCoordinatorContextTests.swift
+++ b/bitchatTests/ChatMediaTransferCoordinatorContextTests.swift
@@ -189,6 +189,21 @@ struct ChatMediaTransferCoordinatorContextTests {
     }
 
     @Test @MainActor
+    func resetForPanic_cancelsEveryTransportTransferAndClearsMappings() {
+        let context = MockChatMediaTransferContext()
+        let coordinator = ChatMediaTransferCoordinator(context: context)
+        coordinator.registerTransfer(transferId: "t1", messageID: "m1")
+        coordinator.registerTransfer(transferId: "t1", messageID: "m2")
+        coordinator.registerTransfer(transferId: "t2", messageID: "m3")
+
+        coordinator.resetForPanic()
+
+        #expect(Set(context.cancelledTransfers) == Set(["t1", "t2"]))
+        #expect(coordinator.transferIdToMessageIDs.isEmpty)
+        #expect(coordinator.messageIDToTransferId.isEmpty)
+    }
+
+    @Test @MainActor
     func sendVoiceNote_blockedContextRemovesFileAndExplains() async throws {
         let context = MockChatMediaTransferContext()
         let coordinator = ChatMediaTransferCoordinator(context: context)

--- a/bitchatTests/ChatMediaTransferCoordinatorContextTests.swift
+++ b/bitchatTests/ChatMediaTransferCoordinatorContextTests.swift
@@ -16,6 +16,11 @@
 import Testing
 import Foundation
 import BitFoundation
+#if os(iOS)
+import UIKit
+#else
+import AppKit
+#endif
 @testable import bitchat
 
 // MARK: - Mock Context
@@ -204,6 +209,99 @@ struct ChatMediaTransferCoordinatorContextTests {
     }
 
     @Test @MainActor
+    func resetForPanic_waitsForActiveImageWriterBeforeReturning() async throws {
+        let context = MockChatMediaTransferContext()
+        let sourceURL = try makeCoordinatorTestImageURL()
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("panic-prepared-\(UUID().uuidString).jpg")
+        let preparer = PausedImagePreparer(outputURL: outputURL)
+        let coordinator = ChatMediaTransferCoordinator(
+            context: context,
+            prepareImagePacket: { sourceURL in
+                try preparer.prepare(sourceURL)
+            }
+        )
+        defer {
+            preparer.release()
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        coordinator.sendImage(from: sourceURL)
+        #expect(await TestHelpers.waitUntil(
+            { preparer.hasStarted },
+            timeout: TestConstants.longTimeout
+        ))
+
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + .milliseconds(100)
+        ) {
+            preparer.release()
+        }
+        coordinator.resetForPanic()
+
+        // The synchronous reset boundary cannot return while a pre-panic
+        // writer can still create output. The real panic path deletes media
+        // immediately after this method returns.
+        #expect(preparer.hasFinished)
+
+        try? FileManager.default.removeItem(at: outputURL)
+        #expect(await TestHelpers.waitUntil(
+            { !FileManager.default.fileExists(atPath: outputURL.path) },
+            timeout: TestConstants.longTimeout
+        ))
+        await Task.yield()
+        #expect(context.privateFileSends.isEmpty)
+        #expect(context.broadcastFileSends.isEmpty)
+        #expect(context.systemMessages.isEmpty)
+    }
+
+    @Test @MainActor
+    func imagePreparation_doesNotRetainCoordinatorOrDeallocatedContext() async throws {
+        let sourceURL = try makeCoordinatorTestImageURL()
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("released-context-\(UUID().uuidString).jpg")
+        let preparer = PausedImagePreparer(outputURL: outputURL)
+        var context: MockChatMediaTransferContext? = MockChatMediaTransferContext()
+        var coordinator: ChatMediaTransferCoordinator? = ChatMediaTransferCoordinator(
+            context: context!,
+            prepareImagePacket: { sourceURL in
+                try preparer.prepare(sourceURL)
+            }
+        )
+        weak var weakContext: MockChatMediaTransferContext?
+        weak var weakCoordinator: ChatMediaTransferCoordinator?
+        weakContext = context
+        weakCoordinator = coordinator
+        defer {
+            preparer.release()
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        coordinator?.sendImage(from: sourceURL)
+        #expect(await TestHelpers.waitUntil(
+            { preparer.hasStarted },
+            timeout: TestConstants.longTimeout
+        ))
+
+        coordinator = nil
+        context = nil
+        #expect(weakCoordinator == nil)
+        #expect(weakContext == nil)
+
+        preparer.release()
+        #expect(await TestHelpers.waitUntil(
+            { preparer.hasFinished },
+            timeout: TestConstants.longTimeout
+        ))
+        #expect(await TestHelpers.waitUntil(
+            { !FileManager.default.fileExists(atPath: outputURL.path) },
+            timeout: TestConstants.longTimeout
+        ))
+    }
+
+    @Test @MainActor
     func sendVoiceNote_blockedContextRemovesFileAndExplains() async throws {
         let context = MockChatMediaTransferContext()
         let coordinator = ChatMediaTransferCoordinator(context: context)
@@ -221,4 +319,92 @@ struct ChatMediaTransferCoordinatorContextTests {
         #expect(context.appendedPublicMessages.isEmpty)
         #expect(coordinator.transferIdToMessageIDs.isEmpty)
     }
+}
+
+private final class PausedImagePreparer: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let outputURL: URL
+    private var started = false
+    private var released = false
+    private var finished = false
+
+    init(outputURL: URL) {
+        self.outputURL = outputURL
+    }
+
+    var hasStarted: Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return started
+    }
+
+    var hasFinished: Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return finished
+    }
+
+    func prepare(_ _: URL) throws -> ChatPreparedImage {
+        condition.lock()
+        started = true
+        condition.broadcast()
+        while !released {
+            condition.wait()
+        }
+        condition.unlock()
+
+        let data = Data("prepared image".utf8)
+        try data.write(to: outputURL, options: .atomic)
+        let packet = BitchatFilePacket(
+            fileName: outputURL.lastPathComponent,
+            fileSize: UInt64(data.count),
+            mimeType: "image/jpeg",
+            content: data
+        )
+
+        condition.lock()
+        finished = true
+        condition.broadcast()
+        condition.unlock()
+        return ChatPreparedImage(outputURL: outputURL, packet: packet)
+    }
+
+    func release() {
+        condition.lock()
+        released = true
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
+private func makeCoordinatorTestImageURL() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("coordinator-image-\(UUID().uuidString).png")
+    #if os(iOS)
+    let image = UIGraphicsImageRenderer(size: CGSize(width: 16, height: 16))
+        .image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 16, height: 16))
+        }
+    guard let data = image.pngData() else {
+        throw CoordinatorImageTestError.encodingFailed
+    }
+    #else
+    let image = NSImage(size: NSSize(width: 16, height: 16))
+    image.lockFocus()
+    NSColor.systemBlue.setFill()
+    NSRect(x: 0, y: 0, width: 16, height: 16).fill()
+    image.unlockFocus()
+    guard let tiff = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff),
+          let data = bitmap.representation(using: .png, properties: [:]) else {
+        throw CoordinatorImageTestError.encodingFailed
+    }
+    #endif
+    try data.write(to: url, options: .atomic)
+    return url
+}
+
+private enum CoordinatorImageTestError: Error {
+    case encodingFailed
 }

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -15,7 +15,9 @@ import BitFoundation
 
 /// Creates a ChatViewModel with mock dependencies for testing
 @MainActor
-private func makeTestableViewModel() -> (viewModel: ChatViewModel, transport: MockTransport) {
+private func makeTestableViewModel(
+    panicMediaWipe: (() throws -> Void)? = nil
+) -> (viewModel: ChatViewModel, transport: MockTransport) {
     let keychain = MockKeychain()
     let keychainHelper = MockKeychainHelper()
     let idBridge = NostrIdentityBridge(keychain: keychainHelper)
@@ -26,7 +28,8 @@ private func makeTestableViewModel() -> (viewModel: ChatViewModel, transport: Mo
         keychain: keychain,
         idBridge: idBridge,
         identityManager: identityManager,
-        transport: transport
+        transport: transport,
+        panicMediaWipe: panicMediaWipe
     )
 
     return (viewModel, transport)
@@ -1115,6 +1118,18 @@ struct ChatViewModelBluetoothTests {
 // MARK: - Panic Clear Tests
 
 struct ChatViewModelPanicTests {
+
+    @Test @MainActor
+    func panicClearAllData_finishesMediaWipeBeforeReturning() {
+        var wipeFinished = false
+        let (viewModel, _) = makeTestableViewModel {
+            wipeFinished = true
+        }
+
+        viewModel.panicClearAllData()
+
+        #expect(wipeFinished)
+    }
 
     @Test @MainActor
     func panicClearAllData_delegatesToTransport() async {

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -16,9 +16,12 @@ import BitFoundation
 /// Creates a ChatViewModel with mock dependencies for testing
 @MainActor
 private func makeTestableViewModel(
-    panicMediaWipe: (() throws -> Void)? = nil
+    keychain injectedKeychain: MockKeychain? = nil,
+    panicMediaWipe: (() throws -> Void)? = nil,
+    panicRecoveryOperations: PanicRecoveryOperations? = nil,
+    panicNetworkLifecycle: PanicNetworkLifecycle = .noop
 ) -> (viewModel: ChatViewModel, transport: MockTransport) {
-    let keychain = MockKeychain()
+    let keychain = injectedKeychain ?? MockKeychain()
     let keychainHelper = MockKeychainHelper()
     let idBridge = NostrIdentityBridge(keychain: keychainHelper)
     let identityManager = MockIdentityManager(keychain)
@@ -29,7 +32,9 @@ private func makeTestableViewModel(
         idBridge: idBridge,
         identityManager: identityManager,
         transport: transport,
-        panicMediaWipe: panicMediaWipe
+        panicMediaWipe: panicMediaWipe,
+        panicRecoveryOperations: panicRecoveryOperations,
+        panicNetworkLifecycle: panicNetworkLifecycle
     )
 
     return (viewModel, transport)
@@ -1122,13 +1127,154 @@ struct ChatViewModelPanicTests {
     @Test @MainActor
     func panicClearAllData_finishesMediaWipeBeforeReturning() {
         var wipeFinished = false
-        let (viewModel, _) = makeTestableViewModel {
+        let (viewModel, _) = makeTestableViewModel(panicMediaWipe: {
             wipeFinished = true
-        }
+        })
 
         viewModel.panicClearAllData()
 
         #expect(wipeFinished)
+    }
+
+    @Test @MainActor
+    func panicClearAllData_stopsNetworkBeforeWipeAndRestartsAfterCommit() {
+        var events: [String] = []
+        let lifecycle = PanicNetworkLifecycle(
+            stop: { events.append("stop") },
+            restart: { events.append("restart") }
+        )
+        let (viewModel, _) = makeTestableViewModel(
+            panicMediaWipe: { events.append("wipe") },
+            panicNetworkLifecycle: lifecycle
+        )
+
+        let completed = viewModel.panicClearAllData()
+
+        #expect(completed)
+        #expect(events == ["stop", "wipe", "restart"])
+        #expect(viewModel.networkActivationAllowed)
+    }
+
+    @Test @MainActor
+    func panicKeychainFailureKeepsRecoveryPendingAndServicesStopped() {
+        let keychain = MockKeychain()
+        keychain.simulatedDeleteAllResult = false
+        var events: [String] = []
+        let operations = PanicRecoveryOperations(
+            isPending: { false },
+            begin: {
+                events.append("begin")
+                return PanicRecoveryIntent(
+                    fileMarkerEstablished: true,
+                    externalMarkerEstablished: false
+                )
+            },
+            wipeMedia: { _ in events.append("wipe") },
+            complete: { events.append("complete") }
+        )
+        let lifecycle = PanicNetworkLifecycle(
+            stop: { events.append("stop") },
+            restart: { events.append("restart") }
+        )
+        let (viewModel, transport) = makeTestableViewModel(
+            keychain: keychain,
+            panicRecoveryOperations: operations,
+            panicNetworkLifecycle: lifecycle
+        )
+        let startsBeforePanic = transport.startServicesCallCount
+
+        let completed = viewModel.panicClearAllData()
+
+        #expect(!completed)
+        #expect(events == ["stop", "begin", "wipe"])
+        #expect(keychain.deleteAllCallCount == 1)
+        #expect(transport.startServicesCallCount == startsBeforePanic)
+        #expect(!viewModel.networkActivationAllowed)
+    }
+
+    @Test @MainActor
+    func pendingPanicRecoveryCompletesBeforeTransportBootstrap() {
+        var events: [String] = []
+        let operations = PanicRecoveryOperations(
+            isPending: {
+                events.append("read")
+                return true
+            },
+            begin: {
+                events.append("begin")
+                return PanicRecoveryIntent(
+                    fileMarkerEstablished: true,
+                    externalMarkerEstablished: false
+                )
+            },
+            wipeMedia: { _ in events.append("wipe") },
+            complete: { events.append("complete") }
+        )
+
+        let (viewModel, transport) = makeTestableViewModel(
+            panicRecoveryOperations: operations
+        )
+
+        #expect(events == ["read", "begin", "wipe", "complete"])
+        #expect(transport.emergencyDisconnectCallCount == 1)
+        #expect(transport.startServicesCallCount == 1)
+        #expect(viewModel.networkActivationAllowed)
+    }
+
+    @Test @MainActor
+    func failedStartupRecoveryLeavesTransportAndNetworkBlocked() {
+        enum WipeFailure: Error { case failed }
+        var completedMarker = false
+        let operations = PanicRecoveryOperations(
+            isPending: { true },
+            begin: {
+                PanicRecoveryIntent(
+                    fileMarkerEstablished: true,
+                    externalMarkerEstablished: false
+                )
+            },
+            wipeMedia: { _ in throw WipeFailure.failed },
+            complete: { completedMarker = true }
+        )
+
+        let (viewModel, transport) = makeTestableViewModel(
+            panicRecoveryOperations: operations
+        )
+
+        #expect(!completedMarker)
+        #expect(transport.emergencyDisconnectCallCount == 1)
+        #expect(transport.startServicesCallCount == 0)
+        #expect(!viewModel.networkActivationAllowed)
+    }
+
+    @Test @MainActor
+    func failedStartupKeychainRecoveryLeavesIntentAndTransportBlocked() {
+        let keychain = MockKeychain()
+        keychain.simulatedDeleteAllResult = false
+        var events: [String] = []
+        let operations = PanicRecoveryOperations(
+            isPending: { true },
+            begin: {
+                events.append("begin")
+                return PanicRecoveryIntent(
+                    fileMarkerEstablished: true,
+                    externalMarkerEstablished: true
+                )
+            },
+            wipeMedia: { _ in events.append("wipe") },
+            complete: { events.append("complete") }
+        )
+
+        let (viewModel, transport) = makeTestableViewModel(
+            keychain: keychain,
+            panicRecoveryOperations: operations
+        )
+
+        #expect(events == ["begin", "wipe"])
+        #expect(keychain.deleteAllCallCount == 1)
+        #expect(transport.emergencyDisconnectCallCount == 1)
+        #expect(transport.startServicesCallCount == 0)
+        #expect(!viewModel.networkActivationAllowed)
     }
 
     @Test @MainActor

--- a/bitchatTests/Mocks/MockKeychain.swift
+++ b/bitchatTests/Mocks/MockKeychain.swift
@@ -18,6 +18,8 @@ final class MockKeychain: KeychainManagerProtocol {
     var simulatedReadError: KeychainReadResult?
     var simulatedSaveError: KeychainSaveResult?
     var simulatedGenericReadError: KeychainReadResult?
+    var simulatedDeleteAllResult = true
+    private(set) var deleteAllCallCount = 0
 
     func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool {
         storage[key] = keyData
@@ -34,6 +36,8 @@ final class MockKeychain: KeychainManagerProtocol {
     }
 
     func deleteAllKeychainData() -> Bool {
+        deleteAllCallCount += 1
+        guard simulatedDeleteAllResult else { return false }
         storage.removeAll()
         serviceStorage.removeAll()
         return true

--- a/bitchatTests/PreviewKeychainManagerTests.swift
+++ b/bitchatTests/PreviewKeychainManagerTests.swift
@@ -1,9 +1,30 @@
 import Foundation
 import Testing
+import BitFoundation
 @testable import bitchat
 
 @Suite("PreviewKeychainManager Tests")
 struct PreviewKeychainManagerTests {
+
+    @Test("Install lifecycle distinguishes upgrade, reinstall, bootstrap, and unreadable keychain")
+    func installLifecycleDecision() {
+        #expect(KeychainManager.installLifecycleAction(
+            containerKnowsMarker: true,
+            markerRead: .success(Data([1]))
+        ) == .markerPresent)
+        #expect(KeychainManager.installLifecycleAction(
+            containerKnowsMarker: false,
+            markerRead: .success(Data([1]))
+        ) == .clearStaleKeys)
+        #expect(KeychainManager.installLifecycleAction(
+            containerKnowsMarker: false,
+            markerRead: .itemNotFound
+        ) == .bootstrapMarker)
+        #expect(KeychainManager.installLifecycleAction(
+            containerKnowsMarker: false,
+            markerRead: .deviceLocked
+        ) == .retryLater)
+    }
 
     @Test("Preview keychain manager stores identity and service-scoped data in memory")
     func previewKeychainManagerRoundTripsData() {

--- a/bitchatTests/PreviewKeychainManagerTests.swift
+++ b/bitchatTests/PreviewKeychainManagerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import Testing
 import BitFoundation
 @testable import bitchat
@@ -24,6 +25,77 @@ struct PreviewKeychainManagerTests {
             containerKnowsMarker: false,
             markerRead: .deviceLocked
         ) == .retryLater)
+        #expect(KeychainManager.installLifecycleAction(
+            containerKnowsMarker: false,
+            cleanupPending: true,
+            markerRead: .itemNotFound
+        ) == .clearStaleKeys)
+    }
+
+    @Test("Accessibility migration covers custom services and retries after any incomplete update")
+    func accessibilityMigrationCoversEveryApplicationOwnedService() {
+        let primaryService = "chat.bitchat.test-primary"
+        var visitedServices: [String] = []
+
+        let completed = KeychainManager
+            .migrateAccessibilityForApplicationOwnedServices(
+                primaryService: primaryService
+            ) { service in
+                visitedServices.append(service)
+                return service == "chat.bitchat.favorites"
+                    ? errSecInteractionNotAllowed
+                    : errSecItemNotFound
+            }
+
+        #expect(!completed)
+        #expect(visitedServices.first == primaryService)
+        #expect(Set(visitedServices).isSuperset(of: [
+            "chat.bitchat.nostr",
+            "chat.bitchat.favorites",
+            "chat.bitchat.outbox"
+        ]))
+        #expect(Set(visitedServices).count == visitedServices.count)
+
+        let retryCompleted = KeychainManager
+            .migrateAccessibilityForApplicationOwnedServices(
+                primaryService: primaryService
+            ) { _ in errSecSuccess }
+        #expect(retryCompleted)
+    }
+
+    @Test("Keychain cleanup is complete only when every owned scope is clean")
+    func keychainCleanupRequiresEveryApplicationOwnedService() {
+        let primaryService = "chat.bitchat.test-primary"
+        var visitedServices: [String] = []
+
+        let partialCleanup = KeychainManager
+            .deleteApplicationOwnedKeychainServices(
+                primaryService: primaryService
+            ) { service in
+                visitedServices.append(service)
+                return service == "chat.bitchat.outbox"
+                    ? errSecInteractionNotAllowed
+                    : errSecSuccess
+            }
+
+        #expect(!partialCleanup)
+        #expect(visitedServices.first == primaryService)
+        #expect(Set(visitedServices).isSuperset(of: [
+            "chat.bitchat.nostr",
+            "chat.bitchat.favorites",
+            "chat.bitchat.outbox"
+        ]))
+        #expect(Set(visitedServices).count == visitedServices.count)
+
+        let emptyCleanup = KeychainManager
+            .deleteApplicationOwnedKeychainServices(
+                primaryService: primaryService
+            ) { _ in errSecItemNotFound }
+        #expect(emptyCleanup)
+        #expect(KeychainManager.completedApplicationGroupDelete(status: -34018))
+        #expect(!KeychainManager.completedApplicationGroupDelete(
+            status: errSecInteractionNotAllowed
+        ))
     }
 
     @Test("Preview keychain manager stores identity and service-scoped data in memory")
@@ -71,5 +143,133 @@ struct PreviewKeychainManagerTests {
         } else {
             Issue.record("Expected preview keychain to be empty after deleteAllKeychainData")
         }
+    }
+
+    @Test("Failed reinstall cleanup blocks stale data until a successful retry")
+    func failedReinstallCleanupBlocksEveryNamespaceUntilSuccessfulRetry() {
+        let gate = KeychainInstallAccessGate()
+        var cleanupCanComplete = false
+        var reconciliationAttempts = 0
+        var manager: PreviewKeychainManager!
+        manager = PreviewKeychainManager(
+            installAccessGate: gate
+        ) {
+            reconciliationAttempts += 1
+            guard cleanupCanComplete else { return false }
+            return manager.deleteAllKeychainData()
+        }
+
+        let staleIdentity = Data([1, 2, 3])
+        let staleFavorite = Data([4, 5, 6])
+        let staleOutbox = Data([7, 8, 9])
+        let staleCustom = Data([10, 11, 12])
+        #expect(manager.saveIdentityKey(
+            staleIdentity,
+            forKey: "noiseStaticKey"
+        ))
+        #expect(manager.saveIdentityKey(
+            staleIdentity,
+            forKey: "identity_noiseStaticKey"
+        ))
+        #expect(manager.verifyIdentityKeyExists())
+        manager.save(
+            key: "favorite",
+            data: staleFavorite,
+            service: "chat.bitchat.favorites",
+            accessible: nil
+        )
+        manager.save(
+            key: "outbox",
+            data: staleOutbox,
+            service: "chat.bitchat.outbox",
+            accessible: nil
+        )
+        manager.save(
+            key: "custom",
+            data: staleCustom,
+            service: "chat.bitchat.future-custom",
+            accessible: nil
+        )
+
+        gate.block()
+
+        #expect(manager.getIdentityKey(forKey: "noiseStaticKey") == nil)
+        #expect(!manager.verifyIdentityKeyExists())
+        if case .accessDenied = manager.getIdentityKeyWithResult(
+            forKey: "noiseStaticKey"
+        ) {
+        } else {
+            Issue.record("Expected blocked identity read to fail closed")
+        }
+
+        for (key, service) in [
+            ("favorite", "chat.bitchat.favorites"),
+            ("outbox", "chat.bitchat.outbox"),
+            ("custom", "chat.bitchat.future-custom")
+        ] {
+            #expect(manager.load(key: key, service: service) == nil)
+            if case .accessDenied = manager.loadWithResult(
+                key: key,
+                service: service
+            ) {
+            } else {
+                Issue.record(
+                    "Expected blocked \(service) read to fail closed"
+                )
+            }
+        }
+
+        #expect(!manager.saveIdentityKey(
+            Data([13]),
+            forKey: "replacement"
+        ))
+        if case .accessDenied = manager.saveIdentityKeyWithResult(
+            Data([14]),
+            forKey: "replacement"
+        ) {
+        } else {
+            Issue.record("Expected blocked identity save to fail closed")
+        }
+
+        let failedAttempts = reconciliationAttempts
+        #expect(failedAttempts > 0)
+        cleanupCanComplete = true
+
+        // The first access retries cleanup synchronously. It must not return
+        // any surviving value from before the reinstall.
+        #expect(manager.getIdentityKey(forKey: "noiseStaticKey") == nil)
+        #expect(reconciliationAttempts == failedAttempts + 1)
+        #expect(manager.load(
+            key: "favorite",
+            service: "chat.bitchat.favorites"
+        ) == nil)
+        #expect(manager.load(
+            key: "outbox",
+            service: "chat.bitchat.outbox"
+        ) == nil)
+        #expect(manager.load(
+            key: "custom",
+            service: "chat.bitchat.future-custom"
+        ) == nil)
+
+        let replacementIdentity = Data([21, 22, 23])
+        let replacementCustom = Data([24, 25, 26])
+        #expect(manager.saveIdentityKey(
+            replacementIdentity,
+            forKey: "noiseStaticKey"
+        ))
+        #expect(manager.getIdentityKey(
+            forKey: "noiseStaticKey"
+        ) == replacementIdentity)
+        manager.save(
+            key: "custom",
+            data: replacementCustom,
+            service: "chat.bitchat.future-custom",
+            accessible: nil
+        )
+        #expect(manager.load(
+            key: "custom",
+            service: "chat.bitchat.future-custom"
+        ) == replacementCustom)
     }
 }

--- a/bitchatTests/Services/BLEFileTransferHandlerTests.swift
+++ b/bitchatTests/Services/BLEFileTransferHandlerTests.swift
@@ -370,6 +370,46 @@ struct BLEFileTransferHandlerTests {
         #expect(!FileManager.default.fileExists(atPath: evictable.path))
     }
 
+    @Test
+    func panicWipeDeletesEveryManagedMediaFileAndRecreatesEmptyDirectories() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("panic-media-wipe-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let store = BLEIncomingFileStore(baseDirectory: base)
+        let subdirectories = [
+            "voicenotes/incoming",
+            "voicenotes/outgoing",
+            "images/incoming",
+            "images/outgoing",
+            "files/incoming",
+            "files/outgoing"
+        ]
+
+        for subdirectory in subdirectories {
+            let directory = base
+                .appendingPathComponent("files", isDirectory: true)
+                .appendingPathComponent(subdirectory, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data("secret".utf8).write(to: directory.appendingPathComponent("artifact.bin"))
+        }
+        let unmanaged = base.appendingPathComponent("files/legacy/secret.bin")
+        try FileManager.default.createDirectory(at: unmanaged.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("legacy".utf8).write(to: unmanaged)
+
+        try store.panicWipe()
+
+        #expect(!FileManager.default.fileExists(atPath: unmanaged.path))
+        for subdirectory in subdirectories {
+            let directory = base
+                .appendingPathComponent("files", isDirectory: true)
+                .appendingPathComponent(subdirectory, isDirectory: true)
+            var isDirectory: ObjCBool = false
+            #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
+            #expect(isDirectory.boolValue)
+            #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+        }
+    }
+
     private func expectNoSideEffects(_ recorder: Recorder) {
         #expect(recorder.signedNameQueries.isEmpty)
         #expect(recorder.trackedPackets.isEmpty)

--- a/bitchatTests/Services/BLEFileTransferHandlerTests.swift
+++ b/bitchatTests/Services/BLEFileTransferHandlerTests.swift
@@ -410,6 +410,92 @@ struct BLEFileTransferHandlerTests {
         }
     }
 
+    @Test
+    func panicWipeAttemptsDeletionWhenMarkerPersistenceFails() throws {
+        enum MarkerFailure: Error { case unavailable }
+
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "panic-marker-failure-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: base) }
+        let secret = base
+            .appendingPathComponent("files/images/outgoing", isDirectory: true)
+            .appendingPathComponent("secret.jpg")
+        try FileManager.default.createDirectory(
+            at: secret.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("secret".utf8).write(to: secret)
+        let store = BLEIncomingFileStore(
+            baseDirectory: base,
+            panicMarkerWriter: { _, _ in throw MarkerFailure.unavailable }
+        )
+
+        do {
+            try store.panicWipe(hasDurablePendingMarker: false)
+            Issue.record("Expected the missing durable marker to fail closed")
+        } catch {
+            // The marker error is reported only after the deletion attempt.
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: secret.path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: secret.deletingLastPathComponent().path
+            )
+        )
+    }
+
+    @Test
+    func externalMarkerAllowsDeletionToCommitWhenFileMarkerFails() throws {
+        enum MarkerFailure: Error { case unavailable }
+
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "panic-external-marker-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: base) }
+        let secret = base
+            .appendingPathComponent("files/voicenotes/incoming", isDirectory: true)
+            .appendingPathComponent("secret.m4a")
+        try FileManager.default.createDirectory(
+            at: secret.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("secret".utf8).write(to: secret)
+        let store = BLEIncomingFileStore(
+            baseDirectory: base,
+            panicMarkerWriter: { _, _ in throw MarkerFailure.unavailable }
+        )
+
+        try store.panicWipe(hasDurablePendingMarker: true)
+
+        #expect(!FileManager.default.fileExists(atPath: secret.path))
+    }
+
+    @Test
+    func panicRecoveryMarkerPersistsUntilExplicitCommit() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "panic-recovery-marker-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: base) }
+        let store = BLEIncomingFileStore(baseDirectory: base)
+
+        try store.markPanicRecoveryPending()
+        #expect(try store.isPanicRecoveryPending())
+        try store.panicWipe(hasDurablePendingMarker: true)
+        #expect(try store.isPanicRecoveryPending())
+
+        try store.completePanicRecovery()
+
+        #expect(try !store.isPanicRecoveryPending())
+    }
+
     private func expectNoSideEffects(_ recorder: Recorder) {
         #expect(recorder.signedNameQueries.isEmpty)
         #expect(recorder.trackedPackets.isEmpty)

--- a/bitchatTests/Services/GeohashPresenceServiceTests.swift
+++ b/bitchatTests/Services/GeohashPresenceServiceTests.swift
@@ -76,6 +76,7 @@ final class GeohashPresenceServiceTests: XCTestCase {
             burstMaxDelay: 0
         )
 
+        service.start()
         service.performHeartbeat()
 
         let sentAllAllowedChannels = await waitUntil { sentGeohashes.count == 3 }
@@ -83,7 +84,7 @@ final class GeohashPresenceServiceTests: XCTestCase {
         XCTAssertEqual(Set(sentGeohashes), Set(["9q", "9q8y", "9q8yy"]))
         XCTAssertEqual(Set(lookedUpGeohashes), Set(["9q", "9q8y", "9q8yy"]))
         XCTAssertEqual(sleptNanoseconds.count, 3)
-        XCTAssertEqual(scheduler.intervals, [17])
+        XCTAssertEqual(scheduler.intervals, [17, 17])
     }
 
     func test_performHeartbeat_skipsBroadcastWhenTorIsNotReady() async {
@@ -97,11 +98,12 @@ final class GeohashPresenceServiceTests: XCTestCase {
             loopMaxInterval: 21
         )
 
+        service.start()
         service.performHeartbeat()
         try? await Task.sleep(nanoseconds: 20_000_000)
 
         XCTAssertEqual(sendCount, 0)
-        XCTAssertEqual(scheduler.intervals, [21])
+        XCTAssertEqual(scheduler.intervals, [21, 21])
     }
 
     func test_performHeartbeat_skipsBroadcastWhenAppIsBackgrounded() async {
@@ -115,11 +117,45 @@ final class GeohashPresenceServiceTests: XCTestCase {
             loopMaxInterval: 22
         )
 
+        service.start()
         service.performHeartbeat()
         try? await Task.sleep(nanoseconds: 20_000_000)
 
         XCTAssertEqual(sendCount, 0)
-        XCTAssertEqual(scheduler.intervals, [22])
+        XCTAssertEqual(scheduler.intervals, [22, 22])
+    }
+
+    func test_stopForPanic_cancelsTimerAndSuppressesDelayedBroadcast() async throws {
+        let identity = try NostrIdentity.generate()
+        let scheduler = MockGeohashPresenceScheduler()
+        var sleeperContinuation: CheckedContinuation<Void, Never>?
+        var sendCount = 0
+        let service = makeService(
+            scheduler: scheduler,
+            deriveIdentity: { _ in identity },
+            relaySender: { _, _ in sendCount += 1 },
+            sleeper: { _ in
+                await withCheckedContinuation { continuation in
+                    sleeperContinuation = continuation
+                }
+            },
+            burstMinDelay: 1,
+            burstMaxDelay: 1
+        )
+
+        service.start()
+        service.performHeartbeat()
+        let delayStarted = await waitUntil {
+            sleeperContinuation != nil
+        }
+        XCTAssertTrue(delayStarted)
+
+        service.stopForPanic()
+        sleeperContinuation?.resume()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(sendCount, 0)
+        XCTAssertEqual(scheduler.timers.first?.invalidateCallCount, 1)
     }
 
     func test_broadcastPresence_skipsSendWhenNoRelaysAreAvailable() async throws {

--- a/bitchatTests/Services/NetworkActivationServiceTests.swift
+++ b/bitchatTests/Services/NetworkActivationServiceTests.swift
@@ -91,6 +91,53 @@ final class NetworkActivationServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(context.relayController.connectCallCount, 1)
     }
 
+    func test_stopForPanic_synchronouslyStopsAndIgnoresPublisherUpdates() async {
+        let context = makeService(permission: .authorized, favorites: [])
+
+        context.service.start()
+        context.service.stopForPanic()
+        let connectCountAfterStop = context.relayController.connectCallCount
+        let startCountAfterStop = context.torController.startIfNeededCallCount
+
+        context.favoritesSubject.send([Data([0x01])])
+        context.reachability.set(false)
+        context.reachability.set(true)
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        XCTAssertFalse(context.service.activationAllowed)
+        XCTAssertEqual(context.reachability.stopCallCount, 1)
+        XCTAssertEqual(context.torController.autoStartAllowedValues.last, false)
+        XCTAssertEqual(context.proxyController.proxyModes.last, false)
+        XCTAssertGreaterThanOrEqual(
+            context.torController.shutdownCompletelyCallCount,
+            1
+        )
+        XCTAssertGreaterThanOrEqual(
+            context.relayController.disconnectCallCount,
+            1
+        )
+        XCTAssertEqual(
+            context.relayController.connectCallCount,
+            connectCountAfterStop
+        )
+        XCTAssertEqual(
+            context.torController.startIfNeededCallCount,
+            startCountAfterStop
+        )
+    }
+
+    func test_start_afterPanicStop_reestablishesSubscriptions() {
+        let context = makeService(permission: .authorized, favorites: [])
+
+        context.service.start()
+        context.service.stopForPanic()
+        context.service.start()
+
+        XCTAssertTrue(context.service.activationAllowed)
+        XCTAssertEqual(context.reachability.startCallCount, 2)
+        XCTAssertEqual(context.relayController.connectCallCount, 2)
+    }
+
     private func makeService(
         permission: LocationChannelManager.PermissionState,
         favorites: Set<Data>
@@ -104,6 +151,7 @@ final class NetworkActivationServiceTests: XCTestCase {
         let torController = MockNetworkActivationTorController()
         let relayController = MockNetworkActivationRelayController()
         let proxyController = MockNetworkActivationProxyController()
+        let reachability = MockNetworkActivationReachability()
         let notificationCenter = NotificationCenter()
         let service = NetworkActivationService(
             storage: storage,
@@ -111,7 +159,7 @@ final class NetworkActivationServiceTests: XCTestCase {
             mutualFavoritesPublisher: favoritesSubject.eraseToAnyPublisher(),
             permissionProvider: { permissionSubject.value },
             mutualFavoritesProvider: { favoritesSubject.value },
-            reachabilityMonitor: AlwaysReachableMonitor(),
+            reachabilityMonitor: reachability,
             torController: torController,
             relayController: relayController,
             proxyController: proxyController,
@@ -121,6 +169,7 @@ final class NetworkActivationServiceTests: XCTestCase {
             service: service,
             storage: storage,
             favoritesSubject: favoritesSubject,
+            reachability: reachability,
             torController: torController,
             relayController: relayController,
             proxyController: proxyController,
@@ -148,10 +197,36 @@ private struct NetworkActivationTestContext {
     let service: NetworkActivationService
     let storage: UserDefaults
     let favoritesSubject: CurrentValueSubject<Set<Data>, Never>
+    let reachability: MockNetworkActivationReachability
     let torController: MockNetworkActivationTorController
     let relayController: MockNetworkActivationRelayController
     let proxyController: MockNetworkActivationProxyController
     let notificationCenter: NotificationCenter
+}
+
+@MainActor
+private final class MockNetworkActivationReachability:
+    NetworkReachabilityMonitoring {
+    private let subject = CurrentValueSubject<Bool, Never>(true)
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+
+    var isReachable: Bool { subject.value }
+    var reachabilityPublisher: AnyPublisher<Bool, Never> {
+        subject.removeDuplicates().dropFirst().eraseToAnyPublisher()
+    }
+
+    func start() {
+        startCallCount += 1
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+
+    func set(_ reachable: Bool) {
+        subject.send(reachable)
+    }
 }
 
 @MainActor

--- a/bitchatTests/Services/NetworkReachabilityGateTests.swift
+++ b/bitchatTests/Services/NetworkReachabilityGateTests.swift
@@ -213,6 +213,7 @@ private final class ControllableReachabilityMonitor: NetworkReachabilityMonitori
         subject.removeDuplicates().dropFirst().eraseToAnyPublisher()
     }
     func start() { startCalled = true }
+    func stop() { startCalled = false }
     func set(_ reachable: Bool) { subject.send(reachable) }
 }
 

--- a/bitchatTests/VoiceCaptureSessionTests.swift
+++ b/bitchatTests/VoiceCaptureSessionTests.swift
@@ -61,6 +61,7 @@ private final class GatedVoiceCaptureSession: VoiceCaptureSession {
     private let startError: Error?
     private(set) var finishStarted = false
     private(set) var cancelCount = 0
+    private(set) var panicCancelCount = 0
     private var finishContinuation: CheckedContinuation<URL?, Never>?
 
     init(startError: Error? = nil) {
@@ -81,6 +82,10 @@ private final class GatedVoiceCaptureSession: VoiceCaptureSession {
 
     func cancel() async {
         cancelCount += 1
+    }
+
+    func panicCancelSynchronously() {
+        panicCancelCount += 1
     }
 
     func resolveFinish(with url: URL?) {
@@ -203,5 +208,58 @@ struct VoiceCaptureSessionTests {
             await Task.yield()
         }
         #expect(viewModel.state == .idle)
+    }
+
+    @Test func panicSynchronouslyCancelsActiveCaptureAndResetsUI() async {
+        let session = GatedVoiceCaptureSession()
+        let viewModel = VoiceRecordingViewModel()
+        viewModel.sessionProvider = { session }
+
+        viewModel.start(shouldShow: true)
+        await waitUntil { self.isRecording(viewModel.state) }
+
+        viewModel.panicWipe()
+
+        #expect(session.panicCancelCount == 1)
+        #expect(viewModel.state == .idle)
+        #expect(!viewModel.isLiveStreaming)
+    }
+
+    @Test func panicInvalidatesARecordingAlreadyFinalizing() async throws {
+        let session = GatedVoiceCaptureSession()
+        let viewModel = VoiceRecordingViewModel()
+        viewModel.sessionProvider = { session }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-panic-\(UUID().uuidString).m4a")
+        try Data([0x01]).write(to: url)
+        var delivered = false
+
+        viewModel.start(shouldShow: true)
+        await waitUntil { self.isRecording(viewModel.state) }
+        viewModel.finish { _ in delivered = true }
+        await waitUntil { session.finishStarted }
+
+        viewModel.panicWipe()
+        session.resolveFinish(with: url)
+        await waitUntil {
+            !FileManager.default.fileExists(atPath: url.path)
+        }
+
+        #expect(!delivered)
+        #expect(viewModel.state == .idle)
+    }
+
+    @Test func liveSessionPanicStopsCaptureWithoutSendingControl() {
+        let capture = StubPTTCapture(stopResult: (nil, 0))
+        var sentPackets: [Data] = []
+        let session = PTTLiveVoiceSession(
+            sendPacket: { sentPackets.append($0) },
+            capture: capture
+        )
+
+        session.panicCancelSynchronously()
+
+        #expect(capture.cancelCount == 1)
+        #expect(sentPackets.isEmpty)
     }
 }

--- a/bitchatTests/VoiceRecorderTests.swift
+++ b/bitchatTests/VoiceRecorderTests.swift
@@ -360,6 +360,35 @@ struct VoiceRecorderTests {
         #expect(FileManager.default.fileExists(atPath: secondURL.path))
     }
 
+    @Test func classicSessionPanicStopsRecorderAndDeletesFileBeforeReturning() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let rawSession = VoiceRecorderTestSession()
+        let coordinator = AudioSessionCoordinator(session: rawSession)
+        let factory = TestVoiceAudioRecorderFactory(plans: [.success])
+        let voiceRecorder = VoiceRecorder(
+            sessionCoordinator: coordinator,
+            recorderFactory: factory,
+            permissionGranted: { true },
+            paddingInterval: 0,
+            outputDirectory: directory
+        )
+        let capture = VoiceNoteCaptureSession(recorder: voiceRecorder)
+
+        try await capture.start()
+        let url = try #require(factory.urls.first)
+        let recorder = try #require(factory.recorders.first)
+
+        capture.panicCancelSynchronously()
+
+        #expect(recorder.stopCallCount == 1)
+        #expect(!recorder.isRecording)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        await coordinator.drain()
+        #expect(rawSession.activationCalls == [true, false])
+    }
+
     private func verifyFailedStart(
         firstPlan: TestVoiceAudioRecorderFactory.Plan,
         expectedPrepareCalls: Int,

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -48,7 +48,7 @@ Residual risk: private-message metadata such as timing, radio adjacency, ciphert
 - Recent signed public mesh messages are archived in Application Support for up to 15 minutes so gossip sync survives a relaunch and can cross mesh partitions.
 - Signed public board posts and tombstones persist until author-selected expiry, at most seven days. Stores are bounded by global and per-author quotas.
 - Group metadata (name, roster, creator, epoch) persists as protected JSON; group keys live in the keychain until leave/removal/wipe.
-- Voice notes and images are stored in Application Support. Incoming media has a 100 MB oldest-first quota; outgoing media does not have an equivalent automatic lifetime and remains until cleanup, panic wipe, or app removal.
+- Voice notes and images are stored in Application Support. Incoming media has a 100 MB oldest-first quota; outgoing media does not have an equivalent automatic lifetime and remains until cleanup, panic wipe, or app removal. Panic wipe invalidates detached preparation work, cancels active transfers, closes live capture files, and removes the managed media tree before returning.
 
 Public archives contain content already intended for public mesh/board distribution, but a seized unlocked device can reveal it. Group metadata and media can reveal relationships or content even when the in-memory chat timeline has gone away.
 
@@ -88,7 +88,7 @@ Residual risk: Nostr relay retention and logging are outside project control. Pu
 
 ## Panic Wipe Coverage
 
-The panic action clears identity/session state, preferences, location state, groups, prekeys, outbox mail, courier mail, bridge dedup state, gossip archive, board data, managed media, and active subscriptions/transports. New persistent stores must add an explicit wipe hook and a regression test.
+The panic action clears identity/session state, preferences, location state, groups, prekeys, outbox mail, courier mail, bridge dedup state, gossip archive, board data, managed media, and active subscriptions/transports. Managed media deletion completes synchronously, after active media work has been invalidated. Keychain secrets use device-only accessibility, and an install marker detects and clears app keys that survive uninstall before a later reinstall can use them. New persistent stores must add an explicit wipe hook and a regression test.
 
 ## Release Review Checklist
 


### PR DESCRIPTION
## Summary

- cancel media preparation, active transfers, live PTT, and classic voice recording synchronously before panic deletion
- stop BLE, Tor/Nostr, geohash presence, reachability, and network activation services, and gate late callbacks/outbound work until recovery completes
- delete and recreate the managed media tree even if either durable panic-marker write fails
- recover an interrupted wipe on startup before services or message state can resume
- store identity/group/custom-service secrets with `AfterFirstUnlockThisDeviceOnly`, migrate existing items, and detect reinstall-surviving keys
- fix custom-service key replacement to delete by primary key rather than add-only attributes
- keep current-process keychain access blocked after an incomplete reinstall wipe until synchronous reconciliation succeeds

## Security and failure behavior

The panic latch and recovery marker form a durable two-stage startup gate. A crash, protected-data failure, or late CoreBluetooth callback cannot restart transport work or recreate media before recovery finishes. Media deletion is attempted regardless of marker-write outcome, while already-running network and capture services are stopped explicitly rather than merely prevented from starting later.

This branch is independent of the private-media receipt stack and changes no BLE/Noise/Nostr wire format, so Android and older clients are unaffected.

## Validation

Final release-gate validation was run on assembled exact stack head `ca4c4973008a6e252ab38bdf91e61dce6f024ba6`:

- SwiftPM app suite: 204 XCTest + 1,911 Swift Testing = 2,115 passed, 0 failed
- exact GitHub parallel app-test command: 193 XCTest workers + 1,911 Swift Testing cases passed repeatedly; full strict one-worker cooperative-pool run passed, including the prior media-preparation starvation path
- iPhone 17 / iOS 26.5 simulator: 2,116/2,116 passed, 0 failed, 0 skipped (authoritative `.xcresult` summary)
- focused high-risk iOS suites: 104 passed, 0 failed, including Nostr relay ACKs, Noise/BLE/private media, panic recovery, and reinstall keychain reconciliation
- BitFoundation: 122/122 passed
- macOS Debug unsigned build: succeeded
- strict Periphery scan: no unused code detected
- all 14 PR ranges are linear, with no merge commits, conflict markers, unmerged entries, or `git diff --check` errors
- independent aggregate code review: no remaining P0/P1/P2 findings
- real-device testing covered mesh chat, DMs, reconnect/offline transitions, open-DM updates, delivery/read receipts, image transfer, and Bluetooth transitions
## Current stack

This is layer 1 of 14 and targets `main`.

Landing order: #1431 → #1432 → #1434 → #1463 → #1464 → #1465 → #1466 → #1467 → #1468 → #1437 → #1460 → #1461 → #1462 → #1471. The branches were published together atomically with exact force-with-lease protection.