### PR TITLE
Make nearby notes tests parallel-safe

### DIFF
--- a/bitchat/App/NearbyNotesCounter.swift
+++ b/bitchat/App/NearbyNotesCounter.swift
@@ -33,15 +33,25 @@ final class NearbyNotesCounter: ObservableObject {
     private let locationManager: LocationChannelManager
     private let managerFactory: @MainActor (String) -> LocationNotesManager
     private let releaseManager: @MainActor (LocationNotesManager?) -> Void
+    private let locationNotesEnabled: @MainActor () -> Bool
+    private let locationNotesSettingsPublisher: AnyPublisher<Void, Never>
 
     init(
         locationManager: LocationChannelManager = .shared,
         managerFactory: @escaping @MainActor (String) -> LocationNotesManager = { LocationNotesPool.shared.acquire($0) },
-        releaseManager: @escaping @MainActor (LocationNotesManager?) -> Void = { LocationNotesPool.shared.release($0) }
+        releaseManager: @escaping @MainActor (LocationNotesManager?) -> Void = { LocationNotesPool.shared.release($0) },
+        locationNotesEnabled: @escaping @MainActor () -> Bool = { LocationNotesSettings.enabled },
+        locationNotesSettings: AnyPublisher<Void, Never>? = nil
     ) {
         self.locationManager = locationManager
         self.managerFactory = managerFactory
         self.releaseManager = releaseManager
+        self.locationNotesEnabled = locationNotesEnabled
+        self.locationNotesSettingsPublisher = locationNotesSettings
+            ?? NotificationCenter.default
+                .publisher(for: LocationNotesSettings.didChangeNotification)
+                .map { _ in () }
+                .eraseToAnyPublisher()
     }
 
     /// Whether the empty-timeline "check for notes" hint should render.
@@ -53,7 +63,7 @@ final class NearbyNotesCounter: ObservableObject {
     /// passes its own observed permission state so the hint re-renders when
     /// authorization changes.
     func offersRevealHint(permissionState: LocationChannelManager.PermissionState) -> Bool {
-        !revealed && LocationNotesSettings.enabled && permissionState == .authorized
+        !revealed && locationNotesEnabled() && permissionState == .authorized
     }
 
     /// Marks the one explicit act that lets the counter subscribe. Sticky for
@@ -83,8 +93,7 @@ final class NearbyNotesCounter: ObservableObject {
             .sink { [weak self] _ in self?.retarget() }
         // The app-info kill switch must take effect immediately, not on the
         // next location change or remount.
-        settingCancellable = NotificationCenter.default
-            .publisher(for: LocationNotesSettings.didChangeNotification)
+        settingCancellable = locationNotesSettingsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.retarget() }
         retarget()
@@ -105,7 +114,7 @@ final class NearbyNotesCounter: ObservableObject {
     private func retarget() {
         guard activeHolders > 0,
               revealed,
-              LocationNotesSettings.enabled,
+              locationNotesEnabled(),
               locationManager.permissionState == .authorized,
               let geohash = locationManager.availableChannels
                   .first(where: { $0.level == .building })?.geohash

--- a/bitchatTests/NearbyNotesCounterTests.swift
+++ b/bitchatTests/NearbyNotesCounterTests.swift
@@ -8,25 +8,9 @@ import XCTest
 /// the pooled subscription must come up exactly once and go down exactly once.
 @MainActor
 final class NearbyNotesCounterTests: XCTestCase {
-    private var previousNotesEnabled: Any?
-
-    override func setUp() {
-        super.setUp()
-        previousNotesEnabled = UserDefaults.standard.object(forKey: "locationNotes.enabled")
-        UserDefaults.standard.set(true, forKey: "locationNotes.enabled")
-    }
-
-    override func tearDown() {
-        if let previous = previousNotesEnabled as? Bool {
-            UserDefaults.standard.set(previous, forKey: "locationNotes.enabled")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "locationNotes.enabled")
-        }
-        super.tearDown()
-    }
-
     func test_counterOnlySubscribesAfterReveal_countsUnexpiredNotes_andUnsubscribesOnDeactivate() async throws {
         let relays = SubscriptionRecorder()
+        let settings = LocationNotesSettingsStub()
         let locationManager = try await makeAuthorizedLocationManager()
         let buildingGeohash = try XCTUnwrap(
             locationManager.availableChannels.first(where: { $0.level == .building })?.geohash
@@ -35,7 +19,9 @@ final class NearbyNotesCounterTests: XCTestCase {
         let counter = NearbyNotesCounter(
             locationManager: locationManager,
             managerFactory: { LocationNotesManager(geohash: $0, dependencies: relays.dependencies) },
-            releaseManager: { $0?.cancel() }
+            releaseManager: { $0?.cancel() },
+            locationNotesEnabled: { settings.enabled },
+            locationNotesSettings: settings.changes
         )
 
         counter.activate()
@@ -93,11 +79,14 @@ final class NearbyNotesCounterTests: XCTestCase {
 
     func test_permissionRevocation_releasesBuildingSubscriptionDespiteCachedChannels() async throws {
         let relays = SubscriptionRecorder()
+        let settings = LocationNotesSettingsStub()
         let locationManager = try await makeAuthorizedLocationManager()
         let counter = NearbyNotesCounter(
             locationManager: locationManager,
             managerFactory: { LocationNotesManager(geohash: $0, dependencies: relays.dependencies) },
-            releaseManager: { $0?.cancel() }
+            releaseManager: { $0?.cancel() },
+            locationNotesEnabled: { settings.enabled },
+            locationNotesSettings: settings.changes
         )
 
         counter.activate()
@@ -122,24 +111,27 @@ final class NearbyNotesCounterTests: XCTestCase {
 
     func test_locationNotesKillSwitch_releasesAndCanReacquireBuildingSubscription() async throws {
         let relays = SubscriptionRecorder()
+        let settings = LocationNotesSettingsStub()
         let locationManager = try await makeAuthorizedLocationManager()
         let counter = NearbyNotesCounter(
             locationManager: locationManager,
             managerFactory: { LocationNotesManager(geohash: $0, dependencies: relays.dependencies) },
-            releaseManager: { $0?.cancel() }
+            releaseManager: { $0?.cancel() },
+            locationNotesEnabled: { settings.enabled },
+            locationNotesSettings: settings.changes
         )
 
         counter.activate()
         counter.reveal()
         XCTAssertEqual(relays.subscribeCount, 1)
 
-        LocationNotesSettings.enabled = false
+        settings.setEnabled(false)
 
         let released = await waitUntil { relays.unsubscribeCount == 1 }
         XCTAssertTrue(released)
         XCTAssertEqual(counter.noteCount, 0)
 
-        LocationNotesSettings.enabled = true
+        settings.setEnabled(true)
 
         let reacquired = await waitUntil { relays.subscribeCount == 2 }
         XCTAssertTrue(reacquired)
@@ -149,10 +141,13 @@ final class NearbyNotesCounterTests: XCTestCase {
 
     func test_checkNotesHint_requiresAuthorizedLocationPermission() {
         let relays = SubscriptionRecorder()
+        let settings = LocationNotesSettingsStub()
         let counter = NearbyNotesCounter(
             locationManager: makeBareLocationManager(),
             managerFactory: { LocationNotesManager(geohash: $0, dependencies: relays.dependencies) },
-            releaseManager: { $0?.cancel() }
+            releaseManager: { $0?.cancel() },
+            locationNotesEnabled: { settings.enabled },
+            locationNotesSettings: settings.changes
         )
 
         // An unauthorized install must never see the hint: the tap can't
@@ -164,9 +159,9 @@ final class NearbyNotesCounterTests: XCTestCase {
         XCTAssertTrue(counter.offersRevealHint(permissionState: .authorized))
 
         // The app-info kill switch hides it too.
-        LocationNotesSettings.enabled = false
+        settings.setEnabled(false)
         XCTAssertFalse(counter.offersRevealHint(permissionState: .authorized))
-        LocationNotesSettings.enabled = true
+        settings.setEnabled(true)
 
         // Once revealed, the hint yields to the live strip and count.
         counter.reveal()
@@ -408,6 +403,21 @@ final class NearbyNotesCounterTests: XCTestCase {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         return condition()
+    }
+}
+
+@MainActor
+private final class LocationNotesSettingsStub {
+    private let changesSubject = PassthroughSubject<Void, Never>()
+    private(set) var enabled = true
+
+    var changes: AnyPublisher<Void, Never> {
+        changesSubject.eraseToAnyPublisher()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        self.enabled = enabled
+        changesSubject.send(())
     }
 }
 


### PR DESCRIPTION
## Summary

- inject the current location-notes enabled getter and settings-change publisher into `NearbyNotesCounter`
- keep production defaults exactly the same: `LocationNotesSettings.enabled` plus `didChangeNotification`
- replace shared `UserDefaults.standard` and process-wide notification mutation in `NearbyNotesCounterTests` with a MainActor-local stub
- eliminate the cross-process race created by `swift test --parallel`

## Failure mode

SwiftPM runs XCTest methods in separate worker processes. Sibling Nearby Notes tests were toggling and restoring the same persistent `locationNotes.enabled` key while another worker called `activate()` and `reveal()`. That worker could observe the temporary disabled value, never subscribe, and then fail its release assertions.

The production activation path was stable in isolation; the flake required sibling parallel state. This change isolates only the test dependency while preserving the live default wiring.

## Compatibility

This changes no BLE, Noise, Nostr, storage, or message wire format. The production initializer retains behavior-equivalent defaults, so Android, older iOS clients, and existing installs are unaffected.

## Validation

Validated on assembled exact stack head `ca4c4973008a6e252ab38bdf91e61dce6f024ba6`:

- pre-fix parallel stress reproduced the failure at iteration 57
- isolated pre-fix production-path test: 100/100 passed
- post-fix parallel stress: 200/200 suite iterations, 2,000 test invocations, passed
- exact GitHub app-test command: 193 XCTest workers + 1,911 Swift Testing cases passed repeatedly; full strict one-worker cooperative-pool run passed, including the prior media-preparation starvation path
- full SwiftPM app suite: 204 XCTest + 1,911 Swift Testing = 2,115 passed
- iPhone 17 / iOS 26.5 simulator: 2,116/2,116 passed, 0 failed, 0 skipped
- BitFoundation: 122/122 passed
- macOS Debug unsigned build: succeeded
- strict Periphery scan: no unused code detected
- independent review: no P0/P1/P2 findings

## Current stack

This is layer 14 of 14 and targets `codex/cleanup-pm-retry`.

Landing order: #1431 → #1432 → #1434 → #1463 → #1464 → #1465 → #1466 → #1467 → #1468 → #1437 → #1460 → #1461 → #1462 → this PR.