### PR TITLE
Harden Nostr intake bounds and Noise handshake

### DIFF
--- a/bitchat/App/LocationPresenceStore.swift
+++ b/bitchat/App/LocationPresenceStore.swift
@@ -7,24 +7,78 @@ final class LocationPresenceStore: ObservableObject {
     @Published private(set) var geoNicknames: [String: String] = [:]
     @Published private(set) var teleportedGeo: Set<String> = []
 
+    private let geoNicknameCapacity: Int
+    private var geoNicknameOrder: [String] = []
+
+    init(geoNicknameCapacity: Int = TransportConfig.geoNicknameParticipantsCap) {
+        self.geoNicknameCapacity = max(0, geoNicknameCapacity)
+    }
+
     func setCurrentGeohash(_ geohash: String?) {
-        currentGeohash = geohash?.lowercased()
+        let normalized = geohash?.lowercased()
+        if currentGeohash != normalized {
+            // Nicknames are scoped to the active geohash presence table.
+            clearGeoNicknames()
+        }
+        currentGeohash = normalized
     }
 
     func setNickname(_ nickname: String, for pubkeyHex: String) {
-        geoNicknames[pubkeyHex.lowercased()] = nickname
+        guard geoNicknameCapacity > 0 else {
+            clearGeoNicknames()
+            return
+        }
+
+        let key = pubkeyHex.lowercased()
+        if geoNicknames[key] != nil {
+            geoNicknames[key] = nickname
+            return
+        }
+
+        while geoNicknameOrder.count >= geoNicknameCapacity, let oldest = geoNicknameOrder.first {
+            geoNicknameOrder.removeFirst()
+            geoNicknames.removeValue(forKey: oldest)
+        }
+
+        geoNicknames[key] = nickname
+        geoNicknameOrder.append(key)
     }
 
     func replaceGeoNicknames(_ nicknames: [String: String]) {
-        geoNicknames = Dictionary(
-            uniqueKeysWithValues: nicknames.map { key, value in
-                (key.lowercased(), value)
-            }
-        )
+        guard geoNicknameCapacity > 0 else {
+            clearGeoNicknames()
+            return
+        }
+
+        var seen: Set<String> = []
+        var ordered: [String] = []
+        var normalized: [String: String] = [:]
+        for (key, value) in nicknames {
+            let lower = key.lowercased()
+            guard seen.insert(lower).inserted else { continue }
+            ordered.append(lower)
+            normalized[lower] = value
+        }
+        if ordered.count > geoNicknameCapacity {
+            let kept = Array(ordered.suffix(geoNicknameCapacity))
+            ordered = kept
+            normalized = Dictionary(uniqueKeysWithValues: kept.compactMap { key in
+                normalized[key].map { (key, $0) }
+            })
+        }
+        geoNicknameOrder = ordered
+        geoNicknames = normalized
     }
 
     func clearGeoNicknames() {
         geoNicknames.removeAll()
+        geoNicknameOrder.removeAll()
+    }
+
+    func retainGeoNicknames(keeping pubkeys: Set<String>) {
+        let allowed = Set(pubkeys.map { $0.lowercased() })
+        geoNicknameOrder = geoNicknameOrder.filter { allowed.contains($0) }
+        geoNicknames = geoNicknames.filter { allowed.contains($0.key) }
     }
 
     func markTeleported(_ pubkeyHex: String) {
@@ -46,6 +100,7 @@ final class LocationPresenceStore: ObservableObject {
     func reset() {
         currentGeohash = nil
         geoNicknames.removeAll()
+        geoNicknameOrder.removeAll()
         teleportedGeo.removeAll()
     }
 }

--- a/bitchat/Noise/NoiseSession.swift
+++ b/bitchat/Noise/NoiseSession.swift
@@ -66,7 +66,10 @@ class NoiseSession {
             
             // Only initiator writes the first message
             if role == .initiator {
-                let message = try handshakeState!.writeMessage()
+                guard let handshake = handshakeState else {
+                    throw NoiseSessionError.invalidState
+                }
+                let message = try handshake.writeMessage()
                 sentHandshakeMessages.append(message)
                 return message
             } else {

--- a/bitchat/Nostr/NostrProtocol.swift
+++ b/bitchat/Nostr/NostrProtocol.swift
@@ -700,6 +700,10 @@ struct NostrEvent: Codable {
               let content = dict["content"] as? String else {
             throw NostrError.invalidEvent
         }
+
+        guard Self.isWithinInboundTagLimits(tags) else {
+            throw NostrError.invalidEvent
+        }
         
         self.id = dict["id"] as? String ?? ""
         self.pubkey = pubkey
@@ -708,6 +712,21 @@ struct NostrEvent: Codable {
         self.tags = tags
         self.content = content
         self.sig = dict["sig"] as? String
+    }
+
+    /// Bounds untrusted relay tag arrays so attackers cannot force large
+    /// allocations or expensive joins on the inbound hot path.
+    static func isWithinInboundTagLimits(_ tags: [[String]]) -> Bool {
+        guard tags.count <= TransportConfig.nostrMaxEventTags else { return false }
+
+        for tag in tags {
+            guard tag.count <= TransportConfig.nostrMaxEventTagValues else { return false }
+            guard tag.allSatisfy({ $0.utf8.count <= TransportConfig.nostrMaxEventTagValueBytes }) else {
+                return false
+            }
+        }
+
+        return true
     }
     
     func sign(with key: P256K.Schnorr.PrivateKey) throws -> NostrEvent {

--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -1480,7 +1480,7 @@ private enum ParsedInbound {
     case notice(String)
     
     init?(_ message: URLSessionWebSocketTask.Message) {
-        guard let data = message.data,
+        guard let data = message.dataWithinInboundLimit,
               let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
               array.count >= 2,
               let type = array[0] as? String else {
@@ -1530,6 +1530,22 @@ private extension URLSessionWebSocketTask.Message {
         case .string(let text): text.data(using: .utf8)
         case .data(let data):   data
         @unknown default:       nil
+        }
+    }
+
+    /// Prefer rejecting oversized frames before UTF-8/Data materialization
+    /// where we can (string length), and always before JSON parse.
+    var dataWithinInboundLimit: Data? {
+        let maxBytes = TransportConfig.nostrMaxInboundMessageBytes
+        switch self {
+        case .string(let text):
+            guard text.utf8.count <= maxBytes else { return nil }
+            return text.data(using: .utf8)
+        case .data(let data):
+            guard data.count <= maxBytes else { return nil }
+            return data
+        @unknown default:
+            return nil
         }
     }
 }

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -46,6 +46,7 @@ enum TransportConfig {
     static let privateChatCap: Int = 1337
     static let meshTimelineCap: Int = 1337
     static let geoTimelineCap: Int = 1337
+    static let geoNicknameParticipantsCap: Int = 1337
     static let contentLRUCap: Int = 2000
     static let geoSamplingEventLRUCap: Int = 2000
 
@@ -81,6 +82,11 @@ enum TransportConfig {
     static let nostrDuplicateEventLogInterval: Int = 50
     // Sample interval for per-event debug logs on the inbound hot path.
     static let nostrInboundEventLogInterval: Int = 100
+    // Reject oversized/untrusted relay frames before JSON parse / store.
+    static let nostrMaxInboundMessageBytes: Int = 256 * 1024
+    static let nostrMaxEventTags: Int = 64
+    static let nostrMaxEventTagValues: Int = 16
+    static let nostrMaxEventTagValueBytes: Int = 1024
 
     // Conversation store diagnostics (field observability)
     // Sample interval for the periodic store-audit "OK" heartbeat line

--- a/bitchat/ViewModels/ChatViewModelBootstrapper.swift
+++ b/bitchat/ViewModels/ChatViewModelBootstrapper.swift
@@ -156,6 +156,17 @@ private extension ChatViewModelBootstrapper {
                 viewModel?.objectWillChange.send()
             }
             .store(in: &viewModel.cancellables)
+
+        viewModel.participantTracker.$visiblePeople
+            .receive(on: DispatchQueue.main)
+            .sink { [weak viewModel] people in
+                Task { @MainActor [weak viewModel] in
+                    viewModel?.locationPresenceStore.retainGeoNicknames(
+                        keeping: Set(people.map { $0.id })
+                    )
+                }
+            }
+            .store(in: &viewModel.cancellables)
     }
 
     func loadPersistedViewState() {

--- a/bitchat/ViewModels/NostrInboundPipeline.swift
+++ b/bitchat/ViewModels/NostrInboundPipeline.swift
@@ -196,7 +196,10 @@ final class NostrInboundPipeline {
         // Sampled: fires for every geo event and floods dev logs in busy geohashes.
         geoEventLogCount += 1
         if geoEventLogCount == 1 || geoEventLogCount.isMultiple(of: TransportConfig.nostrInboundEventLogInterval) {
-            SecureLogger.debug("GeoTeleport: recv #\(geoEventLogCount) pub=\(event.pubkey.prefix(8))… pow=\(powBits) tags=\(event.tags.map { "[" + $0.joined(separator: ",") + "]" }.joined(separator: ","))", category: .session)
+            SecureLogger.debug(
+                "GeoTeleport: recv #\(geoEventLogCount) pub=\(event.pubkey.prefix(8))… pow=\(powBits) tagCount=\(event.tags.count)",
+                category: .session
+            )
         }
 
         if context.isNostrBlocked(pubkeyHexLowercased: event.pubkey) {

--- a/bitchatTests/AppArchitectureTests.swift
+++ b/bitchatTests/AppArchitectureTests.swift
@@ -147,6 +147,25 @@ struct AppArchitectureTests {
         #expect(store.teleportedGeo.isEmpty)
     }
 
+    @Test("LocationPresenceStore bounds geohash nicknames and clears on channel switch")
+    @MainActor
+    func locationPresenceStoreBoundsGeoNicknames() {
+        let store = LocationPresenceStore(geoNicknameCapacity: 2)
+
+        store.setCurrentGeohash("u4pruy")
+        store.setNickname("alice", for: "AAAAAA")
+        store.setNickname("bob", for: "BBBBBB")
+        store.setNickname("carol", for: "CCCCCC")
+
+        #expect(store.geoNicknames == ["bbbbbb": "bob", "cccccc": "carol"])
+
+        store.retainGeoNicknames(keeping: Set(["CCCCCC"]))
+        #expect(store.geoNicknames == ["cccccc": "carol"])
+
+        store.setCurrentGeohash("u4pruz")
+        #expect(store.geoNicknames.isEmpty)
+    }
+
     @Test("PeerHandle equality and hashing use the canonical identity only")
     func peerHandleEqualityUsesCanonicalIdentity() {
         let first = PeerHandle(id: "noise:abc123", routingPeerID: PeerID(str: "peer-a"))

--- a/bitchatTests/NostrProtocolTests.swift
+++ b/bitchatTests/NostrProtocolTests.swift
@@ -290,7 +290,65 @@ struct NostrProtocolTests {
         #expect(object["limit"] as? Int == 42)
     }
 
+
+    @Test func inboundNostrEventRejectsTooManyTags() throws {
+        var eventDict = Self.validInboundEventDict()
+        eventDict["tags"] = Array(
+            repeating: ["g", "u4pruyd"],
+            count: TransportConfig.nostrMaxEventTags + 1
+        )
+
+        #expect(throws: NostrError.invalidEvent) {
+            _ = try NostrEvent(from: eventDict)
+        }
+    }
+
+    @Test func inboundNostrEventRejectsTooManyTagValues() throws {
+        var eventDict = Self.validInboundEventDict()
+        eventDict["tags"] = [Array(
+            repeating: "value",
+            count: TransportConfig.nostrMaxEventTagValues + 1
+        )]
+
+        #expect(throws: NostrError.invalidEvent) {
+            _ = try NostrEvent(from: eventDict)
+        }
+    }
+
+    @Test func inboundNostrEventRejectsOversizedTagValues() throws {
+        var eventDict = Self.validInboundEventDict()
+        eventDict["tags"] = [[
+            "g",
+            String(repeating: "a", count: TransportConfig.nostrMaxEventTagValueBytes + 1)
+        ]]
+
+        #expect(throws: NostrError.invalidEvent) {
+            _ = try NostrEvent(from: eventDict)
+        }
+    }
+
+    @Test func inboundNostrEventAcceptsTagsWithinLimits() throws {
+        var eventDict = Self.validInboundEventDict()
+        eventDict["tags"] = [["g", "u4pruyd"], ["t", "teleport"]]
+
+        let event = try NostrEvent(from: eventDict)
+
+        #expect(event.tags.count == 2)
+    }
+
     // MARK: - Helpers
+    private static func validInboundEventDict() -> [String: Any] {
+        [
+            "id": String(repeating: "0", count: 64),
+            "pubkey": String(repeating: "1", count: 64),
+            "created_at": 1_234_567,
+            "kind": NostrProtocol.EventKind.ephemeralEvent.rawValue,
+            "tags": [["g", "u4pruyd"]],
+            "content": "hello",
+            "sig": String(repeating: "2", count: 128)
+        ]
+    }
+
     private static func base64URLDecode(_ s: String) -> Data? {
         var str = s.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
         let rem = str.count % 4


### PR DESCRIPTION
## Summary
- Cap inbound Nostr message/tag sizes and stop concatenating untrusted tags into logs
- Replace Noise `startHandshake` force unwrap with a fail-soft invalidState path
- Bound the geohash nickname map (FIFO + channel-switch clear + visible prune)

## Test plan
- [x] Nostr tag-limit unit tests
- [x] LocationPresenceStore nickname bound/prune tests
- [ ] CI: Build & Test + Release apps

Made with [Cursor](https://cursor.com)