### PR TITLE
Deflake GeoRelayDirectoryTests under constrained runners

### DIFF
--- a/bitchatTests/Nostr/GeoRelayDirectoryTests.swift
+++ b/bitchatTests/Nostr/GeoRelayDirectoryTests.swift
@@ -290,11 +290,15 @@ final class GeoRelayDirectoryTests: XCTestCase {
         harness.userDefaults.set(harness.clock.now, forKey: "georelay.lastFetchAt")
         let directory = GeoRelayDirectory(dependencies: harness.dependencies)
 
+        let baselineRequestCount = await harness.fetcher.recordedRequestCount()
         directory.prefetchIfNeeded()
+        // Negative check: nothing should have been scheduled, so there is no
+        // condition to wait on. A modest delay gives a wrongly spawned fetch
+        // task a chance to run before we compare against the baseline.
         try? await Task.sleep(nanoseconds: 20_000_000)
 
         let requestCount = await harness.fetcher.recordedRequestCount()
-        XCTAssertEqual(requestCount, 0)
+        XCTAssertEqual(requestCount, baselineRequestCount)
         XCTAssertFalse(directory.debugHasRetryTask)
     }
 
@@ -319,9 +323,11 @@ final class GeoRelayDirectoryTests: XCTestCase {
         XCTAssertFalse(directory.debugHasRetryTask)
 
         directory.prefetchIfNeeded(force: true)
+        // Negative check against the captured baseline: the forced refetch
+        // must be skipped, so there is no condition to wait on.
         try? await Task.sleep(nanoseconds: 20_000_000)
         let forcedRequestCount = await harness.fetcher.recordedRequestCount()
-        XCTAssertEqual(forcedRequestCount, 1)
+        XCTAssertEqual(forcedRequestCount, requestCount)
     }
 
     func test_prefetchIfNeeded_runsRemoteFetchOffMainThread() async {
@@ -436,26 +442,43 @@ final class GeoRelayDirectoryTests: XCTestCase {
             autoStart: true,
             activeNotificationName: activeNotification
         )
-        var directory: GeoRelayDirectory? = GeoRelayDirectory(dependencies: harness.dependencies)
-        let initialFetch = await waitUntil {
-            await harness.fetcher.recordedRequestCount() == 1
+        // Wait on the refresh notification rather than the raw request count:
+        // the request count increments before the directory finishes handling
+        // the response on the main actor (resetting `isFetching`, recording
+        // `lastFetchAt`). Posting the next trigger inside that gap would get
+        // swallowed by the in-flight guard. The notification is posted at the
+        // end of the synchronous success handler, so once it fires the next
+        // trigger is guaranteed to be accepted.
+        var refreshCount = 0
+        let refreshObserver = harness.notificationCenter.addObserver(
+            forName: .geoRelayDirectoryDidRefresh,
+            object: nil,
+            queue: .main
+        ) { _ in
+            refreshCount += 1
         }
+        defer { harness.notificationCenter.removeObserver(refreshObserver) }
+
+        var directory: GeoRelayDirectory? = GeoRelayDirectory(dependencies: harness.dependencies)
+        let initialFetch = await waitUntil { refreshCount == 1 }
         XCTAssertTrue(initialFetch)
+        var requestCount = await harness.fetcher.recordedRequestCount()
+        XCTAssertEqual(requestCount, 1)
         XCTAssertEqual(directory?.debugObserverCount, 2)
 
         harness.clock.now = harness.clock.now.addingTimeInterval(6)
         harness.notificationCenter.post(name: .TorDidBecomeReady, object: nil)
-        let torTriggered = await waitUntil {
-            await harness.fetcher.recordedRequestCount() == 2
-        }
+        let torTriggered = await waitUntil { refreshCount == 2 }
         XCTAssertTrue(torTriggered)
+        requestCount = await harness.fetcher.recordedRequestCount()
+        XCTAssertEqual(requestCount, 2)
 
         harness.clock.now = harness.clock.now.addingTimeInterval(61)
         harness.notificationCenter.post(name: activeNotification, object: nil)
-        let activeTriggered = await waitUntil {
-            await harness.fetcher.recordedRequestCount() == 3
-        }
+        let activeTriggered = await waitUntil { refreshCount == 3 }
         XCTAssertTrue(activeTriggered)
+        requestCount = await harness.fetcher.recordedRequestCount()
+        XCTAssertEqual(requestCount, 3)
 
         weak var weakDirectory: GeoRelayDirectory?
         weakDirectory = directory
@@ -553,8 +576,12 @@ final class GeoRelayDirectoryTests: XCTestCase {
         )
     }
 
+    /// Polls until `condition` holds. The timeout is deliberately generous:
+    /// constrained CI runners (2-core, serialized testing) can starve the
+    /// detached utility-priority fetch task for seconds before it runs, and
+    /// a successful wait returns as soon as the condition becomes true.
     private func waitUntil(
-        timeout: TimeInterval = 1.0,
+        timeout: TimeInterval = 10.0,
         condition: @escaping @MainActor () async -> Bool
     ) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)


### PR DESCRIPTION
## Problem

Two different `GeoRelayDirectoryTests` failed on two separate iOS-simulator CI runs (2-core macOS runner, serialized `-parallel-testing-enabled NO`), each passing on other runs — classic task-scheduling starvation:

1. `test_prefetchIfNeeded_successUpdatesEntriesPersistsCacheAndSkipsImmediateForcedRefetch` — `waitUntil { directory.entries == ... }` returned false **and** the recorded request count was 0: the `Task` spawned by `prefetchIfNeeded()` (which itself hops through `Task.detached(priority: .utility)` and back to the main actor) never got scheduled within the wait window. The cache/`lastFetchAt` assertions then failed as a cascade.
2. `test_observers_triggerPrefetchesForTorReadyAndAppActivation` — three `waitUntil`-backed `XCTAssertTrue`s failed while the log showed the refresh *did* eventually succeed ("refreshed 1 relays from remote"), i.e. the work completed after the wait gave up.

Root cause: the file-local `waitUntil` helper defaulted to a **1-second** timeout — too small for a starved scheduler.

## Fixes

- **Raise `waitUntil`'s default timeout from 1s to 10s.** The helper polls and returns as soon as the condition holds, so the generous ceiling adds zero time to healthy runs (the suite still finishes in ~0.16s locally).
- **Close a second latent race in the observers test.** It waited on `recordedRequestCount() == n`, but the count increments inside `fetch()` *before* `handleFetchSuccess` runs on the main actor (which resets `isFetching` and records `lastFetchAt`). A trigger notification posted inside that gap was silently swallowed by the `guard !isFetching` / time gates — a flake no timeout could fix. The test now waits on `.geoRelayDirectoryDidRefresh`, posted at the end of the fully synchronous success handler, so the next trigger is guaranteed to be accepted; request counts are still hard-asserted after each wait.
- **Negative checks assert against captured baselines.** The two "no request happened" checks (interval skip, forced-refetch skip) keep their modest fixed delay — there is no condition to wait on for a non-event — but now compare against a captured baseline request count instead of literals.

Because `handleFetchSuccess` is fully synchronous on the main actor, any awaited condition observing its effects implies all its effects (cache write, `lastFetchAt`, retry-state reset) are settled, so every hard assertion sits after a successful wait on the same fetch cycle.

**No assertion is weakened; test intent is unchanged.**

## Testing

- `swift test --filter GeoRelayDirectoryTests`: 15/15 pass across 9 runs (6 unloaded, 3 under a full-CPU busy-loop to simulate runner contention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)