### PR TITLE
fix: normalize nicknames to Unicode NFC for matching

### DIFF
--- a/bitchat/Services/AutocompleteService.swift
+++ b/bitchat/Services/AutocompleteService.swift
@@ -55,10 +55,10 @@ final class AutocompleteService {
         
         let fullRange = match.range(at: 0)
         let captureRange = match.range(at: 1)
-        let prefix = nsText.substring(with: captureRange).lowercased()
+        let prefix = nsText.substring(with: captureRange).bitchatNicknameKey
         
         let suggestions = peers
-            .filter { $0.lowercased().hasPrefix(prefix) }
+            .filter { $0.bitchatNicknameKey.hasPrefix(prefix) }
             .sorted()
             .prefix(5)
             .map { "@\($0)" }

--- a/bitchat/Services/PrivateChatManager.swift
+++ b/bitchat/Services/PrivateChatManager.swift
@@ -141,12 +141,12 @@ final class PrivateChatManager: ObservableObject {
         }
 
         // 2. Consolidate from temporary Nostr peer IDs (nostr_* prefixed)
-        let normalizedNickname = peerNickname.lowercased()
+        let normalizedNickname = peerNickname.bitchatNicknameKey
         var tempPeerIDsToConsolidate: [PeerID] = []
 
         for (storedPeerID, messages) in privateChats {
             if storedPeerID.isGeoDM && storedPeerID != peerID {
-                let nicknamesMatch = messages.allSatisfy { $0.sender.lowercased() == normalizedNickname }
+                let nicknamesMatch = messages.allSatisfy { $0.sender.bitchatNicknameKey == normalizedNickname }
                 if nicknamesMatch && !messages.isEmpty {
                     tempPeerIDsToConsolidate.append(storedPeerID)
                 }

--- a/bitchat/Services/UnifiedPeerService.swift
+++ b/bitchat/Services/UnifiedPeerService.swift
@@ -237,7 +237,8 @@ final class UnifiedPeerService: ObservableObject, TransportPeerEventsDelegate {
     /// Get peer ID for nickname
     func getPeerID(for nickname: String) -> PeerID? {
         for peer in peers {
-            if peer.displayName == nickname || peer.nickname == nickname {
+            if peer.displayName.bitchatNicknameMatches(nickname)
+                || peer.nickname.bitchatNicknameMatches(nickname) {
                 return peer.peerID
             }
         }

--- a/bitchat/Utils/String+Nickname.swift
+++ b/bitchat/Utils/String+Nickname.swift
@@ -9,6 +9,21 @@
 import Foundation
 
 extension String {
+    /// Unicode NFC form used when storing and comparing nicknames (#214).
+    /// Typing "café" (NFC) vs "café" (NFD) must resolve to the same peer.
+    var bitchatCanonicalNickname: String {
+        precomposedStringWithCanonicalMapping
+    }
+
+    /// Case-folded NFC key for nickname equality / prefix matching.
+    var bitchatNicknameKey: String {
+        bitchatCanonicalNickname.lowercased()
+    }
+
+    func bitchatNicknameMatches(_ other: String) -> Bool {
+        bitchatNicknameKey == other.bitchatNicknameKey
+    }
+
     /// Split a nickname into base and a '#abcd' suffix if present
     func splitSuffix() -> (String, String) {
         let name = self.replacingOccurrences(of: "@", with: "")

--- a/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
+++ b/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
@@ -505,7 +505,7 @@ final class ChatPeerIdentityCoordinator {
         case .location:
             if nickname.contains("#"),
                let person = context.visibleGeohashPeople()
-                .first(where: { $0.displayName == nickname }) {
+                .first(where: { $0.displayName.bitchatNicknameMatches(nickname) }) {
                 let conversationKey = PeerID(nostr_: person.id)
                 context.registerNostrKeyMapping(person.id, for: conversationKey)
                 return conversationKey
@@ -515,8 +515,8 @@ final class ChatPeerIdentityCoordinator {
                 .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
                 .first
                 .map(String.init)?
-                .lowercased() ?? nickname.lowercased()
-            if let pubkey = context.geoNicknames.first(where: { $0.value.lowercased() == base })?.key {
+                .bitchatNicknameKey ?? nickname.bitchatNicknameKey
+            if let pubkey = context.geoNicknames.first(where: { $0.value.bitchatNicknameKey == base })?.key {
                 let conversationKey = PeerID(nostr_: pubkey)
                 context.registerNostrKeyMapping(pubkey, for: conversationKey)
                 return conversationKey

--- a/bitchat/ViewModels/ChatUnreadStateResolver.swift
+++ b/bitchat/ViewModels/ChatUnreadStateResolver.swift
@@ -28,7 +28,7 @@ enum ChatUnreadStateResolver {
             return true
         }
 
-        guard let peerNickname = context.nickname?.lowercased(), !peerNickname.isEmpty else {
+        guard let peerNickname = context.nickname?.bitchatNicknameKey, !peerNickname.isEmpty else {
             return false
         }
 
@@ -37,7 +37,7 @@ enum ChatUnreadStateResolver {
                   let firstMessage = privateChats[unreadPeerID]?.first else {
                 return false
             }
-            return firstMessage.sender.lowercased() == peerNickname
+            return firstMessage.sender.bitchatNicknameKey == peerNickname
         }
     }
 }

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -176,8 +176,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
     var networkActivationAllowed: Bool { !panicRecoveryBlocked }
     @Published var nickname: String = "" {
         didSet {
-            // Trim whitespace whenever nickname is set; whitespace-only becomes ""
-            let trimmed = nickname.trimmedOrNilIfEmpty ?? ""
+            // Trim whitespace and normalize to Unicode NFC whenever nickname
+            // is set (#214). Whitespace-only becomes "".
+            let trimmed = (nickname.trimmedOrNilIfEmpty ?? "").bitchatCanonicalNickname
             if trimmed != nickname {
                 nickname = trimmed
                 return
@@ -1256,7 +1257,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
 
     func loadNickname() {
         if let savedNickname = userDefaults.string(forKey: nicknameKey) {
-            nickname = savedNickname.trimmed
+            nickname = savedNickname.trimmed.bitchatCanonicalNickname
         } else {
             nickname = "anon\(Int.random(in: 1000...9999))"
             saveNickname()

--- a/bitchatTests/NicknameUnicodeTests.swift
+++ b/bitchatTests/NicknameUnicodeTests.swift
@@ -1,0 +1,29 @@
+//
+// NicknameUnicodeTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Testing
+@testable import bitchat
+
+struct NicknameUnicodeTests {
+    @Test func nfcAndNfdFormsMatch() {
+        // U+00E9 LATIN SMALL LETTER E WITH ACUTE (NFC)
+        let nfc = "caf\u{00E9}"
+        // e + U+0301 COMBINING ACUTE ACCENT (NFD)
+        let nfd = "cafe\u{0301}"
+
+        #expect(nfc != nfd)
+        #expect(nfc.bitchatNicknameMatches(nfd))
+        #expect(nfc.bitchatCanonicalNickname == nfd.bitchatCanonicalNickname)
+    }
+
+    @Test func caseFoldingUsesCanonicalForm() {
+        let upperNFC = "CAF\u{00C9}"
+        let lowerNFD = "cafe\u{0301}"
+        #expect(upperNFC.bitchatNicknameMatches(lowerNFD))
+    }
+}


### PR DESCRIPTION
## Summary
- store local nicknames in Unicode NFC form
- compare nicknames / mentions / geo lookups with an NFC + casefold key so `café` (NFC) and `café` (NFD) resolve to the same peer

Closes #214

## Test plan
- [ ] set nickname to an accented name — persists in NFC
- [ ] `/msg` / mention a peer whose name was typed in the other normalization form
- [ ] `NicknameUnicodeTests` pass


Made with [Cursor](https://cursor.com)