### PR TITLE
fix: show verified seal next to sender names in chat

### DIFF
--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -41,7 +41,9 @@ final class ChatMessageFormatter {
         }()
 
         let isDark = colorScheme == .dark
-        if let cachedText = message.getCachedFormattedText(isDark: isDark, isSelf: isSelf, variant: theme.formatCacheVariant) {
+        let isVerifiedSender = !isSelf && isVerifiedSender(of: message)
+        let cacheVariant = theme.formatCacheVariant + (isVerifiedSender ? "-vf" : "")
+        if let cachedText = message.getCachedFormattedText(isDark: isDark, isSelf: isSelf, variant: cacheVariant) {
             return cachedText
         }
 
@@ -65,6 +67,9 @@ final class ChatMessageFormatter {
                 var suffixStyle = senderStyle
                 suffixStyle.foregroundColor = baseColor.opacity(0.6)
                 result.append(AttributedString(suffix).mergingAttributes(suffixStyle))
+            }
+            if isVerifiedSender {
+                appendVerifiedSeal(to: &result, baseColor: baseColor, design: design)
             }
             result.append(AttributedString("> ").mergingAttributes(senderStyle))
 
@@ -335,7 +340,7 @@ final class ChatMessageFormatter {
             result.append(timestamp.mergingAttributes(timestampStyle))
         }
 
-        message.setCachedFormattedText(result, isDark: isDark, isSelf: isSelf, variant: theme.formatCacheVariant)
+        message.setCachedFormattedText(result, isDark: isDark, isSelf: isSelf, variant: cacheVariant)
         return result
     }
 
@@ -356,6 +361,7 @@ final class ChatMessageFormatter {
 
         let isDark = colorScheme == .dark
         let baseColor: Color = isSelf ? .orange : peerColor(for: message, isDark: isDark)
+        let isVerifiedSender = !isSelf && isVerifiedSender(of: message)
 
         if message.sender == "system" {
             var style = AttributeContainer()
@@ -380,6 +386,9 @@ final class ChatMessageFormatter {
             var suffixStyle = senderStyle
             suffixStyle.foregroundColor = baseColor.opacity(0.6)
             result.append(AttributedString(suffix).mergingAttributes(suffixStyle))
+        }
+        if isVerifiedSender {
+            appendVerifiedSeal(to: &result, baseColor: baseColor, design: design)
         }
         result.append(AttributedString("> ").mergingAttributes(senderStyle))
         return result
@@ -427,6 +436,29 @@ final class ChatMessageFormatter {
 }
 
 private extension ChatMessageFormatter {
+    /// Whether the message sender has a fingerprint the user has verified.
+    /// Used for the in-chat seal next to `<@name>` so verification is visible
+    /// without opening the fingerprint sheet (#1439).
+    func isVerifiedSender(of message: BitchatMessage) -> Bool {
+        guard let peerID = message.senderPeerID,
+              let fingerprint = viewModel.getFingerprint(for: peerID) else {
+            return false
+        }
+        return viewModel.peerIdentityStore.isVerified(fingerprint)
+    }
+
+    func appendVerifiedSeal(
+        to result: inout AttributedString,
+        baseColor: Color,
+        design: Font.Design
+    ) {
+        var sealStyle = AttributeContainer()
+        // Match the peer-list verified seal: filled checkmark in the sender tint.
+        sealStyle.foregroundColor = baseColor
+        sealStyle.font = .bitchatSystem(size: 11, weight: .semibold, design: design)
+        result.append(AttributedString(" ✓").mergingAttributes(sealStyle))
+    }
+
     func peerColor(for message: BitchatMessage, isDark: Bool) -> Color {
         if let spid = message.senderPeerID {
             if spid.isGeoChat || spid.isGeoDM {


### PR DESCRIPTION
## Summary
- append a verified seal next to `<@name>` in chat and media message headers when the sender's fingerprint is verified
- include verification in the format cache key so badge state updates after verify/unverify

Addresses the chat half of #1439 (peer list already surfaces the seal via encryption / offline badge).

## Test plan
- [ ] verify a peer, send/receive a mesh message — seal appears beside their name
- [ ] unverify — seal disappears on re-render
- [ ] own messages never show the seal


Made with [Cursor](https://cursor.com)