### PR TITLE
Keep open DMs alive across Bluetooth settings

### DIFF
--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -6,6 +6,18 @@ import UIKit
 import AppKit
 #endif
 
+struct ContentPeopleSheetModalPresentationState {
+    var isImagePreviewPresented = false
+    var isVerificationSheetPresented = false
+    var isMediaPickerPresented = false
+
+    var hasPresentation: Bool {
+        isImagePreviewPresented
+            || isVerificationSheetPresented
+            || isMediaPickerPresented
+    }
+}
+
 struct ContentPeopleSheetView: View {
     @EnvironmentObject private var appChromeModel: AppChromeModel
     @EnvironmentObject private var privateConversationModel: PrivateConversationModel
@@ -24,6 +36,7 @@ struct ContentPeopleSheetView: View {
     var isTextFieldFocused: FocusState<Bool>.Binding
     @ObservedObject var voiceRecordingVM: VoiceRecordingViewModel
     @Binding var autocompleteDebounceTimer: Timer?
+    @State private var showVerifySheet = false
     @ThemedPalette private var palette
 
     let headerHeight: CGFloat
@@ -37,14 +50,17 @@ struct ContentPeopleSheetView: View {
     #endif
 
     private var hasModalPresentation: Bool {
-        if imagePreviewURL != nil {
-            return true
-        }
         #if os(iOS)
-        return showImagePicker
+        let isMediaPickerPresented = showImagePicker
         #else
-        return showMacImagePicker
+        let isMediaPickerPresented = showMacImagePicker
         #endif
+
+        return ContentPeopleSheetModalPresentationState(
+            isImagePreviewPresented: imagePreviewURL != nil,
+            isVerificationSheetPresented: showVerifySheet,
+            isMediaPickerPresented: isMediaPickerPresented
+        ).hasPresentation
     }
 
     private var bluetoothAlertBinding: Binding<Bool> {
@@ -108,7 +124,8 @@ struct ContentPeopleSheetView: View {
                     #endif
                 } else {
                     ContentPeopleListView(
-                        showSidebar: $showSidebar
+                        showSidebar: $showSidebar,
+                        showVerifySheet: $showVerifySheet
                     )
                 }
             }
@@ -237,8 +254,7 @@ private struct ContentPeopleListView: View {
     @ThemedPalette private var palette
 
     @Binding var showSidebar: Bool
-
-    @State private var showVerifySheet = false
+    @Binding var showVerifySheet: Bool
 
     var body: some View {
         VStack(spacing: 0) {

--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -9,11 +9,13 @@ import AppKit
 struct ContentPeopleSheetModalPresentationState {
     var isImagePreviewPresented = false
     var isVerificationSheetPresented = false
+    var legacyPrivateMediaConsentRequest: LegacyPrivateMediaConsentRequest? = nil
     var isMediaPickerPresented = false
 
     var hasPresentation: Bool {
         isImagePreviewPresented
             || isVerificationSheetPresented
+            || legacyPrivateMediaConsentRequest != nil
             || isMediaPickerPresented
     }
 }
@@ -59,6 +61,8 @@ struct ContentPeopleSheetView: View {
         return ContentPeopleSheetModalPresentationState(
             isImagePreviewPresented: imagePreviewURL != nil,
             isVerificationSheetPresented: showVerifySheet,
+            legacyPrivateMediaConsentRequest:
+                conversationUIModel.legacyPrivateMediaConsentRequest,
             isMediaPickerPresented: isMediaPickerPresented
         ).hasPresentation
     }

--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -11,6 +11,7 @@ struct ContentPeopleSheetView: View {
     @EnvironmentObject private var privateConversationModel: PrivateConversationModel
     @EnvironmentObject private var verificationModel: VerificationModel
     @EnvironmentObject private var conversationUIModel: ConversationUIModel
+    @Environment(\.scenePhase) private var scenePhase
 
     @Binding var showSidebar: Bool
     @Binding var messageText: String
@@ -34,6 +35,35 @@ struct ContentPeopleSheetView: View {
     #else
     @Binding var showMacImagePicker: Bool
     #endif
+
+    private var hasModalPresentation: Bool {
+        if imagePreviewURL != nil {
+            return true
+        }
+        #if os(iOS)
+        return showImagePicker
+        #else
+        return showMacImagePicker
+        #endif
+    }
+
+    private var bluetoothAlertBinding: Binding<Bool> {
+        Binding(
+            get: {
+                scenePhase == .active
+                    && appChromeModel.showBluetoothAlert
+                    && !hasModalPresentation
+            },
+            set: { isPresented in
+                guard !isPresented,
+                      scenePhase == .active,
+                      !hasModalPresentation else {
+                    return
+                }
+                appChromeModel.showBluetoothAlert = false
+            }
+        )
+    }
 
     var body: some View {
         let legacyConsentRequest = conversationUIModel.legacyPrivateMediaConsentRequest
@@ -182,6 +212,17 @@ struct ContentPeopleSheetView: View {
             }
         }
         #endif
+        .alert(
+            "content.alert.bluetooth_required.title",
+            isPresented: bluetoothAlertBinding
+        ) {
+            Button("content.alert.bluetooth_required.settings") {
+                SystemSettings.bluetooth.open()
+            }
+            Button("common.ok", role: .cancel) {}
+        } message: {
+            Text(appChromeModel.bluetoothAlertMessage)
+        }
     }
 }
 

--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -10,12 +10,14 @@ struct ContentPeopleSheetModalPresentationState {
     var isImagePreviewPresented = false
     var isVerificationSheetPresented = false
     var legacyPrivateMediaConsentRequest: LegacyPrivateMediaConsentRequest? = nil
+    var isVoiceAlertPresented = false
     var isMediaPickerPresented = false
 
     var hasPresentation: Bool {
         isImagePreviewPresented
             || isVerificationSheetPresented
             || legacyPrivateMediaConsentRequest != nil
+            || isVoiceAlertPresented
             || isMediaPickerPresented
     }
 }
@@ -51,7 +53,9 @@ struct ContentPeopleSheetView: View {
     @Binding var showMacImagePicker: Bool
     #endif
 
-    private var hasModalPresentation: Bool {
+    private func modalPresentationState(
+        includingVoiceAlert: Bool
+    ) -> ContentPeopleSheetModalPresentationState {
         #if os(iOS)
         let isMediaPickerPresented = showImagePicker
         #else
@@ -63,8 +67,19 @@ struct ContentPeopleSheetView: View {
             isVerificationSheetPresented: showVerifySheet,
             legacyPrivateMediaConsentRequest:
                 conversationUIModel.legacyPrivateMediaConsentRequest,
+            isVoiceAlertPresented: includingVoiceAlert && voiceRecordingVM.showAlert,
             isMediaPickerPresented: isMediaPickerPresented
-        ).hasPresentation
+        )
+    }
+
+    private var hasModalPresentation: Bool {
+        modalPresentationState(includingVoiceAlert: true).hasPresentation
+    }
+
+    /// The voice alert cannot defer to itself: its own binding must keep
+    /// reporting `true` while it is the presented modal.
+    private var hasModalPresentationBesidesVoiceAlert: Bool {
+        modalPresentationState(includingVoiceAlert: false).hasPresentation
     }
 
     private var bluetoothAlertBinding: Binding<Bool> {
@@ -81,6 +96,28 @@ struct ContentPeopleSheetView: View {
                     return
                 }
                 appChromeModel.showBluetoothAlert = false
+            }
+        )
+    }
+
+    /// Voice recording happens inside this sheet, so its error alert must
+    /// present from here as well: the root copy defers whenever this sheet
+    /// is up, exactly like the Bluetooth alert above. Presenting from the
+    /// root instead would force-dismiss the sheet and end the conversation.
+    private var voiceAlertBinding: Binding<Bool> {
+        Binding(
+            get: {
+                scenePhase == .active
+                    && voiceRecordingVM.showAlert
+                    && !hasModalPresentationBesidesVoiceAlert
+            },
+            set: { isPresented in
+                guard !isPresented,
+                      scenePhase == .active,
+                      !hasModalPresentationBesidesVoiceAlert else {
+                    return
+                }
+                voiceRecordingVM.showAlert = false
             }
         )
     }
@@ -233,6 +270,16 @@ struct ContentPeopleSheetView: View {
             }
         }
         #endif
+        .alert("Recording Error", isPresented: voiceAlertBinding, actions: {
+            Button("common.ok", role: .cancel) {}
+            if voiceRecordingVM.state == .permissionDenied {
+                Button("location_channels.action.open_settings") {
+                    SystemSettings.microphone.open()
+                }
+            }
+        }, message: {
+            Text(voiceRecordingVM.state.alertMessage)
+        })
         .alert(
             "content.alert.bluetooth_required.title",
             isPresented: bluetoothAlertBinding

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -14,6 +14,30 @@ import AppKit
 #endif
 import BitFoundation
 
+struct ContentRootModalPresentationState {
+    var isPeopleSheetPresented = false
+    var isAppInfoPresented = false
+    var isFingerprintPresented = false
+    var isLocationChannelsSheetPresented = false
+    var isNoticesSheetPresented = false
+    var isImagePreviewPresented = false
+    var isVerificationSheetPresented = false
+    var isVoiceAlertPresented = false
+    var isMediaPickerPresented = false
+
+    var hasPresentation: Bool {
+        isPeopleSheetPresented
+            || isAppInfoPresented
+            || isFingerprintPresented
+            || isLocationChannelsSheetPresented
+            || isNoticesSheetPresented
+            || isImagePreviewPresented
+            || isVerificationSheetPresented
+            || isVoiceAlertPresented
+            || isMediaPickerPresented
+    }
+}
+
 /// On macOS 14+, disables the default system focus ring on TextFields.
 /// On earlier macOS versions and on iOS this is a no-op.
 struct FocusEffectDisabledModifier: ViewModifier {
@@ -86,19 +110,23 @@ struct ContentView: View {
     }
 
     private var hasRootModalPresentation: Bool {
-        if isPeopleSheetPresented
-            || appChromeModel.isAppInfoPresented
-            || appChromeModel.showingFingerprintFor != nil
-            || imagePreviewURL != nil
-            || showVerifySheet
-            || voiceRecordingVM.showAlert {
-            return true
-        }
         #if os(iOS)
-        return showImagePicker
+        let isMediaPickerPresented = showImagePicker
         #else
-        return showMacImagePicker
+        let isMediaPickerPresented = showMacImagePicker
         #endif
+
+        return ContentRootModalPresentationState(
+            isPeopleSheetPresented: isPeopleSheetPresented,
+            isAppInfoPresented: appChromeModel.isAppInfoPresented,
+            isFingerprintPresented: appChromeModel.showingFingerprintFor != nil,
+            isLocationChannelsSheetPresented: appChromeModel.isLocationChannelsSheetPresented,
+            isNoticesSheetPresented: appChromeModel.isNoticesSheetPresented,
+            isImagePreviewPresented: imagePreviewURL != nil,
+            isVerificationSheetPresented: showVerifySheet,
+            isVoiceAlertPresented: voiceRecordingVM.showAlert,
+            isMediaPickerPresented: isMediaPickerPresented
+        ).hasPresentation
     }
 
     private var rootBluetoothAlertBinding: Binding<Bool> {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -140,7 +140,9 @@ struct ContentView: View {
         showSidebar || selectedPrivatePeerID != nil
     }
 
-    private var hasRootModalPresentation: Bool {
+    private func rootModalPresentationState(
+        includingVoiceAlert: Bool
+    ) -> ContentRootModalPresentationState {
         #if os(iOS)
         let isMediaPickerPresented = showImagePicker
         #else
@@ -152,9 +154,19 @@ struct ContentView: View {
             isPeopleSheetPresented: isPeopleSheetPresented,
             isImagePreviewPresented: imagePreviewURL != nil,
             isVerificationSheetPresented: showVerifySheet,
-            isVoiceAlertPresented: voiceRecordingVM.showAlert,
+            isVoiceAlertPresented: includingVoiceAlert && voiceRecordingVM.showAlert,
             isMediaPickerPresented: isMediaPickerPresented
-        ).hasPresentation
+        )
+    }
+
+    private var hasRootModalPresentation: Bool {
+        rootModalPresentationState(includingVoiceAlert: true).hasPresentation
+    }
+
+    /// The voice alert cannot defer to itself: its own binding must keep
+    /// reporting `true` while it is the presented modal.
+    private var hasRootModalPresentationBesidesVoiceAlert: Bool {
+        rootModalPresentationState(includingVoiceAlert: false).hasPresentation
     }
 
     private var rootBluetoothAlertBinding: Binding<Bool> {
@@ -171,6 +183,29 @@ struct ContentView: View {
                     return
                 }
                 appChromeModel.showBluetoothAlert = false
+            }
+        )
+    }
+
+    /// Voice recording errors can surface while the people/DM sheet is up
+    /// (recording happens inside the sheet). Presenting the root alert then
+    /// would force-dismiss the sheet, so the root copy defers to any other
+    /// root modal; the sheet presents its own copy. Mirrors the Bluetooth
+    /// alert treatment above.
+    private var rootVoiceAlertBinding: Binding<Bool> {
+        Binding(
+            get: {
+                scenePhase == .active
+                    && voiceRecordingVM.showAlert
+                    && !hasRootModalPresentationBesidesVoiceAlert
+            },
+            set: { isPresented in
+                guard !isPresented,
+                      scenePhase == .active,
+                      !hasRootModalPresentationBesidesVoiceAlert else {
+                    return
+                }
+                voiceRecordingVM.showAlert = false
             }
         )
     }
@@ -220,12 +255,14 @@ struct ContentView: View {
                 set: { isPresented in
                     if !isPresented {
                         showSidebar = false
-                        // Scene/background and Bluetooth-alert presentation
-                        // reconciliation are not user requests to leave the
-                        // conversation. Keep the selected DM so the sheet
-                        // remains live when the app returns from Settings.
+                        // Scene/background and alert-presentation
+                        // reconciliation (Bluetooth-off, recording errors)
+                        // are not user requests to leave the conversation.
+                        // Keep the selected DM so the sheet remains live
+                        // when the app returns from Settings.
                         if scenePhase == .active,
-                           !appChromeModel.showBluetoothAlert {
+                           !appChromeModel.showBluetoothAlert,
+                           !voiceRecordingVM.showAlert {
                             privateConversationModel.endConversation()
                         }
                     }
@@ -328,7 +365,7 @@ struct ContentView: View {
                 ImagePreviewView(url: url)
             }
         }
-        .alert("Recording Error", isPresented: $voiceRecordingVM.showAlert, actions: {
+        .alert("Recording Error", isPresented: rootVoiceAlertBinding, actions: {
             Button("common.ok", role: .cancel) {}
             if voiceRecordingVM.state == .permissionDenied {
                 Button("location_channels.action.open_settings") {

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
     @FocusState private var isTextFieldFocused: Bool
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.appTheme) private var appTheme
+    @Environment(\.scenePhase) private var scenePhase
     @State private var showSidebar = false
     @State private var selectedMessageSender: String?
     @State private var selectedMessageSenderID: PeerID?
@@ -79,6 +80,44 @@ struct ContentView: View {
     }
 
     private var usesGlassLayout: Bool { appTheme.usesGlassChrome }
+
+    private var isPeopleSheetPresented: Bool {
+        showSidebar || selectedPrivatePeerID != nil
+    }
+
+    private var hasRootModalPresentation: Bool {
+        if isPeopleSheetPresented
+            || appChromeModel.isAppInfoPresented
+            || appChromeModel.showingFingerprintFor != nil
+            || imagePreviewURL != nil
+            || showVerifySheet
+            || voiceRecordingVM.showAlert {
+            return true
+        }
+        #if os(iOS)
+        return showImagePicker
+        #else
+        return showMacImagePicker
+        #endif
+    }
+
+    private var rootBluetoothAlertBinding: Binding<Bool> {
+        Binding(
+            get: {
+                scenePhase == .active
+                    && appChromeModel.showBluetoothAlert
+                    && !hasRootModalPresentation
+            },
+            set: { isPresented in
+                guard !isPresented,
+                      scenePhase == .active,
+                      !hasRootModalPresentation else {
+                    return
+                }
+                appChromeModel.showBluetoothAlert = false
+            }
+        )
+    }
 
     var body: some View {
         mainContent
@@ -121,11 +160,18 @@ struct ContentView: View {
         }
         .sheet(
             isPresented: Binding(
-                get: { showSidebar || selectedPrivatePeerID != nil },
+                get: { isPeopleSheetPresented },
                 set: { isPresented in
                     if !isPresented {
                         showSidebar = false
-                        privateConversationModel.endConversation()
+                        // Scene/background and Bluetooth-alert presentation
+                        // reconciliation are not user requests to leave the
+                        // conversation. Keep the selected DM so the sheet
+                        // remains live when the app returns from Settings.
+                        if scenePhase == .active,
+                           !appChromeModel.showBluetoothAlert {
+                            privateConversationModel.endConversation()
+                        }
                     }
                 }
             )
@@ -236,7 +282,7 @@ struct ContentView: View {
         }, message: {
             Text(voiceRecordingVM.state.alertMessage)
         })
-        .alert("content.alert.bluetooth_required.title", isPresented: $appChromeModel.showBluetoothAlert) {
+        .alert("content.alert.bluetooth_required.title", isPresented: rootBluetoothAlertBinding) {
             Button("content.alert.bluetooth_required.settings") {
                 SystemSettings.bluetooth.open()
             }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentRootModalPresentationState {
     var isImagePreviewPresented = false
     var isVerificationSheetPresented = false
     var isVoiceAlertPresented = false
+    var isScreenshotPrivacyAlertPresented = false
     var isMediaPickerPresented = false
 
     var hasPresentation: Bool {
@@ -34,7 +35,37 @@ struct ContentRootModalPresentationState {
             || isImagePreviewPresented
             || isVerificationSheetPresented
             || isVoiceAlertPresented
+            || isScreenshotPrivacyAlertPresented
             || isMediaPickerPresented
+    }
+}
+
+extension ContentRootModalPresentationState {
+    @MainActor
+    init(
+        appChromeModel: AppChromeModel,
+        isPeopleSheetPresented: Bool = false,
+        isImagePreviewPresented: Bool = false,
+        isVerificationSheetPresented: Bool = false,
+        isVoiceAlertPresented: Bool = false,
+        isMediaPickerPresented: Bool = false
+    ) {
+        self.init(
+            isPeopleSheetPresented: isPeopleSheetPresented,
+            isAppInfoPresented: appChromeModel.isAppInfoPresented,
+            isFingerprintPresented:
+                appChromeModel.showingFingerprintFor != nil,
+            isLocationChannelsSheetPresented:
+                appChromeModel.isLocationChannelsSheetPresented,
+            isNoticesSheetPresented:
+                appChromeModel.isNoticesSheetPresented,
+            isImagePreviewPresented: isImagePreviewPresented,
+            isVerificationSheetPresented: isVerificationSheetPresented,
+            isVoiceAlertPresented: isVoiceAlertPresented,
+            isScreenshotPrivacyAlertPresented:
+                appChromeModel.showScreenshotPrivacyWarning,
+            isMediaPickerPresented: isMediaPickerPresented
+        )
     }
 }
 
@@ -117,11 +148,8 @@ struct ContentView: View {
         #endif
 
         return ContentRootModalPresentationState(
+            appChromeModel: appChromeModel,
             isPeopleSheetPresented: isPeopleSheetPresented,
-            isAppInfoPresented: appChromeModel.isAppInfoPresented,
-            isFingerprintPresented: appChromeModel.showingFingerprintFor != nil,
-            isLocationChannelsSheetPresented: appChromeModel.isLocationChannelsSheetPresented,
-            isNoticesSheetPresented: appChromeModel.isNoticesSheetPresented,
             isImagePreviewPresented: imagePreviewURL != nil,
             isVerificationSheetPresented: showVerifySheet,
             isVoiceAlertPresented: voiceRecordingVM.showAlert,

--- a/bitchatTests/ViewSmokeTests.swift
+++ b/bitchatTests/ViewSmokeTests.swift
@@ -554,6 +554,31 @@ struct ViewSmokeTests {
         #expect(featureModels.privateConversationModel.selectedHeaderState?.headerPeerID == peerID)
     }
 
+    @Test("Root Bluetooth alert waits for location and notices sheets")
+    func rootBluetoothAlertGuard_includesHeaderSheets() {
+        #expect(!ContentRootModalPresentationState().hasPresentation)
+        #expect(
+            ContentRootModalPresentationState(
+                isLocationChannelsSheetPresented: true
+            ).hasPresentation
+        )
+        #expect(
+            ContentRootModalPresentationState(
+                isNoticesSheetPresented: true
+            ).hasPresentation
+        )
+    }
+
+    @Test("People-sheet Bluetooth alert waits for local verification sheet")
+    func peopleSheetBluetoothAlertGuard_includesVerificationSheet() {
+        #expect(!ContentPeopleSheetModalPresentationState().hasPresentation)
+        #expect(
+            ContentPeopleSheetModalPresentationState(
+                isVerificationSheetPresented: true
+            ).hasPresentation
+        )
+    }
+
     @Test
     func geohashAndTextMessageViews_renderCoreBranches() {
         let (viewModel, _, _) = makeSmokeViewModel()

--- a/bitchatTests/ViewSmokeTests.swift
+++ b/bitchatTests/ViewSmokeTests.swift
@@ -579,6 +579,64 @@ struct ViewSmokeTests {
         )
     }
 
+    @Test("Root Bluetooth alert waits for screenshot privacy alert")
+    @MainActor
+    func rootBluetoothAlertGuard_tracksScreenshotPrivacyState() {
+        let (viewModel, _, _) = makeSmokeViewModel()
+        let featureModels = makeSmokeFeatureModels(for: viewModel)
+
+        #expect(
+            !ContentRootModalPresentationState(
+                appChromeModel: featureModels.appChromeModel
+            ).hasPresentation
+        )
+
+        featureModels.appChromeModel.showScreenshotPrivacyWarning = true
+
+        #expect(
+            ContentRootModalPresentationState(
+                appChromeModel: featureModels.appChromeModel
+            ).hasPresentation
+        )
+    }
+
+    @Test("People-sheet Bluetooth alert waits for legacy media consent")
+    @MainActor
+    func peopleSheetBluetoothAlertGuard_tracksLegacyConsentState() async {
+        let (viewModel, _, _) = makeSmokeViewModel()
+        let featureModels = makeSmokeFeatureModels(for: viewModel)
+
+        #expect(
+            !ContentPeopleSheetModalPresentationState(
+                legacyPrivateMediaConsentRequest:
+                    featureModels.conversationUIModel
+                        .legacyPrivateMediaConsentRequest
+            ).hasPresentation
+        )
+
+        viewModel.enqueueLegacyPrivateMediaConsent(
+            for: PeerID(str: "5152535455565758"),
+            transferId: "legacy-consent-transfer",
+            messageID: "legacy-consent-message"
+        ) { _ in }
+        defer { viewModel.cancelAllLegacyPrivateMediaConsents() }
+
+        let consentPropagated = await TestHelpers.waitUntil {
+            featureModels.conversationUIModel
+                .legacyPrivateMediaConsentRequest != nil
+        }
+        #expect(
+            consentPropagated
+        )
+        #expect(
+            ContentPeopleSheetModalPresentationState(
+                legacyPrivateMediaConsentRequest:
+                    featureModels.conversationUIModel
+                        .legacyPrivateMediaConsentRequest
+            ).hasPresentation
+        )
+    }
+
     @Test
     func geohashAndTextMessageViews_renderCoreBranches() {
         let (viewModel, _, _) = makeSmokeViewModel()

--- a/bitchatTests/ViewSmokeTests.swift
+++ b/bitchatTests/ViewSmokeTests.swift
@@ -579,6 +579,20 @@ struct ViewSmokeTests {
         )
     }
 
+    @Test("Bluetooth alerts wait for the voice recording error alert")
+    func bluetoothAlertGuards_includeVoiceAlert() {
+        #expect(
+            ContentRootModalPresentationState(
+                isVoiceAlertPresented: true
+            ).hasPresentation
+        )
+        #expect(
+            ContentPeopleSheetModalPresentationState(
+                isVoiceAlertPresented: true
+            ).hasPresentation
+        )
+    }
+
     @Test("Root Bluetooth alert waits for screenshot privacy alert")
     @MainActor
     func rootBluetoothAlertGuard_tracksScreenshotPrivacyState() {


### PR DESCRIPTION
## Summary

- keep the selected private conversation stable while SwiftUI reconciles the sheet during scene/background and Bluetooth-alert transitions
- present the Bluetooth alert from the already-presented people/DM sheet instead of forcing a competing root presentation
- defer alert presentation while the app is inactive or another modal owns presentation
- preserve normal explicit sheet dismissal when the app is active and alert-free

## User-visible fix

Opening Settings to toggle Bluetooth no longer destroys the open DM view or leaves incoming messages and read receipts updating a different replacement window.

This is presentation-only: no transport, wire format, conversation-store, delivery-status, Android, or older-client behavior changes.

## Validation

Final release-gate validation was run on assembled exact stack head `ca4c4973008a6e252ab38bdf91e61dce6f024ba6`:

- SwiftPM app suite: 204 XCTest + 1,911 Swift Testing = 2,115 passed, 0 failed
- exact GitHub parallel app-test command: 193 XCTest workers + 1,911 Swift Testing cases passed repeatedly; full strict one-worker cooperative-pool run passed, including the prior media-preparation starvation path
- iPhone 17 / iOS 26.5 simulator: 2,116/2,116 passed, 0 failed, 0 skipped (authoritative `.xcresult` summary)
- focused high-risk iOS suites: 104 passed, 0 failed, including Nostr relay ACKs, Noise/BLE/private media, panic recovery, and reinstall keychain reconciliation
- BitFoundation: 122/122 passed
- macOS Debug unsigned build: succeeded
- strict Periphery scan: no unused code detected
- all 14 PR ranges are linear, with no merge commits, conflict markers, unmerged entries, or `git diff --check` errors
- independent aggregate code review: no remaining P0/P1/P2 findings
- real-device testing covered mesh chat, DMs, reconnect/offline transitions, open-DM updates, delivery/read receipts, image transfer, and Bluetooth transitions
## Current stack

This is layer 11 of 14 and targets `codex/fix-nostr-envelope-labeling`.

Landing order: #1431 → #1432 → #1434 → #1463 → #1464 → #1465 → #1466 → #1467 → #1468 → #1437 → #1460 → #1461 → #1462 → #1471. The branches were published together atomically with exact force-with-lease protection.