### PR TITLE
chore: fix receive typo and refresh relay count

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ BitChat uses a **hybrid messaging architecture** with two complementary transpor
 
 - **Global Reach**: Connect with users worldwide via internet relays
 - **Location Channels**: Geographic chat rooms using geohash coordinates
-- **290+ Relay Network**: Distributed across the globe for reliability
+- **440+ Relay Network**: Distributed across the globe for reliability
 - **BitChat Private Envelopes**: App-specific encrypted private messages over Nostr relays
 - **Ephemeral Keys**: Fresh cryptographic identity per geohash area
 

--- a/bitchatTests/EndToEnd/PublicChatE2ETests.swift
+++ b/bitchatTests/EndToEnd/PublicChatE2ETests.swift
@@ -50,7 +50,7 @@ struct PublicChatE2ETests {
         var bobReceivedMessage = false
         var charlieReceivedMessage = false
         
-        await confirmation("Both recieve message", expectedCount: 2) { receiveMessage in
+        await confirmation("Both receive message", expectedCount: 2) { receiveMessage in
             bob.messageDeliveryHandler = { message in
                 if message.content == TestConstants.testMessage1 {
                     if !bobReceivedMessage {


### PR DESCRIPTION
## Summary
- fix \`recieve\` → \`receive\` in \`PublicChatE2ETests\`
- update README relay-network claim from 290+ to 440+ to match \`relays/online_relays_gps.csv\`

## Test plan
- [ ] skim the E2E confirmation label
- [ ] confirm README count ≈ CSV row count (~441 hosts)


Made with [Cursor](https://cursor.com)