### PR TITLE
Normalize nicknames to Unicode NFC at storage and comparison boundaries

### DIFF
--- a/bitchat/App/LocationPresenceStore.swift
+++ b/bitchat/App/LocationPresenceStore.swift
@@ -36,6 +36,7 @@ final class LocationPresenceStore: ObservableObject {
             return
         }
 
+        let nickname = nickname.normalizedNickname
         let key = pubkeyHex.lowercased()
         if geoNicknames[key] != nil {
             geoNicknames[key] = nickname
@@ -64,7 +65,7 @@ final class LocationPresenceStore: ObservableObject {
             let lower = key.lowercased()
             guard seen.insert(lower).inserted else { continue }
             ordered.append(lower)
-            normalized[lower] = value
+            normalized[lower] = value.normalizedNickname
         }
         if ordered.count > geoNicknameCapacity {
             let kept = Array(ordered.suffix(geoNicknameCapacity))

--- a/bitchat/Services/AutocompleteService.swift
+++ b/bitchat/Services/AutocompleteService.swift
@@ -55,10 +55,10 @@ final class AutocompleteService {
         
         let fullRange = match.range(at: 0)
         let captureRange = match.range(at: 1)
-        let prefix = nsText.substring(with: captureRange).lowercased()
-        
+        let prefix = nsText.substring(with: captureRange).normalizedNickname.lowercased()
+
         let suggestions = peers
-            .filter { $0.lowercased().hasPrefix(prefix) }
+            .filter { $0.normalizedNickname.lowercased().hasPrefix(prefix) }
             .sorted()
             .prefix(5)
             .map { "@\($0)" }

--- a/bitchat/Services/BLE/BLEPeerRegistry.swift
+++ b/bitchat/Services/BLE/BLEPeerRegistry.swift
@@ -223,7 +223,7 @@ struct BLEPeerRegistry {
 
         peers[peerID] = BLEPeerInfo(
             peerID: existing?.peerID ?? peerID,
-            nickname: nickname,
+            nickname: nickname.normalizedNickname,
             isConnected: isConnected,
             noisePublicKey: noisePublicKey,
             // Never drop an already-pinned signing key.

--- a/bitchat/Services/MessageDeduplicationService.swift
+++ b/bitchat/Services/MessageDeduplicationService.swift
@@ -104,12 +104,10 @@ final class LRUDeduplicationCache<Value> {
 enum ContentNormalizer {
 
     /// Regex to simplify HTTP URLs by stripping query strings and fragments
-    private static let simplifyHTTPURL: NSRegularExpression = {
-        try! NSRegularExpression(
-            pattern: "https?://[^\\s?#]+(?:[?#][^\\s]*)?",
-            options: [.caseInsensitive]
-        )
-    }()
+    private static let simplifyHTTPURL = SafeRegex.compile(
+        "https?://[^\\s?#]+(?:[?#][^\\s]*)?",
+        options: [.caseInsensitive]
+    )
 
     /// Normalizes content for deduplication comparison.
     /// - Parameters:

--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -110,11 +110,12 @@ final class MessageFormattingEngine {
             )
 
             // Format content
+            let myNickname = context.nickname.normalizedNickname
             let contentResult = formatContent(
                 message.content,
                 baseColor: baseColor,
                 isSelf: isSelf,
-                isMentioned: message.mentions?.contains(context.nickname) ?? false
+                isMentioned: message.mentions?.contains { $0.normalizedNickname == myNickname } ?? false
             )
             result.append(contentResult)
 

--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -39,37 +39,23 @@ final class MessageFormattingEngine {
 
     /// Precompiled regex patterns for message content parsing
     enum Patterns {
-        static let hashtag: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "#([a-zA-Z0-9_]+)", options: [])
-        }()
+        static let hashtag = SafeRegex.compile("#([a-zA-Z0-9_]+)")
 
-        static let mention: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "@([\\p{L}0-9_]+(?:#[a-fA-F0-9]{4})?)", options: [])
-        }()
+        static let mention = SafeRegex.compile("@([\\p{L}0-9_]+(?:#[a-fA-F0-9]{4})?)")
 
-        static let cashu: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "\\bcashu[AB][A-Za-z0-9._-]{40,}\\b", options: [])
-        }()
+        static let cashu = SafeRegex.compile("\\bcashu[AB][A-Za-z0-9._-]{40,}\\b")
 
-        static let bolt11: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "(?i)\\bln(bc|tb|bcrt)[0-9][a-z0-9]{50,}\\b", options: [])
-        }()
+        static let bolt11 = SafeRegex.compile("(?i)\\bln(bc|tb|bcrt)[0-9][a-z0-9]{50,}\\b")
 
-        static let lnurl: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "(?i)\\blnurl1[a-z0-9]{20,}\\b", options: [])
-        }()
+        static let lnurl = SafeRegex.compile("(?i)\\blnurl1[a-z0-9]{20,}\\b")
 
-        static let lightningScheme: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "(?i)\\blightning:[^\\s]+", options: [])
-        }()
+        static let lightningScheme = SafeRegex.compile("(?i)\\blightning:[^\\s]+")
 
         static let linkDetector: NSDataDetector? = {
             try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
         }()
 
-        static let quickCashuPresence: NSRegularExpression = {
-            try! NSRegularExpression(pattern: "\\bcashu[AB][A-Za-z0-9._-]{40,}\\b", options: [])
-        }()
+        static let quickCashuPresence = SafeRegex.compile("\\bcashu[AB][A-Za-z0-9._-]{40,}\\b")
     }
 
     // MARK: - Match Types

--- a/bitchat/Services/UnifiedPeerService.swift
+++ b/bitchat/Services/UnifiedPeerService.swift
@@ -236,8 +236,11 @@ final class UnifiedPeerService: ObservableObject, TransportPeerEventsDelegate {
     
     /// Get peer ID for nickname
     func getPeerID(for nickname: String) -> PeerID? {
+        // Normalize both sides: the query may come from typed content and
+        // stored names may predate NFC-at-ingest (e.g. persisted favorites).
+        let target = nickname.normalizedNickname
         for peer in peers {
-            if peer.displayName == nickname || peer.nickname == nickname {
+            if peer.displayName.normalizedNickname == target || peer.nickname.normalizedNickname == target {
                 return peer.peerID
             }
         }

--- a/bitchat/Utils/InputValidator.swift
+++ b/bitchat/Utils/InputValidator.swift
@@ -39,9 +39,10 @@ struct InputValidator {
         return trimmed
     }
     
-    /// Validates nickname
+    /// Validates nickname and returns it in canonical (NFC) form so
+    /// visually identical names always compare equal.
     static func validateNickname(_ nickname: String) -> String? {
-        return validateUserString(nickname, maxLength: Limits.maxNicknameLength)
+        return validateUserString(nickname, maxLength: Limits.maxNicknameLength)?.normalizedNickname
     }
     
     // MARK: - Protocol Field Validation

--- a/bitchat/Utils/SafeRegex.swift
+++ b/bitchat/Utils/SafeRegex.swift
@@ -1,0 +1,36 @@
+//
+// SafeRegex.swift
+// bitchat
+//
+// Non-trapping construction for the app's compiled-in regex patterns.
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import BitLogger
+import Foundation
+
+enum SafeRegex {
+    /// Compiles a bundled pattern. On failure it logs and returns a regex
+    /// that can never match, so a bad pattern degrades that one feature
+    /// instead of crashing at startup.
+    static func compile(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern, options: options)
+        } catch {
+            SecureLogger.error("Regex pattern failed to compile, matching disabled: \(pattern) (\(error))", category: .session)
+            return neverMatching
+        }
+    }
+
+    /// `(?!)` — an empty negative lookahead — always compiles and can never match.
+    private static let neverMatching: NSRegularExpression = {
+        if let regex = try? NSRegularExpression(pattern: "(?!)", options: []) {
+            return regex
+        }
+        // Unreachable: "(?!)" is a valid ICU pattern. The inherited plain
+        // initializer (empty pattern) is the least-bad non-trapping fallback
+        // if ICU itself were ever broken.
+        return NSRegularExpression()
+    }()
+}

--- a/bitchat/Utils/String+Nickname.swift
+++ b/bitchat/Utils/String+Nickname.swift
@@ -9,6 +9,14 @@
 import Foundation
 
 extension String {
+    /// Canonical form for nickname storage and comparison (Unicode NFC).
+    /// "café" typed with a combining accent and "café" typed precomposed
+    /// must resolve to the same user wherever nicknames are stored or
+    /// matched (mentions, DM resolution, autocomplete, geo presence).
+    var normalizedNickname: String {
+        precomposedStringWithCanonicalMapping
+    }
+
     /// Split a nickname into base and a '#abcd' suffix if present
     func splitSuffix() -> (String, String) {
         let name = self.replacingOccurrences(of: "@", with: "")

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -183,7 +183,8 @@ final class ChatMessageFormatter {
                 allMatches.sort { $0.range.location < $1.range.location }
 
                 var lastEnd = content.startIndex
-                let isMentioned = message.mentions?.contains(viewModel.nickname) ?? false
+                let myNickname = viewModel.nickname.normalizedNickname
+                let isMentioned = message.mentions?.contains { $0.normalizedNickname == myNickname } ?? false
 
                 for (range, type) in allMatches {
                     guard let swiftRange = Range(range, in: content) else { continue }

--- a/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
+++ b/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
@@ -501,6 +501,9 @@ final class ChatPeerIdentityCoordinator {
 
     @MainActor
     func getPeerIDForNickname(_ nickname: String) -> PeerID? {
+        // Queries arrive from typed commands and message content, so bring
+        // them to the same canonical (NFC) form nicknames are stored in.
+        let nickname = nickname.normalizedNickname
         switch context.activeChannel {
         case .location:
             if nickname.contains("#"),

--- a/bitchat/ViewModels/ChatPublicConversationCoordinator.swift
+++ b/bitchat/ViewModels/ChatPublicConversationCoordinator.swift
@@ -506,14 +506,15 @@ final class ChatPublicConversationCoordinator: PublicMessagePipelineDelegate {
     }
 
     func checkForMentions(_ message: BitchatMessage) {
-        var myTokens: Set<String> = [context.nickname]
+        let myNickname = context.nickname.normalizedNickname
+        var myTokens: Set<String> = [myNickname]
         let meshPeers = context.meshPeerNicknames()
-        let collisions = meshPeers.values.filter { $0.hasPrefix(context.nickname + "#") }
+        let collisions = meshPeers.values.filter { $0.normalizedNickname.hasPrefix(myNickname + "#") }
         if !collisions.isEmpty {
             let suffix = "#" + String(context.myPeerID.id.prefix(4))
-            myTokens = [context.nickname + suffix]
+            myTokens = [myNickname + suffix]
         }
-        let isMentioned = message.mentions?.contains(where: myTokens.contains) ?? false
+        let isMentioned = message.mentions?.contains { myTokens.contains($0.normalizedNickname) } ?? false
 
         if isMentioned && message.sender != context.nickname {
             SecureLogger.info("🔔 Mention from \(message.sender)", category: .session)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -176,10 +176,12 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
     var networkActivationAllowed: Bool { !panicRecoveryBlocked }
     @Published var nickname: String = "" {
         didSet {
-            // Trim whitespace whenever nickname is set; whitespace-only becomes ""
-            let trimmed = nickname.trimmedOrNilIfEmpty ?? ""
-            if trimmed != nickname {
-                nickname = trimmed
+            // Canonicalize whenever nickname is set: trim whitespace
+            // (whitespace-only becomes "") and apply Unicode NFC so accented
+            // names match regardless of how they were typed.
+            let cleaned = (nickname.trimmedOrNilIfEmpty ?? "").normalizedNickname
+            if cleaned != nickname {
+                nickname = cleaned
                 return
             }
             // Update mesh service nickname if it's initialized

--- a/bitchatTests/NicknameNormalizationTests.swift
+++ b/bitchatTests/NicknameNormalizationTests.swift
@@ -1,0 +1,53 @@
+//
+// NicknameNormalizationTests.swift
+// bitchatTests
+//
+// Nicknames must compare equal regardless of how the user's keyboard
+// produced them: "café" as precomposed U+00E9 and as "e" + combining
+// U+0301 are canonically equivalent but bytewise different, which broke
+// mention matching, DM resolution, and autocomplete (#214). Storage and
+// comparison both canonicalize to NFC via String.normalizedNickname.
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+struct NicknameNormalizationTests {
+    /// "café" with a combining acute accent (NFD form)
+    private let decomposed = "cafe\u{0301}"
+    /// "café" with precomposed é (NFC form)
+    private let precomposed = "caf\u{00E9}"
+
+    @Test
+    func canonicallyEquivalentFormsNormalizeIdentically() {
+        // Sanity: the raw forms really are different strings byte-wise …
+        #expect(decomposed.unicodeScalars.count != precomposed.unicodeScalars.count)
+        // … and normalization unifies them.
+        #expect(decomposed.normalizedNickname == precomposed.normalizedNickname)
+        #expect(decomposed.normalizedNickname == precomposed)
+    }
+
+    @Test
+    func asciiNicknamesPassThroughUnchanged() {
+        #expect("alice_42".normalizedNickname == "alice_42")
+        #expect("".normalizedNickname == "")
+    }
+
+    @Test
+    func validateNicknameReturnsCanonicalForm() {
+        #expect(InputValidator.validateNickname(decomposed) == precomposed)
+        #expect(InputValidator.validateNickname("  \(decomposed)  ") == precomposed)
+        // Validation behavior is otherwise unchanged.
+        #expect(InputValidator.validateNickname("   ") == nil)
+    }
+
+    @Test
+    func collisionSuffixSplittingSurvivesNormalization() {
+        let (base, suffix) = (decomposed.normalizedNickname + "#ab12").splitSuffix()
+        #expect(base == precomposed)
+        #expect(suffix == "#ab12")
+    }
+}

--- a/bitchatTests/Services/SafeRegexTests.swift
+++ b/bitchatTests/Services/SafeRegexTests.swift
@@ -1,0 +1,64 @@
+//
+// SafeRegexTests.swift
+// bitchatTests
+//
+// SafeRegex must never trap: valid patterns compile normally, invalid ones
+// degrade to a regex that matches nothing. The production-pattern test keeps
+// the compile-time guarantee try! used to provide - a typo in any bundled
+// pattern fails here instead of crashing the app at startup.
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+struct SafeRegexTests {
+
+    private func matchCount(_ regex: NSRegularExpression, _ text: String) -> Int {
+        regex.numberOfMatches(in: text, options: [], range: NSRange(text.startIndex..., in: text))
+    }
+
+    @Test
+    func validPatternCompilesAndMatches() {
+        let regex = SafeRegex.compile("#([a-zA-Z0-9_]+)")
+        #expect(matchCount(regex, "tag #bitchat here") == 1)
+    }
+
+    @Test
+    func invalidPatternDegradesToNeverMatching() {
+        let regex = SafeRegex.compile("(unclosed")
+        #expect(matchCount(regex, "(unclosed anything") == 0)
+        #expect(matchCount(regex, "") == 0)
+    }
+
+    @Test
+    func productionPatternsCompileAndMatchTheirTargets() {
+        // A pattern that failed to compile would have degraded to
+        // never-matching, so each positive match proves the literal compiled.
+        #expect(matchCount(MessageFormattingEngine.Patterns.hashtag, "see #mesh") == 1)
+        #expect(matchCount(MessageFormattingEngine.Patterns.mention, "hi @alice#ab12") == 1)
+
+        let cashuToken = "cashuA" + String(repeating: "x", count: 45)
+        #expect(matchCount(MessageFormattingEngine.Patterns.cashu, cashuToken) == 1)
+        #expect(matchCount(MessageFormattingEngine.Patterns.quickCashuPresence, cashuToken) == 1)
+
+        let bolt11 = "lnbc1" + String(repeating: "q", count: 55)
+        #expect(matchCount(MessageFormattingEngine.Patterns.bolt11, bolt11) == 1)
+
+        let lnurl = "lnurl1" + String(repeating: "q", count: 25)
+        #expect(matchCount(MessageFormattingEngine.Patterns.lnurl, lnurl) == 1)
+
+        #expect(matchCount(MessageFormattingEngine.Patterns.lightningScheme, "pay lightning:abc123") == 1)
+    }
+
+    @Test
+    func contentNormalizerStillSimplifiesURLs() {
+        // Exercises ContentNormalizer's regex through its public entry point:
+        // same URL with different query strings must normalize identically.
+        let a = ContentNormalizer.normalizedKey("check https://example.com/page?q=1")
+        let b = ContentNormalizer.normalizedKey("check https://example.com/page?q=2")
+        #expect(a == b)
+    }
+}


### PR DESCRIPTION
## Problem

A nickname containing an accent can arrive in two canonically equivalent but bytewise different Unicode forms: precomposed (`é` = U+00E9) or decomposed (`e` + combining U+0301), depending on the keyboard and platform that produced it. Nicknames were stored and compared without normalization, so visually identical names silently failed to match (#214):

- mentions of your own name did not highlight or notify,
- `/msg` and `/block` could not resolve the peer,
- autocomplete skipped candidates,
- geohash DM resolution failed.

## Change

Canonicalize to NFC via a new `String.normalizedNickname` at every boundary where a nickname enters storage:

- own nickname (`ChatViewModel` didSet, alongside the existing trim),
- verified announce ingest (`BLEPeerRegistry`),
- geohash presence (`LocationPresenceStore`),
- `InputValidator.validateNickname`.

And normalize both sides at comparison sites that can still see pre-normalization data (persisted favorites, message-content mentions): peer resolution in `UnifiedPeerService` and `ChatPeerIdentityCoordinator`, the three mention checks, and autocomplete prefix matching.

The wire codec (`AnnouncementPacket`) is deliberately untouched: announces are signature-verified against raw bytes, so canonicalization happens at the storage layer, never during parsing.

## Out of scope

Confusable/homoglyph defense (Cyrillic `а` vs Latin `a`) is a different, larger design question — this PR only unifies canonically equivalent encodings of the same characters.

## Tests

`NicknameNormalizationTests` cover NFC/NFD unification, ASCII pass-through, validator canonicalization, and interaction with the `#abcd` collision-suffix splitting.

Fixes #214
