### PR TITLE
Harden iOS-sim CI: destination fallback + Noise reconnect test determinism

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -190,12 +190,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      # Some runner images list only placeholder destinations (rows carrying
+      # "error:" or "unavailable") or ship the selected Xcode without a
+      # matching iOS simulator runtime, so this walks three paths in order:
+      # a usable xcodebuild destination, an existing simctl device, and
+      # finally creating a device from the newest installed iOS runtime.
       - name: Select available iPhone simulator
         id: destination
         run: |
-          destinations=$(xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -showdestinations)
+          set -uo pipefail
+          destinations=$(xcodebuild -project bitchat.xcodeproj -scheme "bitchat (iOS)" -showdestinations 2>/dev/null || true)
           destination_id=$(awk -F'id:' '
-            /platform:iOS Simulator/ && /name:iPhone/ && !found {
+            /platform:iOS Simulator/ && /name:iPhone/ \
+              && !/error/ && !/unavailable/ && !found {
               value=$2
               sub(/,.*/, "", value)
               gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
@@ -203,10 +210,47 @@ jobs:
               found=1
             }
           ' <<< "$destinations")
-          if [ -z "$destination_id" ]; then
-            echo "::error::No available iPhone simulator destination found"
-            exit 1
+
+          if [ -n "$destination_id" ]; then
+            echo "Selected destination via xcodebuild -showdestinations: $destination_id"
+          else
+            echo "No usable iPhone destination in -showdestinations output; falling back to simctl"
+            destination_id=$(xcrun simctl list devices available --json | jq -r '
+              [.devices | to_entries[]
+                | select(.key | contains("iOS"))
+                | .value[]
+                | select(.isAvailable and (.name | startswith("iPhone")))]
+              | first.udid // empty')
+            if [ -n "$destination_id" ]; then
+              echo "Selected existing simctl device: $destination_id"
+            else
+              echo "No available iPhone simulator device; creating one"
+              # Newest installed iOS runtime plus an iPhone device type that
+              # runtime itself reports as supported, so the pair always match.
+              create_spec=$(xcrun simctl list runtimes --json | jq -r '
+                [.runtimes[] | select(.platform == "iOS" and .isAvailable)]
+                | sort_by(.version | split(".") | map(tonumber))
+                | last // empty
+                | .identifier as $runtime
+                | ([(.supportedDeviceTypes // [])[]
+                    | select(.productFamily == "iPhone"
+                        or (.name // "" | startswith("iPhone")))]
+                  | first.identifier // empty) as $devicetype
+                | "\($devicetype) \($runtime)"')
+              read -r devicetype runtime <<< "$create_spec" || true
+              if [ -z "${devicetype:-}" ] || [ -z "${runtime:-}" ]; then
+                echo "::error::No iPhone simulator destination found and none creatable (no installed iOS runtime with an iPhone device type)"
+                exit 1
+              fi
+              destination_id=$(xcrun simctl create ci-iphone "$devicetype" "$runtime") || {
+                echo "::error::simctl create failed for $devicetype on $runtime"
+                exit 1
+              }
+              echo "Created simulator $destination_id ($devicetype, $runtime)"
+            fi
           fi
+
+          echo "Using iPhone simulator destination id: $destination_id"
           echo "id=$destination_id" >> "$GITHUB_OUTPUT"
 
       - name: Run iOS tests

--- a/bitchatTests/Services/NoiseEncryptionServiceTests.swift
+++ b/bitchatTests/Services/NoiseEncryptionServiceTests.swift
@@ -1235,9 +1235,17 @@ struct NoiseEncryptionServiceTests {
     @Test("Lost reconnect completion restores the quarantined transport")
     func timedOutReconnectRestoresQuarantinedTransport() async throws {
         let alice = NoiseEncryptionService(keychain: MockKeychain())
+        // The injected responder timeout also arms during the ordinary setup
+        // handshake below (bob is its responder), where the only work between
+        // message 1 and message 3 is two consecutive synchronous statements.
+        // It must be generous enough that a preempted runner cannot let the
+        // timeout fire mid-setup and tear down the half-open responder — at
+        // 20ms a loaded 2-core CI runner did exactly that, so message 3 was
+        // answered as a fresh initiation (96-byte message 2) and nothing was
+        // ever quarantined.
         let bob = NoiseEncryptionService(
             keychain: MockKeychain(),
-            ordinaryResponderHandshakeTimeout: 0.02
+            ordinaryResponderHandshakeTimeout: 1.0
         )
         let mallory = NoiseEncryptionService(keychain: MockKeychain())
         let alicePeerID = PeerID(publicKey: alice.getStaticPublicKeyData())
@@ -1253,9 +1261,17 @@ struct NoiseEncryptionServiceTests {
         )
         #expect(!bob.hasEstablishedSession(with: alicePeerID))
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(bob.hasEstablishedSession(with: alicePeerID))
+        // Poll instead of sleeping a fixed interval: the responder timeout
+        // fires on bob's manager queue at the quarantine deadline, and a
+        // starved runner can delay that work item well past the deadline.
+        let restored = await TestHelpers.waitUntil(
+            { bob.hasEstablishedSession(with: alicePeerID) },
+            timeout: TestConstants.longTimeout
+        )
+        try #require(
+            restored,
+            "Responder timeout should restore the quarantined transport"
+        )
         let oldTransport = try alice.encrypt(
             Data("timeout rollback".utf8),
             for: bobPeerID


### PR DESCRIPTION
Two CI-robustness fixes for the "Run iOS simulator tests" job added in #1429, both seen on main today.

## 1. Simulator destination picker fails on some runner images

On a `macos-26-arm64` runner (image 20260720.0258) the destination step died with "No available iPhone simulator destination found": `xcodebuild -showdestinations` listed only placeholder rows (containing `error:` / `unavailable`) because the selected Xcode had no matching simulator runtime visible.

The step now walks three paths in order, logging which one was taken:

1. **awk pick** as before, but skipping rows containing `error` or `unavailable`.
2. **simctl fallback**: first available iPhone from `xcrun simctl list devices available --json` (jq).
3. **create**: newest installed iOS runtime + an iPhone device type *that runtime itself reports as supported* (`supportedDeviceTypes`), via `xcrun simctl create ci-iphone <devicetype> <runtime>`; the new UDID is used as the destination.

If none of that works it still fails with a clear `::error`. All four paths were exercised locally by running the extracted step body against the real Xcode and against stubbed `xcodebuild`/`xcrun` (placeholder-only destinations, empty device list, empty runtime list).

## 2. Flaky Noise quarantine-restore test on the constrained runner

`NoiseEncryptionServiceTests` "Lost reconnect completion restores the quarantined transport" failed one main run with `(finalMessage → 96 bytes) == nil` at :1474 plus the :1258 established-session check, passing on adjacent runs.

**Root cause — test-side, definitively.** The test injects `ordinaryResponderHandshakeTimeout: 0.02` into bob, but that timeout also arms during the *setup* handshake in `establishSessions`, where bob is the responder. Under runner load >20ms elapsed between bob processing message 1 and message 3, so the responder-timeout work item tore down bob's half-open responder session (nothing quarantined yet → nothing restored). Message 3 then reached a session-less bob, was treated as a fresh initiation, and answered with a 96-byte message 2 — exactly the observed failure signature, cascading into the later assertions. The #1463 restore path in `NoiseSessionManager` behaved correctly throughout; no production race.

**Fix** (no assertion weakened):
- Injected timeout 0.02 → 1.0s. The setup exposure window is two consecutive synchronous statements, so the margin is enormous; the quarantine-restore behavior under test is unchanged.
- The fixed 100ms `Task.sleep` becomes a `TestHelpers.waitUntil` poll bounded by `TestConstants.longTimeout` (10s), since a starved runner can also delay the timeout work item well past its deadline (same class as the #1479 GeoRelay deflake). Healthy runs complete in ~1.0s.

## Verification

- Destination step: real-Xcode run picks path 1; stubbed placeholder output falls to path 2; stubbed empty device list creates via path 3 (`iPhone-17-Pro` on `iOS-26-5` locally); stubbed empty runtimes exits 1 with `::error`.
- Noise test: **10/10** sequential runs, **3/3** under full-core `yes > /dev/null` CPU load.
- `swift build --build-tests` clean; full `swift test --parallel` green (1918 tests, 202 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)