### PR TITLE
fix(favorites): normalize PeerID with toShort() in favorite status lo…

### DIFF
--- a/bitchat/Services/FavoritesPersistenceService.swift
+++ b/bitchat/Services/FavoritesPersistenceService.swift
@@ -188,7 +188,8 @@ final class FavoritesPersistenceService: ObservableObject {
     func getFavoriteStatus(forPeerID peerID: PeerID) -> FavoriteRelationship? {
         // Quick sanity: peerID should be 16 hex chars (8 bytes)
         guard peerID.isShort else { return nil }
-        for (pubkey, rel) in favorites where PeerID(publicKey: pubkey) == peerID {
+        let targetShort = peerID.toShort()
+        for (pubkey, rel) in favorites where PeerID(publicKey: pubkey) == targetShort {
             return rel
         }
         return nil


### PR DESCRIPTION
### Summary of Changes
Fixes a `PeerID` prefix mismatch in `FavoritesPersistenceService.getFavoriteStatus(forPeerID:)`.

- Normalizes incoming `peerID` with `.toShort()` before comparing against `PeerID(publicKey: pubkey)`.
- Ensures prefixed peer IDs (`mesh:`, `noise:`) properly match stored favorites.
