### PR TITLE
Guard the NoiseSessionManager incoming-handshake reuse branch instead of force-unwrapping

### DIFF
--- a/bitchat/Noise/NoiseSessionManager.swift
+++ b/bitchat/Noise/NoiseSessionManager.swift
@@ -132,7 +132,15 @@ final class NoiseSessionManager {
                 sessions[peerID] = newSession
                 session = newSession
             } else {
-                session = existingSession!
+                // `shouldCreateNew` is only false after the branch above assigned
+                // `existingSession`, so this should always succeed. Guard instead of
+                // force-unwrapping so a future change that breaks that coupling fails
+                // this handshake softly rather than crashing a critical path.
+                guard let reusableSession = existingSession else {
+                    SecureLogger.error("NoiseSessionManager: reuse branch reached with no session for \(peerID); rejecting handshake", category: .session)
+                    throw NoiseSessionError.invalidState
+                }
+                session = reusableSession
             }
             
             // Process the handshake message within the synchronized block

--- a/bitchatTests/Noise/NoiseSessionManagerStateTransitionTests.swift
+++ b/bitchatTests/Noise/NoiseSessionManagerStateTransitionTests.swift
@@ -1,0 +1,276 @@
+//
+// NoiseSessionManagerStateTransitionTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import CryptoKit
+import Foundation
+import Testing
+import BitFoundation
+
+@testable import bitchat
+
+/// State-transition coverage for `NoiseSessionManager.handleIncomingHandshake`.
+///
+/// These tests drive the incoming-session *selection* state machine — create,
+/// reuse, replace, fail — through the `#if DEBUG` `sessionFactory` hook using
+/// scripted `NoiseSession` doubles, so each branch can be exercised deterministically
+/// without a real Noise handshake.
+///
+/// They characterize the invariant that used to sit behind the `existingSession!`
+/// force unwrap in the reuse branch: whenever the manager decides to *reuse*, a
+/// session is present; whenever it decides to *create* or *replace*, exactly one new
+/// responder is minted before the message is processed. The nil case that the former
+/// `!` would have trapped on is unreachable through the public API by construction,
+/// so these are regression guards for the state machine, not a reproduction of a
+/// live crash — a future refactor that breaks the create/reuse coupling now fails a
+/// test (and, at runtime, a handshake) instead of crashing.
+@Suite("Noise Session Manager State Transitions")
+struct NoiseSessionManagerStateTransitionTests {
+    private let keychain = MockKeychain()
+    private let localStaticKey = Curve25519.KeyAgreement.PrivateKey()
+    private let peerID = PeerID(str: "0011223344556677")
+
+    // MARK: (a) No existing session -> a responder is created and processes once
+
+    @Test("No existing session creates one responder and processes the message once")
+    func createsResponderWhenNoSessionExists() throws {
+        let factory = ScriptedSessionFactory(keychain: keychain, localStaticKey: localStaticKey)
+        let responder = factory.enqueue(.respond(Data([0x01])))
+        let manager = makeManager(factory)
+
+        let response = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+
+        #expect(response == Data([0x01]))
+        #expect(factory.createdRoles == [.responder])
+        #expect(responder.processCallCount == 1)
+        #expect(manager.getSession(for: peerID) === responder)
+    }
+
+    // MARK: (b) Existing unfinished handshake -> reused, no second responder
+
+    @Test("Existing unfinished handshake is reused without minting a second responder")
+    func reusesExistingUnfinishedSession() throws {
+        let factory = ScriptedSessionFactory(keychain: keychain, localStaticKey: localStaticKey)
+        let responder = factory.enqueue(.respond(Data([0x01])), state: .handshaking, established: false)
+        let manager = makeManager(factory)
+
+        // First message creates the responder and leaves it mid-handshake.
+        _ = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+        // A continuation message (not a 32-byte re-initiation) must reuse that session.
+        let response = try manager.handleIncomingHandshake(from: peerID, message: continuationMessage())
+
+        #expect(response == Data([0x01]))
+        #expect(factory.createdRoles == [.responder]) // exactly one responder ever minted
+        #expect(responder.processCallCount == 2)       // the same session handled both messages
+        #expect(manager.getSession(for: peerID) === responder)
+    }
+
+    // MARK: (c) Existing established session -> removed, fresh responder created before processing
+
+    @Test("Established session is replaced by a fresh responder that processes the new handshake")
+    func replacesEstablishedSession() throws {
+        let factory = ScriptedSessionFactory(keychain: keychain, localStaticKey: localStaticKey)
+        let established = factory.enqueue(.respond(Data([0x01])), state: .established, established: true)
+        let replacement = factory.enqueue(.respond(Data([0x02])), state: .handshaking, established: false)
+        let manager = makeManager(factory)
+
+        _ = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+        let response = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+
+        #expect(response == Data([0x02]))
+        #expect(factory.createdRoles == [.responder, .responder]) // old removed, new minted
+        #expect(established.processCallCount == 1)                 // established did not handle the 2nd message
+        #expect(replacement.processCallCount == 1)                 // the new responder handled it
+        #expect(manager.getSession(for: peerID) === replacement)
+    }
+
+    // MARK: (d) Restart-style 32-byte initiation during an unfinished handshake -> replaced
+
+    @Test("A 32-byte re-initiation during an unfinished handshake replaces the session")
+    func restartInitiationReplacesUnfinishedSession() throws {
+        let factory = ScriptedSessionFactory(keychain: keychain, localStaticKey: localStaticKey)
+        let firstResponder = factory.enqueue(.respond(Data([0x01])), state: .handshaking, established: false)
+        let replacement = factory.enqueue(.respond(Data([0x02])), state: .handshaking, established: false)
+        let manager = makeManager(factory)
+
+        _ = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+        // A 32-byte initiation while the first session is still handshaking -> restart.
+        let response = try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+
+        #expect(response == Data([0x02]))
+        #expect(factory.createdRoles == [.responder, .responder])
+        #expect(firstResponder.processCallCount == 1)
+        #expect(replacement.processCallCount == 1)
+        #expect(manager.getSession(for: peerID) === replacement)
+    }
+
+    // MARK: (e) Processing failure -> session removed, error propagated, onSessionFailed once
+
+    @Test("A processing failure removes the session, propagates the error, and fires onSessionFailed once")
+    func processingFailureCleansUpAndReportsOnce() async throws {
+        let factory = ScriptedSessionFactory(keychain: keychain, localStaticKey: localStaticKey)
+        _ = factory.enqueue(.fail(ScriptedSessionError.synthetic))
+        let manager = makeManager(factory)
+        let recorder = FailureRecorder()
+        manager.onSessionFailed = recorder.record(peerID:error:)
+
+        #expect(throws: ScriptedSessionError.synthetic) {
+            try manager.handleIncomingHandshake(from: peerID, message: initiationMessage())
+        }
+        #expect(manager.getSession(for: peerID) == nil)
+
+        let reportedOnce = await TestHelpers.waitUntil({ recorder.count == 1 }, timeout: 5.0)
+        #expect(reportedOnce)
+        #expect(recorder.count == 1)
+        #expect(recorder.lastPeerID == peerID)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager(_ factory: ScriptedSessionFactory) -> NoiseSessionManager {
+        NoiseSessionManager(
+            localStaticKey: localStaticKey,
+            keychain: keychain,
+            sessionFactory: factory.make(peerID:role:)
+        )
+    }
+
+    /// A 32-byte payload mimics the first XX handshake message (a fresh initiation).
+    private func initiationMessage() -> Data { Data(repeating: 0xAB, count: 32) }
+
+    /// A non-32-byte payload mimics a handshake continuation, which must not restart the session.
+    private func continuationMessage() -> Data { Data(repeating: 0xCD, count: 48) }
+}
+
+// MARK: - Test doubles
+
+private enum ScriptedSessionError: Error {
+    case synthetic
+}
+
+/// A `NoiseSession` double whose handshake behaviour and reported state are fixed at
+/// construction, letting the manager's branch selection be driven deterministically.
+/// Reads of its counters are safe after `handleIncomingHandshake` returns, because the
+/// manager processes each message inside its serial barrier queue.
+private final class ScriptedNoiseSession: NoiseSession {
+    enum Behavior {
+        case respond(Data)      // return this response from processHandshakeMessage
+        case complete           // return nil (handshake finished)
+        case fail(Error)        // throw from processHandshakeMessage
+    }
+
+    private let behavior: Behavior
+    private let reportedState: NoiseSessionState
+    private let reportedEstablished: Bool
+    private(set) var processCallCount = 0
+
+    init(
+        peerID: PeerID,
+        role: NoiseRole,
+        keychain: KeychainManagerProtocol,
+        localStaticKey: Curve25519.KeyAgreement.PrivateKey,
+        behavior: Behavior,
+        state: NoiseSessionState,
+        established: Bool
+    ) {
+        self.behavior = behavior
+        self.reportedState = state
+        self.reportedEstablished = established
+        super.init(peerID: peerID, role: role, keychain: keychain, localStaticKey: localStaticKey)
+    }
+
+    override func getState() -> NoiseSessionState { reportedState }
+
+    override func isEstablished() -> Bool { reportedEstablished }
+
+    // Keep establishment side effects (onSessionEstablished) out of these tests.
+    override func getRemoteStaticPublicKey() -> Curve25519.KeyAgreement.PublicKey? { nil }
+
+    override func processHandshakeMessage(_ message: Data) throws -> Data? {
+        processCallCount += 1
+        switch behavior {
+        case .respond(let data): return data
+        case .complete: return nil
+        case .fail(let error): throw error
+        }
+    }
+}
+
+/// Vends pre-scripted `ScriptedNoiseSession`s in FIFO order and records the role of
+/// every session the manager asks it to create.
+private final class ScriptedSessionFactory {
+    private let keychain: KeychainManagerProtocol
+    private let localStaticKey: Curve25519.KeyAgreement.PrivateKey
+    private var queued: [ScriptedNoiseSession] = []
+    private(set) var createdRoles: [NoiseRole] = []
+
+    init(keychain: KeychainManagerProtocol, localStaticKey: Curve25519.KeyAgreement.PrivateKey) {
+        self.keychain = keychain
+        self.localStaticKey = localStaticKey
+    }
+
+    /// Registers the next session the factory will hand out and returns it so the test
+    /// can assert on its observations afterwards.
+    @discardableResult
+    func enqueue(
+        _ behavior: ScriptedNoiseSession.Behavior,
+        state: NoiseSessionState = .handshaking,
+        established: Bool = false
+    ) -> ScriptedNoiseSession {
+        let session = ScriptedNoiseSession(
+            peerID: PeerID(str: "0011223344556677"),
+            role: .responder,
+            keychain: keychain,
+            localStaticKey: localStaticKey,
+            behavior: behavior,
+            state: state,
+            established: established
+        )
+        queued.append(session)
+        return session
+    }
+
+    func make(peerID: PeerID, role: NoiseRole) -> NoiseSession {
+        createdRoles.append(role)
+        guard !queued.isEmpty else {
+            Issue.record("ScriptedSessionFactory asked for more sessions than were enqueued")
+            return ScriptedNoiseSession(
+                peerID: peerID,
+                role: role,
+                keychain: keychain,
+                localStaticKey: localStaticKey,
+                behavior: .complete,
+                state: .handshaking,
+                established: false
+            )
+        }
+        return queued.removeFirst()
+    }
+}
+
+/// Thread-safe recorder for the asynchronously dispatched `onSessionFailed` callback,
+/// mirroring the locking pattern used by the existing Noise coverage tests.
+private final class FailureRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [(PeerID, Error)] = []
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return entries.count
+    }
+
+    var lastPeerID: PeerID? {
+        lock.lock(); defer { lock.unlock() }
+        return entries.last?.0
+    }
+
+    func record(peerID: PeerID, error: Error) {
+        lock.lock()
+        entries.append((peerID, error))
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
Addresses the `NoiseSessionManager` force-unwrap item in #645 (umbrella "Stability: Remove force unwraps and `try!` in critical paths"). This does **not** close #645 — it fixes one item from that list.

**What.** `handleIncomingHandshake(from:message:)` selects an incoming session via two separately-maintained locals (`shouldCreateNew`, `existingSession`) and reuses the existing one with `session = existingSession!`. This swaps the `!` for a `guard let` that logs the impossible state via `SecureLogger` and fails soft (`throw NoiseSessionError.invalidState`) instead of trapping — exactly the issue's proposed remedy ("Swap `!` with `guard let/if let` and log via SecureLogger").

**When can it be nil?** The reuse branch runs only when `shouldCreateNew == false`, which today is set only on the one path that also assigns `existingSession = existing` (an existing non-established session that isn't a 32-byte restart). Every other path (no session / established→removed / 32-byte re-init→removed) sets `shouldCreateNew = true`. So the unwrap is safe *by construction* right now.

**Why it's still unsafe.** The safety rests on an implicit, type-unchecked coupling between two mutable locals updated in separate branches. A future edit — new branch, reordered condition, refactored establishment/restart handling — can break `!shouldCreateNew ⟹ existingSession != nil` and turn a rare state combination into a `fatalError` on a critical, attacker-reachable path (untrusted inbound handshake bytes). That's precisely the "crash under rare timing or data conditions" class #645 targets.

**If the invariant is violated post-patch.** The manager logs `NoiseSessionManager: reuse branch reached with no session …` (`SecureLogger.error`, category `.session`) and throws `NoiseSessionError.invalidState`. The sole caller, `NoiseEncryptionService`, already calls this with `try`, and the function already throws (`.alreadyEstablished`, plus re-thrown handshake failures) — so the new throw travels an existing, handled path. The peer simply retries; no crash, no session-state corruption.

**Behavior preserved.** New handshake w/ no session → responder created & processes. Established session → removed, fresh responder before processing. Unfinished + 32-byte re-init → replaced. Unfinished + continuation → same session reused (the former force-unwrap branch — identical behavior, `existingSession` non-nil). Processing failure → session removed, error propagated, `onSessionFailed` once. No changes to the Noise wire protocol, handshake messages, key derivation, retry semantics, or barrier-queue synchronization.

**Tests.** New `bitchatTests/Noise/NoiseSessionManagerStateTransitionTests.swift` (Swift Testing) drives the selection state machine through the existing `#if DEBUG` `sessionFactory` hook with scripted `NoiseSession` doubles: (1) create; (2) reuse, no 2nd responder; (3) replace established; (4) restart replace; (5) failure cleanup + single `onSessionFailed`. Scope note: the nil case the former `!` would trap on is unreachable through the public API by construction, so these are characterization/regression guards that lock in the create/reuse/replace/fail invariant — a future refactor breaking the coupling now fails a test (and, at runtime, fails a handshake softly) rather than crashing.

**Validation.** macOS no-signing build: `** BUILD SUCCEEDED **`. iOS simulator (iPhone 16 Pro), new suite: `** TEST SUCCEEDED **`, 5/5 passed. `git diff --check` clean.

**AI/LLM disclosure.** This change was drafted with the assistance of an AI coding agent (Claude Code). A human maintainer reviewed the diff, the nil-reachability reasoning, and the fail-soft error choice, and ran the macOS build and iOS test suite locally before submission.
