### PR TITLE
[RFC] Add Sonar sticker support (sonar-sticker-pack-v1)

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -1,2278 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "app_info.settings.relays.add" : {
-      "comment" : "Button that adds the typed relay address to the list",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "যোগ করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hinzufügen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "add"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "añadir"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "افزودن"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idagdag"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ajouter"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הוסף"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जोड़ें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tambah"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "aggiungi"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tambah"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "थप"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "toevoegen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dodaj"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "adicionar"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "adicionar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "добавить"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lägg till"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "சேர்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เพิ่ม"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ekle"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "додати"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شامل کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "thêm"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.built_in" : {
-      "comment" : "Label marking a relay as one of the built-in relays, which cannot be removed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مدمج"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "বিল্ট-ইন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eingebaut"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "built in"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "داخلی"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "built in"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "intégré"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מובנה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अंतर्निर्मित"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bawaan"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "組み込み"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기본 제공"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "terbina dalam"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पूर्वनिर्मित"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ingebouwd"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wbudowany"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "встроенное"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "inbyggt"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "உள்ளமைந்தது"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "มาพร้อมแอป"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "yerleşik"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "вбудований"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بلٹ اِن"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tích hợp"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "内置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "內建"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.duplicate" : {
-      "comment" : "Error shown when the typed relay address is already in the list",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذا المرحّل موجود في القائمة بالفعل."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এই রিলে আগেই তালিকায় আছে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dieses relay steht schon in der liste."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "that relay is already in the list."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ese relay ya está en la lista."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این رله از قبل در فهرست است."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nasa listahan na ang relay na iyon."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ce relais est déjà dans la liste."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הממסר הזה כבר ברשימה."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वह रिले पहले से सूची में है।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay itu sudah ada di daftar."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quel relay è già nell'elenco."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "そのリレーはすでにリストにあります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그 릴레이는 이미 목록에 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay itu sudah ada dalam senarai."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "त्यो रिले पहिले नै सूचीमा छ।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "die relay staat al in de lijst."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ten relay już jest na liście."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "esse relé já está na lista."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "esse relay já está na lista."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "это реле уже в списке."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "det reläet finns redan i listan."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "அந்த ரிலே ஏற்கெனவே பட்டியலில் உள்ளது."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเลย์นี้อยู่ในรายการแล้ว"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bu röle listede zaten var."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "цей релей уже в списку."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ ریلے پہلے ہی فہرست میں ہے۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay đó đã có trong danh sách."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该中继已在列表中。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該中繼已在清單中。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.limit" : {
-      "comment" : "Error shown when the relay list is already at its maximum size; %d is that maximum",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يمكنك إضافة %d مرحّلات كحد أقصى."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "আপনি সর্বোচ্চ %d টি রিলে যোগ করতে পারেন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "du kannst bis zu %d relays hinzufügen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "you can add up to %d relays."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "puedes añadir hasta %d relays."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "می‌توانید تا %d رله اضافه کنید."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hanggang %d relay lang ang maaari mong idagdag."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tu peux ajouter jusqu'à %d relais."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפשר להוסיף עד %d ממסרים."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आप %d रिले तक जोड़ सकते हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kamu bisa menambahkan hingga %d relay."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "puoi aggiungere fino a %d relay."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーは最大%d件まで追加できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이는 최대 %d개까지 추가할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "anda boleh menambah sehingga %d relay."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "तिमी %d रिलेसम्म थप्न सक्छौ।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "je kunt tot %d relays toevoegen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "możesz dodać maksymalnie %d relay."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "podes adicionar até %d relés."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "você pode adicionar até %d relays."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "можно добавить до %d реле."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "du kan lägga till upp till %d reläer."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d ரிலேகள் வரை சேர்க்கலாம்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เพิ่มรีเลย์ได้สูงสุด %d รายการ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "en fazla %d röle ekleyebilirsiniz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "можна додати до %d релеїв."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آپ %d ریلے تک شامل کر سکتے ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bạn có thể thêm tối đa %d relay."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最多可以添加 %d 个中继。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最多可以加入 %d 個中繼。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.malformed" : {
-      "comment" : "Error shown when a typed relay address cannot be parsed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يبدو هذا عنوان مرحّل. جرّب wss://host."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এটি রিলের ঠিকানার মতো মনে হচ্ছে না। wss://host দিয়ে চেষ্টা করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "das sieht nicht wie eine relay-adresse aus. versuch wss://host."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "that doesn't look like a relay address. try wss://host."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eso no parece una dirección de relay. prueba wss://host."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این شبیه نشانی رله نیست. wss://host را امتحان کنید."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mukhang hindi ito address ng relay. subukan ang wss://host."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ça ne ressemble pas à une adresse de relais. essaie wss://host."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "זה לא נראה כמו כתובת של ממסר. נסה wss://host."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह रिले का पता नहीं लगता। wss://host आज़माएँ।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "itu tidak tampak seperti alamat relay. coba wss://host."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non sembra l'indirizzo di un relay. prova wss://host."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーのアドレスではないようです。wss://host を試してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이 주소가 아닌 것 같습니다. wss://host 형식으로 시도하세요."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "itu tidak kelihatan seperti alamat relay. cuba wss://host."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यो रिलेको ठेगाना जस्तो देखिँदैन। wss://host प्रयास गर।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dat lijkt niet op een relay-adres. probeer wss://host."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "to nie wygląda na adres relay. spróbuj wss://host."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "isso não parece um endereço de relé. tenta wss://host."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "isso não parece um endereço de relay. tente wss://host."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "это не похоже на адрес реле. попробуй wss://host."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "det ser inte ut som en reläadress. prova wss://host."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "இது ரிலே முகவரி போல் தெரியவில்லை. wss://host முயற்சிக்கவும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ดูเหมือนไม่ใช่ที่อยู่รีเลย์ ลอง wss://host"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bu bir röle adresine benzemiyor. wss://host deneyin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "це не схоже на адресу релея. спробуй wss://host."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ ریلے کا پتہ نہیں لگتا۔ wss://host آزمائیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "đó không giống địa chỉ relay. hãy thử wss://host."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这看起来不像中继地址。试试 wss://host。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這看起來不像中繼位址。試試 wss://host。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.placeholder" : {
-      "comment" : "Placeholder text in the field for adding a relay address",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.remove" : {
-      "comment" : "Accessibility label for the button that removes an added relay",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة المرحّل"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "রিলে সরান"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay entfernen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remove relay"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quitar relay"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حذف رله"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "alisin ang relay"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "retirer le relais"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הסר ממסר"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रिले हटाएँ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hapus relay"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "rimuovi relay"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーを削除"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이 제거"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "buang relay"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रिले हटाउ"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay verwijderen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "usuń relay"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remover relé"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remover relay"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "удалить реле"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ta bort relä"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ரிலேயை நீக்கு"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ลบรีเลย์"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "röleyi kaldır"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "видалити релей"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ریلے ہٹائیں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "xóa relay"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除中继"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除中繼"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.subtitle" : {
-      "comment" : "Subtitle explaining what the relay list is for and why someone would add a relay",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عندما لا تصل شبكة mesh إلى شخص، تنتقل الرسائل الخاصة عبر هذه المرحّلات. المرحّلات المدمجة عناوين معروفة يمكن لمرشّح الشبكة حجبها — لذا يمكنك إضافة مرحّلاتك الخاصة، بما في ذلك عناوين .onion."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "মেশ কারও কাছে পৌঁছাতে না পারলে ব্যক্তিগত বার্তা এই রিলেগুলোর মধ্য দিয়ে যায়। বিল্ট-ইন রিলেগুলো সুপরিচিত ঠিকানা, যা নেটওয়ার্ক ফিল্টার আটকে দিতে পারে — তাই আপনি নিজের রিলে যোগ করতে পারেন, .onion ঠিকানাও।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wenn das mesh jemanden nicht erreicht, laufen private nachrichten über diese relays. die eingebauten sind bekannte adressen, die ein netzwerkfilter blockieren kann — du kannst also eigene hinzufügen, auch .onion-adressen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "when the mesh can't reach someone, private messages travel through these relays. the built-in ones are well-known addresses that a network filter can block, so you can add your own — including .onion addresses."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "cuando el mesh no llega a alguien, los mensajes privados viajan por estos relays. los integrados son direcciones muy conocidas que un filtro de red puede bloquear, así que puedes añadir los tuyos — incluidas direcciones .onion."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وقتی مش به کسی نمی‌رسد، پیام‌های خصوصی از این رله‌ها می‌گذرند. رله‌های داخلی نشانی‌های شناخته‌شده‌ای هستند که یک صافی شبکه می‌تواند مسدودشان کند — پس می‌توانید رله‌های خودتان را اضافه کنید، از جمله نشانی‌های .onion."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kapag hindi maabot ng mesh ang isang tao, dumadaan ang mga pribadong mensahe sa mga relay na ito. ang mga built-in ay kilalang-kilalang address na kayang harangin ng filter ng network — kaya maaari kang magdagdag ng sarili mo, kasama ang mga .onion address."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quand le mesh ne joint pas quelqu'un, les messages privés passent par ces relais. ceux intégrés sont des adresses bien connues qu'un filtre réseau peut bloquer — tu peux donc ajouter les tiens, y compris des adresses .onion."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כשה-mesh לא מגיע למישהו, הודעות פרטיות עוברות דרך הממסרים האלה. הממסרים המובנים הם כתובות מוכרות שמסנן רשת יכול לחסום — אפשר להוסיף ממסרים משלך, כולל כתובות .onion."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जब मेश किसी तक नहीं पहुँच पाता, तब निजी संदेश इन रिले से होकर जाते हैं। अंतर्निर्मित रिले जाने-पहचाने पते हैं जिन्हें नेटवर्क फ़िल्टर रोक सकता है — इसलिए आप अपने रिले जोड़ सकते हैं, .onion पते भी।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saat mesh tidak bisa menjangkau seseorang, pesan pribadi lewat relay ini. relay bawaan adalah alamat yang sudah dikenal luas dan bisa diblokir filter jaringan — jadi kamu bisa menambahkan relay sendiri, termasuk alamat .onion."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando la mesh non raggiunge qualcuno, i messaggi privati passano da questi relay. quelli integrati sono indirizzi molto noti che un filtro di rete può bloccare — puoi quindi aggiungere i tuoi, anche indirizzi .onion."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "meshで相手に届かないとき、プライベートメッセージはこれらのリレーを通ります。組み込みのリレーはよく知られたアドレスで、ネットワークのフィルターにブロックされることがあります — 自分のリレー、.onionアドレスも追加できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh로 상대에게 닿지 않으면 비공개 메시지는 이 릴레이를 거칩니다. 기본 릴레이는 널리 알려진 주소여서 네트워크 필터가 차단할 수 있습니다 — 그래서 .onion 주소를 포함해 직접 릴레이를 추가할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "apabila mesh tidak dapat mencapai seseorang, pesan peribadi bergerak melalui relay ini. relay terbina dalam ialah alamat yang terkenal dan boleh dihalang oleh penapis rangkaian — jadi anda boleh menambah relay sendiri, termasuk alamat .onion."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh कसैसम्म पुग्न सक्दैन भने निजी सन्देश यी रिले मार्फत जान्छन्। पूर्वनिर्मित रिले सबैलाई थाहा भएका ठेगाना हुन्, जसलाई नेटवर्क फिल्टरले रोक्न सक्छ — त्यसैले तिमी आफ्नै रिले थप्न सक्छौ, .onion ठेगाना पनि।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "als de mesh iemand niet bereikt, gaan privéberichten via deze relays. de ingebouwde relays zijn bekende adressen die een netwerkfilter kan blokkeren — je kunt dus je eigen relays toevoegen, ook .onion-adressen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "gdy mesh nie dosięga kogoś, wiadomości prywatne idą przez te relay. wbudowane to powszechnie znane adresy, które filtr sieciowy może zablokować — możesz więc dodać własne, także adresy .onion."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando a mesh não chega a alguém, as mensagens privadas seguem por estes relés. os integrados são endereços bem conhecidos que um filtro de rede pode bloquear — por isso podes acrescentar os teus, incluindo endereços .onion."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando o mesh não alcança alguém, as mensagens privadas passam por estes relays. os integrados são endereços conhecidos que um filtro de rede pode bloquear — então você pode adicionar os seus, inclusive endereços .onion."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "когда mesh не достаёт до человека, приватные сообщения идут через эти реле. встроенные — это широко известные адреса, которые может заблокировать сетевой фильтр, поэтому можно добавить свои, в том числе .onion-адреса."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "när mesh inte når fram till någon går privata meddelanden via dessa reläer. de inbyggda är välkända adresser som ett nätverksfilter kan blockera — du kan därför lägga till egna, även .onion-adresser."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh ஒருவரை எட்ட முடியாதபோது, தனிப்பட்ட செய்திகள் இந்த ரிலேகள் வழியாகச் செல்கின்றன. உள்ளமைந்த ரிலேகள் நன்கு அறியப்பட்ட முகவரிகள், அவற்றை நெட்வொர்க் வடிகட்டி தடுக்க முடியும் — எனவே .onion முகவரிகள் உட்பட உங்கள் சொந்த ரிலேகளைச் சேர்க்கலாம்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เมื่อ mesh ไปไม่ถึงใคร ข้อความส่วนตัวจะเดินทางผ่านรีเลย์เหล่านี้ รีเลย์ที่มาพร้อมแอปเป็นที่อยู่ที่รู้จักกันดีและตัวกรองเครือข่ายปิดกั้นได้ — คุณจึงเพิ่มรีเลย์ของตัวเองได้ รวมถึงที่อยู่ .onion"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh birine ulaşamadığında özel mesajlar bu rölelerden geçer. yerleşik röleler herkesin bildiği adreslerdir ve bir ağ filtresi bunları engelleyebilir — bu yüzden .onion adresleri de dahil kendi rölelerinizi ekleyebilirsiniz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "коли mesh не дотягується до людини, приватні повідомлення йдуть через ці релеї. вбудовані — це добре відомі адреси, які може заблокувати мережевий фільтр, тож можна додати власні, зокрема .onion-адреси."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جب mesh کسی تک نہ پہنچ سکے تو نجی پیغامات ان ریلے سے گزرتے ہیں۔ بلٹ اِن ریلے مشہور پتے ہیں جنہیں نیٹ ورک فلٹر روک سکتا ہے — اس لیے آپ اپنے ریلے شامل کر سکتے ہیں، .onion پتے بھی۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "khi mesh không tới được ai đó, tin nhắn riêng đi qua các relay này. các relay tích hợp là những địa chỉ ai cũng biết nên bộ lọc mạng có thể chặn — vì vậy bạn có thể thêm relay của mình, kể cả địa chỉ .onion."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 mesh 无法触达某人时，私密消息会经这些中继传递。内置中继是众所周知的地址，网络过滤可以封锁它们 — 所以你可以添加自己的中继，包括 .onion 地址。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "當 mesh 無法觸及某人時，私密訊息會經這些中繼傳遞。內建中繼是眾所周知的位址，網路過濾可以封鎖它們 — 所以你可以加入自己的中繼，包括 .onion 位址。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.title" : {
-      "comment" : "Title of the relay list editor in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مرحّلات الرسائل الخاصة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ব্যক্তিগত বার্তার রিলে"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays für private nachrichten"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "private message relays"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays para mensajes privados"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رله‌های پیام خصوصی"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mga relay para sa pribadong mensahe"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relais pour messages privés"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ממסרים להודעות פרטיות"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजी संदेश रिले"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay pesan pribadi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay per messaggi privati"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プライベートメッセージのリレー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "비공개 메시지 릴레이"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay pesan peribadi"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजी सन्देशका रिले"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays voor privéberichten"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay dla wiadomości prywatnych"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relés para mensagens privadas"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays para mensagens privadas"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "реле для приватных сообщений"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reläer för privata meddelanden"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "தனிப்பட்ட செய்திகளுக்கான ரிலேகள்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเลย์สำหรับข้อความส่วนตัว"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "özel mesaj röleleri"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "релеї для приватних повідомлень"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نجی پیغامات کے ریلے"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay cho tin nhắn riêng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私密消息中继"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私密訊息中繼"
-          }
-        }
-      }
-    },
-    "app_info.settings.tor.off_warning" : {
-      "comment" : "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor متوقف: كل مرحّل تتصل به يمكنه رؤية عنوان IP الخاص بك، بما في ذلك المرحّلات التي تحمل رسائلك الخاصة."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor বন্ধ: আপনি যে রিলেতেই সংযুক্ত হন সেটি আপনার IP ঠিকানা দেখতে পায়, আপনার ব্যক্তিগত বার্তা বহনকারী রিলেগুলোও।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor ist aus: jedes relay, mit dem du dich verbindest, kann deine ip-adresse sehen, auch die relays, die deine privaten nachrichten tragen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor está desactivado: cada relay al que te conectas puede ver tu dirección IP, incluidos los relays que llevan tus mensajes privados."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor خاموش است: هر رله‌ای که به آن وصل می‌شوید می‌تواند نشانی IP شما را ببیند، از جمله رله‌هایی که پیام‌های خصوصی شما را می‌برند."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "naka-off ang tor: nakikita ng bawat relay na kinokonekta mo ang iyong IP address, kasama ang mga relay na nagdadala ng iyong mga pribadong mensahe."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor est désactivé : chaque relais auquel tu te connectes voit ton adresse ip, y compris les relais qui transportent tes messages privés."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor כבוי: כל ממסר שאתה מתחבר אליו רואה את כתובת ה-ip שלך, כולל ממסרים שנושאים את ההודעות הפרטיות שלך."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor बंद है: आप जिस भी रिले से जुड़ते हैं वह आपका IP पता देख सकता है, उनमें वे रिले भी शामिल हैं जो आपके निजी संदेश ले जाते हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor nonaktif: setiap relay yang kamu hubungi bisa melihat alamat ip-mu, termasuk relay yang membawa pesan pribadimu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor è disattivato: ogni relay a cui ti colleghi può vedere il tuo indirizzo ip, compresi i relay che trasportano i tuoi messaggi privati."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "torはオフです: 接続するすべてのリレーがあなたのipアドレスを見られます。プライベートメッセージを運ぶリレーも同じです。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor가 꺼져 있습니다: 연결하는 모든 릴레이가 IP 주소를 볼 수 있고, 비공개 메시지를 운반하는 릴레이도 마찬가지입니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor tidak aktif: setiap relay yang anda sambung boleh melihat alamat ip anda, termasuk relay yang membawa pesan peribadi anda."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor बन्द छ: तिमी जोडिने हरेक रिलेले तिम्रो ip ठेगाना देख्न सक्छ, तिम्रा निजी सन्देश बोक्ने रिले पनि।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor staat uit: elke relay waarmee je verbindt kan je IP-adres zien, ook de relays die je privéberichten vervoeren."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor jest wyłączony: każdy relay, z którym się łączysz, widzi twój adres IP, także te przenoszące twoje wiadomości prywatne."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "o Tor está desligado: cada relé a que te ligas consegue ver o teu endereço IP, incluindo os relés que transportam as tuas mensagens privadas."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "o tor está desligado: cada relay a que você se conecta consegue ver seu endereço ip, inclusive os relays que carregam suas mensagens privadas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor выключен: каждое реле, к которому ты подключаешься, видит твой ip-адрес, включая реле, через которые идут твои приватные сообщения."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor är av: varje relä du ansluter till kan se din IP-adress, även reläerna som bär dina privata meddelanden."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor அணைந்திருக்கிறது: நீங்கள் இணைக்கும் ஒவ்வொரு ரிலேயும் உங்கள் IP முகவரியைப் பார்க்க முடியும், உங்கள் தனிப்பட்ட செய்திகளை எடுத்துச் செல்லும் ரிலேகளும் அதில் அடங்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor ปิดอยู่: ทุกรีเลย์ที่คุณเชื่อมต่อเห็นที่อยู่ IP ของคุณ รวมถึงรีเลย์ที่ส่งข้อความส่วนตัวของคุณ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor kapalı: bağlandığınız her röle IP adresinizi görebilir, özel mesajlarınızı taşıyan röleler de dahil."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor вимкнено: кожен релей, до якого ти підключаєшся, бачить твою ip-адресу, включно з релеями, що несуть твої приватні повідомлення."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor بند ہے: آپ جس ریلے سے بھی جڑتے ہیں وہ آپ کا IP پتہ دیکھ سکتا ہے، اُن ریلے سمیت جو آپ کے نجی پیغامات لے جاتے ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor đang tắt: mọi relay bạn kết nối đều thấy địa chỉ IP của bạn, kể cả những relay mang tin nhắn riêng của bạn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor 已关闭：你连接的每个中继都能看到你的 IP 地址，包括承载你私密消息的中继。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor 已關閉：你連線的每個中繼都能看到你的 IP 位址，包括承載你私密訊息的中繼。"
-          }
-        }
-      }
-    },
-    "app_info.settings.tor.subtitle" : {
-      "comment" : "Subtitle for the tor routing toggle in settings, explaining what it covers",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت. الموصى به: تشغيل."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে। সুপারিশ: চালু।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden. empfohlen: an."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet. recomendado: activado."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد. توصیه: روشن."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet. inirerekomenda: naka-on."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet. recommandé : activé."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט. מומלץ: פעיל."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है। अनुशंसित: चालू।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet. disarankan: aktif."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet. consigliato: attivo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。推奨: オン"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다. 권장: 켜기."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet. disarankan: aktif."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ। सिफारिस: अन।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd. aanbevolen: aan."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet. zalecane: włączone."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет. рекомендуем включить."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet. rekommenderas: på."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும். பரிந்துரை: இயக்கவும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต แนะนำให้เปิด"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar. önerilen: açık."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет. рекомендовано ввімкнути."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔ تجویز: آن رکھیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet. khuyến nghị: bật."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。推荐：开启。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。推薦：開啟。"
-          }
-        }
-      }
-    },
-    "content.system.media_delete_refused" : {
-      "comment" : "System message shown in the affected chat when an explicit media delete or /clear was refused and bubbles/files were kept",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "تعذّر حذف بعض الوسائط. جرّب حذف الوسائط الأقدم أولاً." } },
-        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "কিছু মিডিয়া মুছে ফেলা যায়নি। আগে পুরোনো মিডিয়া মুছে ফেলার চেষ্টা করুন।" } },
-        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "einige medien konnten nicht gelöscht werden. versuche zuerst, ältere medien zu löschen." } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "some media could not be deleted. try deleting older media first." } },
-        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "no se pudieron eliminar algunos archivos multimedia. prueba a eliminar primero los más antiguos." } },
-        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "برخی رسانه‌ها حذف نشدند. ابتدا رسانه‌های قدیمی‌تر را حذف کنید." } },
-        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "hindi ma-delete ang ilang media. subukang i-delete muna ang mas lumang media." } },
-        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "impossible de supprimer certains médias. essaie d'abord de supprimer les médias plus anciens." } },
-        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "לא ניתן למחוק חלק מהמדיה. נסה קודם למחוק מדיה ישנה יותר." } },
-        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "कुछ मीडिया हटाई नहीं जा सकी। पहले पुरानी मीडिया हटाने का प्रयास करें।" } },
-        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "sebagian media tidak dapat dihapus. coba hapus media yang lebih lama dulu." } },
-        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "impossibile eliminare alcuni contenuti multimediali. prova prima a eliminare quelli più vecchi." } },
-        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "一部のメディアを削除できませんでした。先に古いメディアを削除してみてください。" } },
-        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "일부 미디어를 삭제하지 못했습니다. 먼저 오래된 미디어를 삭제해 보세요." } },
-        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "sesetengah media tidak dapat dipadamkan. cuba padamkan media yang lebih lama dahulu." } },
-        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "केही मिडिया मेटाउन सकिएन। पहिले पुराना मिडिया मेटाउने प्रयास गर।" } },
-        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "sommige media konden niet worden verwijderd. probeer eerst oudere media te verwijderen." } },
-        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "nie udało się usunąć części multimediów. spróbuj najpierw usunąć starsze multimedia." } },
-        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "não foi possível eliminar alguns ficheiros multimédia. tenta eliminar primeiro os mais antigos." } },
-        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "não foi possível excluir algumas mídias. tente excluir primeiro as mídias mais antigas." } },
-        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "не удалось удалить часть медиафайлов. попробуй сначала удалить более старые." } },
-        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "vissa medier kunde inte raderas. prova att radera äldre medier först." } },
-        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "சில ஊடகங்களை நீக்க முடியவில்லை. முதலில் பழைய ஊடகங்களை நீக்க முயற்சிக்கவும்." } },
-        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ไม่สามารถลบสื่อบางรายการได้ ลองลบสื่อที่เก่ากว่าก่อน" } },
-        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "bazı medya silinemedi. önce daha eski medyayı silmeyi dene." } },
-        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "не вдалося видалити частину медіафайлів. спробуй спочатку видалити старіші." } },
-        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "کچھ میڈیا حذف نہیں ہو سکا۔ پہلے پرانا میڈیا حذف کرنے کی کوشش کریں۔" } },
-        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "không thể xóa một số phương tiện. hãy thử xóa phương tiện cũ hơn trước." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "部分媒体无法删除。请先尝试删除较早的媒体。" } },
-        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "部分媒體無法刪除。請先嘗試刪除較舊的媒體。" } }
-      }
-    },
-    "notification.action.wave" : {
-      "comment" : "Title of the notification action button that sends a friendly wave back to a nearby person",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لوّح 👋"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "হাত নাড়ুন 👋"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "winken 👋"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wave 👋"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saludar 👋"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دست تکان دادن 👋"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kumaway 👋"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saluer 👋"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לנופף 👋"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हाथ हिलाएँ 👋"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "melambai 👋"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saluta 👋"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手を振る 👋"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "손 흔들기 👋"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lambai 👋"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हात हल्लाउनुहोस् 👋"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "zwaaien 👋"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "pomachaj 👋"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "acenar 👋"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "acenar 👋"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "помахать 👋"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vinka 👋"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "கை அசைக்கவும் 👋"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "โบกมือ 👋"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "el salla 👋"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "помахати 👋"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ہاتھ ہلائیں 👋"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vẫy tay 👋"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "挥手 👋"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "揮手 👋"
-          }
-        }
-      }
-    },
     "#%@" : {
       "comment" : "Non-localizable channel hashtag format used in code",
       "extractionState" : "manual",
-      "shouldTranslate" : false,
       "localizations" : {
         "fa" : {
           "stringUnit" : {
@@ -2280,7 +11,8 @@
             "value" : "#%@"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "%@" : {
       "comment" : "Non-localizable symbol used in code",
@@ -2651,6 +383,562 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活躍使用者 %@ 位"
+          }
+        }
+      }
+    },
+    "Choose an image" : {
+      "comment" : "A label displayed above a button that allows the user to choose an image to send.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر صورة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "একটি ছবি নির্বাচন করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild auswählen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose an image"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige una imagen"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتخاب تصویر"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumili ng larawan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir une image"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בחר תמונה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक चित्र चुनें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih gambar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli un’immagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지를 선택하세요"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih imej"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एउटा तस्वीर चयन गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kies een afbeelding"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz obraz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolher uma imagem"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolha uma imagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите изображение"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj en bild"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ஒரு படத்தைத் தேர்ந்தெடுக்கவும்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เลือกภาพ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir görüntü seç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть зображення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایک تصویر منتخب کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn một hình ảnh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择图像"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇圖像"
+          }
+        }
+      }
+    },
+    "Images are only available in mesh chats." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الصور متاحة فقط في محادثات الميش."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ছবি শুধু মেশ চ্যাটে উপলব্ধ।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilder sind nur im Mesh-Chat verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Images are only available in mesh chats."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las imágenes solo están disponibles en los chats de mesh."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصاویر فقط در گفتگوهای مش در دسترس هستند."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ang mga larawan ay available lamang sa mga mesh chat."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les images sont uniquement disponibles dans les discussions mesh."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תמונות זמינות רק בצ׳אט של mesh."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "चित्र केवल मेश चैट में ही उपलब्ध हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar hanya tersedia di obrolan mesh."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le immagini sono disponibili solo nelle chat mesh."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像はメッシュチャットでのみ利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지는 메쉬 채팅에서만 사용할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imej hanya tersedia dalam sembang mesh."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "तस्बिरहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afbeeldingen zijn alleen beschikbaar in mesh-chats."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obrazy są dostępne tylko na czatach mesh."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As imagens só estão disponíveis nos chats mesh."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As imagens só estão disponíveis nos chats mesh."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображения доступны только в mesh-чатах."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilder är bara tillgängliga i mesh-chattar."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "படங்கள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รูปภาพใช้งานได้เฉพาะในแชต mesh เท่านั้น"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görseller yalnızca mesh sohbetlerinde kullanılabilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зображення доступні лише в mesh-чатах."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصاویر صرف میش چیٹس میں دستیاب ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hình ảnh chỉ khả dụng trong các cuộc trò chuyện mesh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片仅可在 mesh 聊天中使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片僅能在 mesh 聊天中使用。"
+          }
+        }
+      }
+    },
+    "Voice notes are only available in mesh chats." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الملاحظات الصوتية متاحة فقط في محادثات الميش."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস নোট শুধু মেশ চ্যাটে উপলব্ধ।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachnachrichten sind nur im Mesh-Chat verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice notes are only available in mesh chats."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las notas de voz solo están disponibles en los chats de mesh."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیام صوتی فقط در گفتگوهای مش در دسترس است."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ang mga voice note ay available lamang sa mga mesh chat."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notes vocales sont uniquement disponibles dans les discussions mesh."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הערות קוליות זמינות רק בצ׳אט של mesh."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वॉइस नोट्स केवल मेश चैट में ही उपलब्ध हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan suara hanya tersedia di obrolan mesh."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le note vocali sono disponibili solo nelle chat mesh."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボイスメモはメッシュチャットでのみ利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "음성 메모는 메쉬 채팅에서만 사용할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota suara hanya tersedia dalam sembang mesh."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भ्वाइस नोटहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spraaknotities zijn alleen beschikbaar in mesh-chats."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notatki głosowe są dostępne tylko na czatach mesh."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As notas de voz só estão disponíveis nos chats mesh."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As mensagens de voz só estão disponíveis nos chats mesh."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голосовые сообщения доступны только в mesh-чатах."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Röstanteckningar är bara tillgängliga i mesh-chattar."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "குரல் குறிப்புகள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "บันทึกเสียงใช้งานได้เฉพาะในแชต mesh เท่านั้น"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesli notlar yalnızca mesh sohbetlerinde kullanılabilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голосові нотатки доступні лише в mesh-чатах."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائس نوٹس صرف میش چیٹس میں دستیاب ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghi chú giọng nói chỉ khả dụng trong các cuộc trò chuyện mesh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音消息仅可在 mesh 聊天中使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音訊息僅能在 mesh 聊天中使用。"
           }
         }
       }
@@ -14886,6 +13174,750 @@
         }
       }
     },
+    "app_info.settings.language.picker_label" : {
+      "comment" : "Label of the app language picker row in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغة التطبيق"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অ্যাপের ভাষা"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Sprache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "app language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma de la app"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان برنامه"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wika ng app"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "langue de l'app"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שפת האפליקציה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐप की भाषा"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bahasa aplikasi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lingua dell'app"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリの言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 언어"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bahasa aplikasi"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एपको भाषा"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "app-taal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "język aplikacji"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma da app"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma do app"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "язык приложения"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "appspråk"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "செயலியின் மொழி"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ภาษาของแอป"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uygulama dili"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мова застосунку"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپ کی زبان"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ngôn ngữ ứng dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "應用程式語言"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.restart_note" : {
+      "comment" : "Caption shown after the user picks a different app language; the change takes effect on next launch",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعد تشغيل bitchat لتطبيق اللغة الجديدة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নতুন ভাষা প্রয়োগ করতে bitchat পুনরায় চালু করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bitchat neu starten, um die neue Sprache zu übernehmen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "restart bitchat to apply the new language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicia bitchat para aplicar el nuevo idioma"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای اعمال زبان جدید، bitchat را دوباره باز کنید"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "i-restart ang bitchat para mailapat ang bagong wika"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "redémarrez bitchat pour appliquer la nouvelle langue"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "יש להפעיל מחדש את bitchat כדי להחיל את השפה החדשה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नई भाषा लागू करने के लिए bitchat पुनः आरंभ करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mulai ulang bitchat untuk menerapkan bahasa baru"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "riavvia bitchat per applicare la nuova lingua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい言語を適用するには bitchat を再起動してください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 언어를 적용하려면 bitchat을 다시 시작하세요"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mulakan semula bitchat untuk menggunakan bahasa baharu"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नयाँ भाषा लागू गर्न bitchat पुनः सुरु गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "herstart bitchat om de nieuwe taal toe te passen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uruchom bitchat ponownie, aby zastosować nowy język"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicie o bitchat para aplicar o novo idioma"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicie o bitchat para aplicar o novo idioma"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "перезапустите bitchat, чтобы применить новый язык"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "starta om bitchat för att använda det nya språket"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "புதிய மொழியைப் பயன்படுத்த bitchat-ஐ மீண்டும் தொடங்கவும்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีสตาร์ท bitchat เพื่อใช้ภาษาใหม่"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yeni dili uygulamak için bitchat'i yeniden başlatın"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "перезапустіть bitchat, щоб застосувати нову мову"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نئی زبان لاگو کرنے کے لیے bitchat دوبارہ شروع کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "khởi động lại bitchat để áp dụng ngôn ngữ mới"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重启 bitchat 以应用新语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動 bitchat 以套用新語言"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.system" : {
+      "comment" : "Menu option that clears the in-app language override so the app follows the device language",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغة النظام"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সিস্টেম ডিফল্ট"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemstandard"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "system default"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predeterminado del sistema"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیش‌فرض سیستم"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "default ng system"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "réglage système"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ברירת המחדל של המערכת"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सिस्टम डिफ़ॉल्ट"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bawaan sistem"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predefinita di sistema"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムのデフォルト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 기본값"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lalai sistem"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रणाली पूर्वनिर्धारित"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "systeemstandaard"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "domyślny systemowy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predefinição do sistema"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "padrão do sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "системный по умолчанию"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "systemstandard"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "கணினி இயல்புநிலை"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ค่าเริ่มต้นของระบบ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sistem varsayılanı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "системна за замовчуванням"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سسٹم ڈیفالٹ"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mặc định hệ thống"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統預設"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.title" : {
+      "comment" : "Section header (uppercase) for the app language picker in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اللغة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভাষা"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SPRACHE"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANGUAGE"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WIKA"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANGUE"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שפה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषा"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BAHASA"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LINGUA"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BAHASA"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषा"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TAAL"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JĘZYK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ЯЗЫК"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SPRÅK"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "மொழி"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ภาษา"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DİL"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "МОВА"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NGÔN NGỮ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語言"
+          }
+        }
+      }
+    },
     "app_info.settings.privacy.title" : {
       "comment" : "Section header (uppercase) for privacy settings such as hiding notification previews",
       "extractionState" : "manual",
@@ -15068,6 +14100,2052 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱私"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.add" : {
+      "comment" : "Button that adds the typed relay address to the list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "যোগ করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "add"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "añadir"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افزودن"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idagdag"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ajouter"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जोड़ें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tambah"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "aggiungi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tambah"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "थप"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "toevoegen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dodaj"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "adicionar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "adicionar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "добавить"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lägg till"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "சேர்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เพิ่ม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ekle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "додати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شامل کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "thêm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.built_in" : {
+      "comment" : "Label marking a relay as one of the built-in relays, which cannot be removed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مدمج"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "বিল্ট-ইন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eingebaut"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "built in"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "داخلی"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "built in"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "intégré"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מובנה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अंतर्निर्मित"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bawaan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "組み込み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 제공"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "terbina dalam"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पूर्वनिर्मित"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ingebouwd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wbudowany"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "встроенное"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "inbyggt"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "உள்ளமைந்தது"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "มาพร้อมแอป"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yerleşik"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "вбудований"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلٹ اِن"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tích hợp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.duplicate" : {
+      "comment" : "Error shown when the typed relay address is already in the list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هذا المرحّل موجود في القائمة بالفعل."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই রিলে আগেই তালিকায় আছে।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dieses relay steht schon in der liste."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "that relay is already in the list."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ese relay ya está en la lista."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این رله از قبل در فهرست است."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nasa listahan na ang relay na iyon."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ce relais est déjà dans la liste."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הממסר הזה כבר ברשימה."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वह रिले पहले से सूची में है।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay itu sudah ada di daftar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quel relay è già nell'elenco."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "そのリレーはすでにリストにあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그 릴레이는 이미 목록에 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay itu sudah ada dalam senarai."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "त्यो रिले पहिले नै सूचीमा छ।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "die relay staat al in de lijst."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ten relay już jest na liście."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "esse relé já está na lista."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "esse relay já está na lista."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "это реле уже в списке."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "det reläet finns redan i listan."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "அந்த ரிலே ஏற்கெனவே பட்டியலில் உள்ளது."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีเลย์นี้อยู่ในรายการแล้ว"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu röle listede zaten var."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "цей релей уже в списку."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ ریلے پہلے ہی فہرست میں ہے۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay đó đã có trong danh sách."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该中继已在列表中。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該中繼已在清單中。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.limit" : {
+      "comment" : "Error shown when the relay list is already at its maximum size; %d is that maximum",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك إضافة %d مرحّلات كحد أقصى."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "আপনি সর্বোচ্চ %d টি রিলে যোগ করতে পারেন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "du kannst bis zu %d relays hinzufügen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you can add up to %d relays."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "puedes añadir hasta %d relays."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "می‌توانید تا %d رله اضافه کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hanggang %d relay lang ang maaari mong idagdag."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tu peux ajouter jusqu'à %d relais."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר להוסיף עד %d ממסרים."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आप %d रिले तक जोड़ सकते हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kamu bisa menambahkan hingga %d relay."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "puoi aggiungere fino a %d relay."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーは最大%d件まで追加できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이는 최대 %d개까지 추가할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "anda boleh menambah sehingga %d relay."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "तिमी %d रिलेसम्म थप्न सक्छौ।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "je kunt tot %d relays toevoegen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "możesz dodać maksymalnie %d relay."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "podes adicionar até %d relés."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "você pode adicionar até %d relays."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "можно добавить до %d реле."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "du kan lägga till upp till %d reläer."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d ரிலேகள் வரை சேர்க்கலாம்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เพิ่มรีเลย์ได้สูงสุด %d รายการ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en fazla %d röle ekleyebilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "можна додати до %d релеїв."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آپ %d ریلے تک شامل کر سکتے ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bạn có thể thêm tối đa %d relay."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多可以添加 %d 个中继。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多可以加入 %d 個中繼。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.malformed" : {
+      "comment" : "Error shown when a typed relay address cannot be parsed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يبدو هذا عنوان مرحّل. جرّب wss://host."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এটি রিলের ঠিকানার মতো মনে হচ্ছে না। wss://host দিয়ে চেষ্টা করুন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "das sieht nicht wie eine relay-adresse aus. versuch wss://host."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "that doesn't look like a relay address. try wss://host."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eso no parece una dirección de relay. prueba wss://host."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این شبیه نشانی رله نیست. wss://host را امتحان کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mukhang hindi ito address ng relay. subukan ang wss://host."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ça ne ressemble pas à une adresse de relais. essaie wss://host."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "זה לא נראה כמו כתובת של ממסר. נסה wss://host."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह रिले का पता नहीं लगता। wss://host आज़माएँ।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "itu tidak tampak seperti alamat relay. coba wss://host."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non sembra l'indirizzo di un relay. prova wss://host."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーのアドレスではないようです。wss://host を試してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이 주소가 아닌 것 같습니다. wss://host 형식으로 시도하세요."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "itu tidak kelihatan seperti alamat relay. cuba wss://host."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यो रिलेको ठेगाना जस्तो देखिँदैन। wss://host प्रयास गर।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dat lijkt niet op een relay-adres. probeer wss://host."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "to nie wygląda na adres relay. spróbuj wss://host."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "isso não parece um endereço de relé. tenta wss://host."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "isso não parece um endereço de relay. tente wss://host."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "это не похоже на адрес реле. попробуй wss://host."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "det ser inte ut som en reläadress. prova wss://host."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இது ரிலே முகவரி போல் தெரியவில்லை. wss://host முயற்சிக்கவும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ดูเหมือนไม่ใช่ที่อยู่รีเลย์ ลอง wss://host"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu bir röle adresine benzemiyor. wss://host deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "це не схоже на адресу релея. спробуй wss://host."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ ریلے کا پتہ نہیں لگتا۔ wss://host آزمائیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "đó không giống địa chỉ relay. hãy thử wss://host."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这看起来不像中继地址。试试 wss://host。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這看起來不像中繼位址。試試 wss://host。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.placeholder" : {
+      "comment" : "Placeholder text in the field for adding a relay address",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.remove" : {
+      "comment" : "Accessibility label for the button that removes an added relay",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة المرحّل"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "রিলে সরান"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay entfernen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remove relay"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quitar relay"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف رله"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alisin ang relay"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "retirer le relais"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הסר ממסר"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिले हटाएँ"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hapus relay"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rimuovi relay"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이 제거"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "buang relay"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिले हटाउ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay verwijderen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "usuń relay"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remover relé"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remover relay"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "удалить реле"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ta bort relä"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ரிலேயை நீக்கு"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ลบรีเลย์"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "röleyi kaldır"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "видалити релей"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریلے ہٹائیں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "xóa relay"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除中继"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除中繼"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.subtitle" : {
+      "comment" : "Subtitle explaining what the relay list is for and why someone would add a relay",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عندما لا تصل شبكة mesh إلى شخص، تنتقل الرسائل الخاصة عبر هذه المرحّلات. المرحّلات المدمجة عناوين معروفة يمكن لمرشّح الشبكة حجبها — لذا يمكنك إضافة مرحّلاتك الخاصة، بما في ذلك عناوين .onion."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মেশ কারও কাছে পৌঁছাতে না পারলে ব্যক্তিগত বার্তা এই রিলেগুলোর মধ্য দিয়ে যায়। বিল্ট-ইন রিলেগুলো সুপরিচিত ঠিকানা, যা নেটওয়ার্ক ফিল্টার আটকে দিতে পারে — তাই আপনি নিজের রিলে যোগ করতে পারেন, .onion ঠিকানাও।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wenn das mesh jemanden nicht erreicht, laufen private nachrichten über diese relays. die eingebauten sind bekannte adressen, die ein netzwerkfilter blockieren kann — du kannst also eigene hinzufügen, auch .onion-adressen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "when the mesh can't reach someone, private messages travel through these relays. the built-in ones are well-known addresses that a network filter can block, so you can add your own — including .onion addresses."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cuando el mesh no llega a alguien, los mensajes privados viajan por estos relays. los integrados son direcciones muy conocidas que un filtro de red puede bloquear, así que puedes añadir los tuyos — incluidas direcciones .onion."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وقتی مش به کسی نمی‌رسد، پیام‌های خصوصی از این رله‌ها می‌گذرند. رله‌های داخلی نشانی‌های شناخته‌شده‌ای هستند که یک صافی شبکه می‌تواند مسدودشان کند — پس می‌توانید رله‌های خودتان را اضافه کنید، از جمله نشانی‌های .onion."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kapag hindi maabot ng mesh ang isang tao, dumadaan ang mga pribadong mensahe sa mga relay na ito. ang mga built-in ay kilalang-kilalang address na kayang harangin ng filter ng network — kaya maaari kang magdagdag ng sarili mo, kasama ang mga .onion address."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quand le mesh ne joint pas quelqu'un, les messages privés passent par ces relais. ceux intégrés sont des adresses bien connues qu'un filtre réseau peut bloquer — tu peux donc ajouter les tiens, y compris des adresses .onion."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כשה-mesh לא מגיע למישהו, הודעות פרטיות עוברות דרך הממסרים האלה. הממסרים המובנים הם כתובות מוכרות שמסנן רשת יכול לחסום — אפשר להוסיף ממסרים משלך, כולל כתובות .onion."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जब मेश किसी तक नहीं पहुँच पाता, तब निजी संदेश इन रिले से होकर जाते हैं। अंतर्निर्मित रिले जाने-पहचाने पते हैं जिन्हें नेटवर्क फ़िल्टर रोक सकता है — इसलिए आप अपने रिले जोड़ सकते हैं, .onion पते भी।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saat mesh tidak bisa menjangkau seseorang, pesan pribadi lewat relay ini. relay bawaan adalah alamat yang sudah dikenal luas dan bisa diblokir filter jaringan — jadi kamu bisa menambahkan relay sendiri, termasuk alamat .onion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando la mesh non raggiunge qualcuno, i messaggi privati passano da questi relay. quelli integrati sono indirizzi molto noti che un filtro di rete può bloccare — puoi quindi aggiungere i tuoi, anche indirizzi .onion."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "meshで相手に届かないとき、プライベートメッセージはこれらのリレーを通ります。組み込みのリレーはよく知られたアドレスで、ネットワークのフィルターにブロックされることがあります — 自分のリレー、.onionアドレスも追加できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh로 상대에게 닿지 않으면 비공개 메시지는 이 릴레이를 거칩니다. 기본 릴레이는 널리 알려진 주소여서 네트워크 필터가 차단할 수 있습니다 — 그래서 .onion 주소를 포함해 직접 릴레이를 추가할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "apabila mesh tidak dapat mencapai seseorang, pesan peribadi bergerak melalui relay ini. relay terbina dalam ialah alamat yang terkenal dan boleh dihalang oleh penapis rangkaian — jadi anda boleh menambah relay sendiri, termasuk alamat .onion."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh कसैसम्म पुग्न सक्दैन भने निजी सन्देश यी रिले मार्फत जान्छन्। पूर्वनिर्मित रिले सबैलाई थाहा भएका ठेगाना हुन्, जसलाई नेटवर्क फिल्टरले रोक्न सक्छ — त्यसैले तिमी आफ्नै रिले थप्न सक्छौ, .onion ठेगाना पनि।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "als de mesh iemand niet bereikt, gaan privéberichten via deze relays. de ingebouwde relays zijn bekende adressen die een netwerkfilter kan blokkeren — je kunt dus je eigen relays toevoegen, ook .onion-adressen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "gdy mesh nie dosięga kogoś, wiadomości prywatne idą przez te relay. wbudowane to powszechnie znane adresy, które filtr sieciowy może zablokować — możesz więc dodać własne, także adresy .onion."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando a mesh não chega a alguém, as mensagens privadas seguem por estes relés. os integrados são endereços bem conhecidos que um filtro de rede pode bloquear — por isso podes acrescentar os teus, incluindo endereços .onion."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando o mesh não alcança alguém, as mensagens privadas passam por estes relays. os integrados são endereços conhecidos que um filtro de rede pode bloquear — então você pode adicionar os seus, inclusive endereços .onion."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "когда mesh не достаёт до человека, приватные сообщения идут через эти реле. встроенные — это широко известные адреса, которые может заблокировать сетевой фильтр, поэтому можно добавить свои, в том числе .onion-адреса."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "när mesh inte når fram till någon går privata meddelanden via dessa reläer. de inbyggda är välkända adresser som ett nätverksfilter kan blockera — du kan därför lägga till egna, även .onion-adresser."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh ஒருவரை எட்ட முடியாதபோது, தனிப்பட்ட செய்திகள் இந்த ரிலேகள் வழியாகச் செல்கின்றன. உள்ளமைந்த ரிலேகள் நன்கு அறியப்பட்ட முகவரிகள், அவற்றை நெட்வொர்க் வடிகட்டி தடுக்க முடியும் — எனவே .onion முகவரிகள் உட்பட உங்கள் சொந்த ரிலேகளைச் சேர்க்கலாம்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เมื่อ mesh ไปไม่ถึงใคร ข้อความส่วนตัวจะเดินทางผ่านรีเลย์เหล่านี้ รีเลย์ที่มาพร้อมแอปเป็นที่อยู่ที่รู้จักกันดีและตัวกรองเครือข่ายปิดกั้นได้ — คุณจึงเพิ่มรีเลย์ของตัวเองได้ รวมถึงที่อยู่ .onion"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh birine ulaşamadığında özel mesajlar bu rölelerden geçer. yerleşik röleler herkesin bildiği adreslerdir ve bir ağ filtresi bunları engelleyebilir — bu yüzden .onion adresleri de dahil kendi rölelerinizi ekleyebilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "коли mesh не дотягується до людини, приватні повідомлення йдуть через ці релеї. вбудовані — це добре відомі адреси, які може заблокувати мережевий фільтр, тож можна додати власні, зокрема .onion-адреси."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جب mesh کسی تک نہ پہنچ سکے تو نجی پیغامات ان ریلے سے گزرتے ہیں۔ بلٹ اِن ریلے مشہور پتے ہیں جنہیں نیٹ ورک فلٹر روک سکتا ہے — اس لیے آپ اپنے ریلے شامل کر سکتے ہیں، .onion پتے بھی۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "khi mesh không tới được ai đó, tin nhắn riêng đi qua các relay này. các relay tích hợp là những địa chỉ ai cũng biết nên bộ lọc mạng có thể chặn — vì vậy bạn có thể thêm relay của mình, kể cả địa chỉ .onion."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 mesh 无法触达某人时，私密消息会经这些中继传递。内置中继是众所周知的地址，网络过滤可以封锁它们 — 所以你可以添加自己的中继，包括 .onion 地址。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 mesh 無法觸及某人時，私密訊息會經這些中繼傳遞。內建中繼是眾所周知的位址，網路過濾可以封鎖它們 — 所以你可以加入自己的中繼，包括 .onion 位址。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.title" : {
+      "comment" : "Title of the relay list editor in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مرحّلات الرسائل الخاصة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ব্যক্তিগত বার্তার রিলে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays für private nachrichten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "private message relays"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays para mensajes privados"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رله‌های پیام خصوصی"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mga relay para sa pribadong mensahe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relais pour messages privés"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ממסרים להודעות פרטיות"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजी संदेश रिले"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay pesan pribadi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay per messaggi privati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライベートメッセージのリレー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비공개 메시지 릴레이"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay pesan peribadi"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजी सन्देशका रिले"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays voor privéberichten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay dla wiadomości prywatnych"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relés para mensagens privadas"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays para mensagens privadas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "реле для приватных сообщений"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reläer för privata meddelanden"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "தனிப்பட்ட செய்திகளுக்கான ரிலேகள்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีเลย์สำหรับข้อความส่วนตัว"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "özel mesaj röleleri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "релеї для приватних повідомлень"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نجی پیغامات کے ریلے"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay cho tin nhắn riêng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密消息中继"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密訊息中繼"
+          }
+        }
+      }
+    },
+    "app_info.settings.tor.off_warning" : {
+      "comment" : "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor متوقف: كل مرحّل تتصل به يمكنه رؤية عنوان IP الخاص بك، بما في ذلك المرحّلات التي تحمل رسائلك الخاصة."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor বন্ধ: আপনি যে রিলেতেই সংযুক্ত হন সেটি আপনার IP ঠিকানা দেখতে পায়, আপনার ব্যক্তিগত বার্তা বহনকারী রিলেগুলোও।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor ist aus: jedes relay, mit dem du dich verbindest, kann deine ip-adresse sehen, auch die relays, die deine privaten nachrichten tragen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor está desactivado: cada relay al que te conectas puede ver tu dirección IP, incluidos los relays que llevan tus mensajes privados."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor خاموش است: هر رله‌ای که به آن وصل می‌شوید می‌تواند نشانی IP شما را ببیند، از جمله رله‌هایی که پیام‌های خصوصی شما را می‌برند."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "naka-off ang tor: nakikita ng bawat relay na kinokonekta mo ang iyong IP address, kasama ang mga relay na nagdadala ng iyong mga pribadong mensahe."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor est désactivé : chaque relais auquel tu te connectes voit ton adresse ip, y compris les relais qui transportent tes messages privés."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor כבוי: כל ממסר שאתה מתחבר אליו רואה את כתובת ה-ip שלך, כולל ממסרים שנושאים את ההודעות הפרטיות שלך."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor बंद है: आप जिस भी रिले से जुड़ते हैं वह आपका IP पता देख सकता है, उनमें वे रिले भी शामिल हैं जो आपके निजी संदेश ले जाते हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor nonaktif: setiap relay yang kamu hubungi bisa melihat alamat ip-mu, termasuk relay yang membawa pesan pribadimu."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor è disattivato: ogni relay a cui ti colleghi può vedere il tuo indirizzo ip, compresi i relay che trasportano i tuoi messaggi privati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "torはオフです: 接続するすべてのリレーがあなたのipアドレスを見られます。プライベートメッセージを運ぶリレーも同じです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor가 꺼져 있습니다: 연결하는 모든 릴레이가 IP 주소를 볼 수 있고, 비공개 메시지를 운반하는 릴레이도 마찬가지입니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor tidak aktif: setiap relay yang anda sambung boleh melihat alamat ip anda, termasuk relay yang membawa pesan peribadi anda."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor बन्द छ: तिमी जोडिने हरेक रिलेले तिम्रो ip ठेगाना देख्न सक्छ, तिम्रा निजी सन्देश बोक्ने रिले पनि।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor staat uit: elke relay waarmee je verbindt kan je IP-adres zien, ook de relays die je privéberichten vervoeren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor jest wyłączony: każdy relay, z którym się łączysz, widzi twój adres IP, także te przenoszące twoje wiadomości prywatne."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "o Tor está desligado: cada relé a que te ligas consegue ver o teu endereço IP, incluindo os relés que transportam as tuas mensagens privadas."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "o tor está desligado: cada relay a que você se conecta consegue ver seu endereço ip, inclusive os relays que carregam suas mensagens privadas."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor выключен: каждое реле, к которому ты подключаешься, видит твой ip-адрес, включая реле, через которые идут твои приватные сообщения."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor är av: varje relä du ansluter till kan se din IP-adress, även reläerna som bär dina privata meddelanden."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor அணைந்திருக்கிறது: நீங்கள் இணைக்கும் ஒவ்வொரு ரிலேயும் உங்கள் IP முகவரியைப் பார்க்க முடியும், உங்கள் தனிப்பட்ட செய்திகளை எடுத்துச் செல்லும் ரிலேகளும் அதில் அடங்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor ปิดอยู่: ทุกรีเลย์ที่คุณเชื่อมต่อเห็นที่อยู่ IP ของคุณ รวมถึงรีเลย์ที่ส่งข้อความส่วนตัวของคุณ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor kapalı: bağlandığınız her röle IP adresinizi görebilir, özel mesajlarınızı taşıyan röleler de dahil."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor вимкнено: кожен релей, до якого ти підключаєшся, бачить твою ip-адресу, включно з релеями, що несуть твої приватні повідомлення."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor بند ہے: آپ جس ریلے سے بھی جڑتے ہیں وہ آپ کا IP پتہ دیکھ سکتا ہے، اُن ریلے سمیت جو آپ کے نجی پیغامات لے جاتے ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor đang tắt: mọi relay bạn kết nối đều thấy địa chỉ IP của bạn, kể cả những relay mang tin nhắn riêng của bạn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor 已关闭：你连接的每个中继都能看到你的 IP 地址，包括承载你私密消息的中继。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor 已關閉：你連線的每個中繼都能看到你的 IP 位址，包括承載你私密訊息的中繼。"
+          }
+        }
+      }
+    },
+    "app_info.settings.tor.subtitle" : {
+      "comment" : "Subtitle for the tor routing toggle in settings, explaining what it covers",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت. الموصى به: تشغيل."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে। সুপারিশ: চালু।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden. empfohlen: an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet. recomendado: activado."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد. توصیه: روشن."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet. inirerekomenda: naka-on."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet. recommandé : activé."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט. מומלץ: פעיל."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है। अनुशंसित: चालू।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet. disarankan: aktif."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet. consigliato: attivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。推奨: オン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다. 권장: 켜기."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet. disarankan: aktif."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ। सिफारिस: अन।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd. aanbevolen: aan."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet. zalecane: włączone."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет. рекомендуем включить."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet. rekommenderas: på."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும். பரிந்துரை: இயக்கவும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต แนะนำให้เปิด"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar. önerilen: açık."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет. рекомендовано ввімкнути."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔ تجویز: آن رکھیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet. khuyến nghị: bật."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。推荐：开启。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。推薦：開啟。"
           }
         }
       }
@@ -16735,192 +17813,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "橋的另一端"
-          }
-        }
-      }
-    },
-    "Choose an image" : {
-      "comment" : "A label displayed above a button that allows the user to choose an image to send.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختر صورة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "একটি ছবি নির্বাচন করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild auswählen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose an image"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige una imagen"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انتخاب تصویر"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumili ng larawan"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir une image"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "בחר תמונה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एक चित्र चुनें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih gambar"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli un’immagine"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像を選択"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지를 선택하세요"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih imej"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एउटा तस्वीर चयन गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kies een afbeelding"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz obraz"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolher uma imagem"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha uma imagem"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите изображение"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välj en bild"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ஒரு படத்தைத் தேர்ந்தெடுக்கவும்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เลือกภาพ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir görüntü seç"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виберіть зображення"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایک تصویر منتخب کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn một hình ảnh"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择图像"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇圖像"
           }
         }
       }
@@ -22295,6 +23187,192 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 則新公告"
+          }
+        }
+      }
+    },
+    "content.accessibility.open_sticker_picker" : {
+      "comment" : "Accessibility label for the sticker picker button in the composer",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the sticker picker"
           }
         }
       }
@@ -33266,6 +34344,192 @@
         }
       }
     },
+    "content.delivery.reason.not_delivered" : {
+      "comment" : "Failure reason shown when the router gave up delivering a message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لم يُسلَّم"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "পৌঁছায়নি"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "nicht zugestellt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "not delivered"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no entregado"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحویل نشد"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "hindi naihatid"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "non livré"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא נמסר"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "डिलीवर नहीं हुआ"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tidak terkirim"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "non consegnato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未配信"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전송되지 않음"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tidak dihantar"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "डेलिभर भएन"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "niet bezorgd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "nie dostarczono"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não entregue"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não entregue"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не доставлено"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "inte levererat"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "வழங்கப்படவில்லை"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ยังไม่ได้ส่ง"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "teslim edilmedi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не доставлено"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نہیں پہنچا"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chưa gửi được"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未送达"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未送達"
+          }
+        }
+      }
+    },
     "content.delivery.reason.private_media_capability_unresolved" : {
       "comment" : "Failure reason shown when the peer's support for encrypted media could not be confirmed before sending",
       "extractionState" : "manual",
@@ -33634,192 +34898,6 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無法確認送達"
-          }
-        }
-      }
-    },
-    "content.delivery.reason.not_delivered" : {
-      "comment" : "Failure reason shown when the router gave up delivering a message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "لم يُسلَّم"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "পৌঁছায়নি"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "nicht zugestellt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "not delivered"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no entregado"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحویل نشد"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "hindi naihatid"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "non livré"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "לא נמסר"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "डिलीवर नहीं हुआ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "tidak terkirim"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "non consegnato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未配信"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "전송되지 않음"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "tidak dihantar"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "डेलिभर भएन"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "niet bezorgd"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "nie dostarczono"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não entregue"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não entregue"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не доставлено"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "inte levererat"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "வழங்கப்படவில்லை"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ยังไม่ได้ส่ง"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "teslim edilmedi"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не доставлено"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "نہیں پہنچا"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "chưa gửi được"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未送达"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未送達"
           }
         }
       }
@@ -41993,6 +43071,192 @@
         }
       }
     },
+    "content.system.media_delete_refused" : {
+      "comment" : "System message shown in the affected chat when an explicit media delete or /clear was refused and bubbles/files were kept",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر حذف بعض الوسائط. جرّب حذف الوسائط الأقدم أولاً."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "কিছু মিডিয়া মুছে ফেলা যায়নি। আগে পুরোনো মিডিয়া মুছে ফেলার চেষ্টা করুন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "einige medien konnten nicht gelöscht werden. versuche zuerst, ältere medien zu löschen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "some media could not be deleted. try deleting older media first."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "no se pudieron eliminar algunos archivos multimedia. prueba a eliminar primero los más antiguos."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "برخی رسانه‌ها حذف نشدند. ابتدا رسانه‌های قدیمی‌تر را حذف کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "hindi ma-delete ang ilang media. subukang i-delete muna ang mas lumang media."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "impossible de supprimer certains médias. essaie d'abord de supprimer les médias plus anciens."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא ניתן למחוק חלק מהמדיה. נסה קודם למחוק מדיה ישנה יותר."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "कुछ मीडिया हटाई नहीं जा सकी। पहले पुरानी मीडिया हटाने का प्रयास करें।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sebagian media tidak dapat dihapus. coba hapus media yang lebih lama dulu."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "impossibile eliminare alcuni contenuti multimediali. prova prima a eliminare quelli più vecchi."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一部のメディアを削除できませんでした。先に古いメディアを削除してみてください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일부 미디어를 삭제하지 못했습니다. 먼저 오래된 미디어를 삭제해 보세요."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sesetengah media tidak dapat dipadamkan. cuba padamkan media yang lebih lama dahulu."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "केही मिडिया मेटाउन सकिएन। पहिले पुराना मिडिया मेटाउने प्रयास गर।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sommige media konden niet worden verwijderd. probeer eerst oudere media te verwijderen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "nie udało się usunąć części multimediów. spróbuj najpierw usunąć starsze multimedia."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não foi possível eliminar alguns ficheiros multimédia. tenta eliminar primeiro os mais antigos."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não foi possível excluir algumas mídias. tente excluir primeiro as mídias mais antigas."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не удалось удалить часть медиафайлов. попробуй сначала удалить более старые."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vissa medier kunde inte raderas. prova att radera äldre medier först."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "சில ஊடகங்களை நீக்க முடியவில்லை. முதலில் பழைய ஊடகங்களை நீக்க முயற்சிக்கவும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ไม่สามารถลบสื่อบางรายการได้ ลองลบสื่อที่เก่ากว่าก่อน"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "bazı medya silinemedi. önce daha eski medyayı silmeyi dene."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не вдалося видалити частину медіафайлів. спробуй спочатку видалити старіші."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کچھ میڈیا حذف نہیں ہو سکا۔ پہلے پرانا میڈیا حذف کرنے کی کوشش کریں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "không thể xóa một số phương tiện. hãy thử xóa phương tiện cũ hơn trước."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "部分媒体无法删除。请先尝试删除较早的媒体。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "部分媒體無法刪除。請先嘗試刪除較舊的媒體。"
+          }
+        }
+      }
+    },
     "encryption.accessibility.establishing" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -48940,191 +50204,6 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "建立者"
-          }
-        }
-      }
-    },
-    "Images are only available in mesh chats." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الصور متاحة فقط في محادثات الميش."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ছবি শুধু মেশ চ্যাটে উপলব্ধ।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder sind nur im Mesh-Chat verfügbar."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Images are only available in mesh chats."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las imágenes solo están disponibles en los chats de mesh."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصاویر فقط در گفتگوهای مش در دسترس هستند."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ang mga larawan ay available lamang sa mga mesh chat."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les images sont uniquement disponibles dans les discussions mesh."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תמונות זמינות רק בצ׳אט של mesh."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "चित्र केवल मेश चैट में ही उपलब्ध हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gambar hanya tersedia di obrolan mesh."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le immagini sono disponibili solo nelle chat mesh."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像はメッシュチャットでのみ利用できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지는 메쉬 채팅에서만 사용할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imej hanya tersedia dalam sembang mesh."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "तस्बिरहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afbeeldingen zijn alleen beschikbaar in mesh-chats."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obrazy są dostępne tylko na czatach mesh."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As imagens só estão disponíveis nos chats mesh."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As imagens só estão disponíveis nos chats mesh."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изображения доступны только в mesh-чатах."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder är bara tillgängliga i mesh-chattar."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "படங்கள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รูปภาพใช้งานได้เฉพาะในแชต mesh เท่านั้น"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Görseller yalnızca mesh sohbetlerinde kullanılabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зображення доступні лише в mesh-чатах."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصاویر صرف میش چیٹس میں دستیاب ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hình ảnh chỉ khả dụng trong các cuộc trò chuyện mesh."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片仅可在 mesh 聊天中使用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片僅能在 mesh 聊天中使用。"
           }
         }
       }
@@ -63266,6 +64345,192 @@
         }
       }
     },
+    "notification.action.wave" : {
+      "comment" : "Title of the notification action button that sends a friendly wave back to a nearby person",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لوّح 👋"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "হাত নাড়ুন 👋"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "winken 👋"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wave 👋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saludar 👋"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دست تکان دادن 👋"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kumaway 👋"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saluer 👋"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לנופף 👋"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हाथ हिलाएँ 👋"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "melambai 👋"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saluta 👋"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手を振る 👋"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "손 흔들기 👋"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lambai 👋"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हात हल्लाउनुहोस् 👋"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zwaaien 👋"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pomachaj 👋"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "acenar 👋"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "acenar 👋"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "помахать 👋"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vinka 👋"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "கை அசைக்கவும் 👋"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "โบกมือ 👋"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "el salla 👋"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "помахати 👋"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہاتھ ہلائیں 👋"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vẫy tay 👋"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "挥手 👋"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "揮手 👋"
+          }
+        }
+      }
+    },
     "notification.redacted.body" : {
       "comment" : "Lock-screen notification body shown in place of the message text when message previews are hidden",
       "extractionState" : "manual",
@@ -64376,6 +65641,2796 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存"
+          }
+        }
+      }
+    },
+    "share_import.review.message" : {
+      "comment" : "Explains that shared content replaces the named destination's composer and is not sent automatically",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "هل تريد استبدال مسودة %@ بهذا المحتوى؟ لن يتم إرسال أي شيء تلقائيًا."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@-এর খসড়াটি এই কনটেন্ট দিয়ে বদলাবেন? কিছুই স্বয়ংক্রিয়ভাবে পাঠানো হবে না।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Entwurf für %@ durch diesen Inhalt ersetzen? Es wird nichts automatisch gesendet."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replace the draft for %@ with this content? Nothing will be sent automatically."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "¿Reemplazar el borrador de %@ con este contenido? No se enviará nada automáticamente."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "پیش‌نویس %@ با این محتوا جایگزین شود؟ چیزی به‌طور خودکار ارسال نمی‌شود."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Palitan ng content na ito ang draft para sa %@? Walang awtomatikong ipapadala."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remplacer le brouillon pour %@ par ce contenu ? Rien ne sera envoyé automatiquement."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "להחליף את הטיוטה עבור %@ בתוכן הזה? שום דבר לא יישלח אוטומטית."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ का ड्राफ़्ट इस सामग्री से बदलें? कुछ भी अपने आप नहीं भेजा जाएगा।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ganti draf untuk %@ dengan konten ini? Tidak ada yang akan dikirim otomatis."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sostituire la bozza per %@ con questo contenuto? Nulla verrà inviato automaticamente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ の下書きをこの内容で置き換えますか？自動的には送信されません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@의 초안을 이 콘텐츠로 바꾸시겠습니까? 자동으로 전송되지 않습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gantikan draf untuk %@ dengan kandungan ini? Tiada apa-apa akan dihantar secara automatik."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ को मस्यौदा यो सामग्रीले बदल्ने? केही पनि स्वचालित रूपमा पठाइने छैन।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Concept voor %@ vervangen door deze inhoud? Er wordt niets automatisch verzonden."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zastąpić szkic dla %@ tą treścią? Nic nie zostanie wysłane automatycznie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Substituir o rascunho para %@ por este conteúdo? Nada será enviado automaticamente."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Substituir o rascunho de %@ por este conteúdo? Nada será enviado automaticamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Заменить черновик для %@ этим содержимым? Ничего не будет отправлено автоматически."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ersätta utkastet för %@ med detta innehåll? Inget skickas automatiskt."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ க்கான வரைவைக் இந்த உள்ளடக்கத்தால் மாற்றவா? எதுவும் தானாக அனுப்பப்படாது."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "แทนที่ฉบับร่างสำหรับ %@ ด้วยเนื้อหานี้หรือไม่? จะไม่มีการส่งอัตโนมัติ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ taslağı bu içerikle değiştirilsin mi? Hiçbir şey otomatik olarak gönderilmez."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Замінити чернетку для %@ цим вмістом? Нічого не буде надіслано автоматично."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ کا مسودہ اس مواد سے بدلیں؟ کچھ بھی خودکار طور پر نہیں بھیجا جائے گا۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Thay bản nháp cho %@ bằng nội dung này? Không có gì được tự động gửi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "要用此内容替换 %@ 的草稿吗？内容不会自动发送。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "要用此內容取代 %@ 的草稿嗎？內容不會自動傳送。"
+          }
+        }
+      }
+    },
+    "share_import.review.title" : {
+      "comment" : "Title for reviewing content received from the share extension",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مراجعة المحتوى المشترك"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "শেয়ার করা কনটেন্ট পর্যালোচনা করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geteilte Inhalte prüfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Review shared content"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Revisar contenido compartido"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "بازبینی محتوای هم‌رسانی‌شده"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Suriin ang ibinahaging content"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vérifier le contenu partagé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בדיקת תוכן משותף"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "शेयर की गई सामग्री की समीक्षा करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tinjau konten yang dibagikan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Controlla il contenuto condiviso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共有コンテンツを確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "공유 콘텐츠 검토"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Semak kandungan yang dikongsi"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "साझा सामग्री समीक्षा गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gedeelde inhoud bekijken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprawdź udostępnioną treść"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rever conteúdo partilhado"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Revisar conteúdo compartilhado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Проверить общий контент"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Granska delat innehåll"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "பகிரப்பட்ட உள்ளடக்கத்தை மதிப்பாய்வு செய்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ตรวจสอบเนื้อหาที่แชร์"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Paylaşılan içeriği gözden geçir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Переглянути спільний вміст"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "شیئر کردہ مواد کا جائزہ لیں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Xem lại nội dung được chia sẻ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查看共享内容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查看分享內容"
+          }
+        }
+      }
+    },
+    "share_import.review.use_in_composer" : {
+      "comment" : "Action that places reviewed shared content in the composer without sending it",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "استخدام في مسودة الرسالة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "বার্তার খসড়ায় ব্যবহার করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Im Nachrichtenentwurf verwenden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use in composer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usar en el borrador"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "استفاده در پیش‌نویس پیام"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gamitin sa draft"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utiliser dans le brouillon"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שימוש בטיוטה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "संदेश के ड्राफ़्ट में उपयोग करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gunakan di draf"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usa nella bozza"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下書きで使用"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "초안에 사용"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gunakan dalam draf"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "सन्देशको मस्यौदामा प्रयोग गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "In concept gebruiken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Użyj w szkicu"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usar no rascunho"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usar no rascunho"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Использовать в черновике"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Använd i utkast"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "செய்தி வரைவில் பயன்படுத்து"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ใช้ในฉบับร่าง"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Taslakta kullan"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Використати в чернетці"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "پیغام کے مسودے میں استعمال کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dùng trong bản nháp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "用于草稿"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "用於草稿"
+          }
+        }
+      }
+    },
+    "sticker.accessibility.send" : {
+      "comment" : "Accessibility hint for tapping a sticker to send it",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send this sticker"
+          }
+        }
+      }
+    },
+    "sticker.install.button" : {
+      "comment" : "Button that installs the pasted sticker pack",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install"
+          }
+        }
+      }
+    },
+    "sticker.install.error.failed" : {
+      "comment" : "Error shown when a pack could not be fetched or installed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
+          }
+        }
+      }
+    },
+    "sticker.install.error.invalid" : {
+      "comment" : "Error shown when a pasted pack coordinate is malformed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
+          }
+        }
+      }
+    },
+    "sticker.install.loading" : {
+      "comment" : "Status shown while a pack is being fetched",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fetching pack…"
+          }
+        }
+      }
+    },
+    "sticker.install.placeholder" : {
+      "comment" : "Placeholder for the pack coordinate input field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30031:<pubkey>:<identifier>"
+          }
+        }
+      }
+    },
+    "sticker.install.title" : {
+      "comment" : "Section heading for installing a new sticker pack",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install a Pack"
+          }
+        }
+      }
+    },
+    "sticker.picker.empty" : {
+      "comment" : "Shown when no sticker packs are installed yet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
+          }
+        }
+      }
+    },
+    "sticker.picker.section.installed" : {
+      "comment" : "Section heading for the installed sticker packs",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed Packs"
+          }
+        }
+      }
+    },
+    "sticker.picker.title" : {
+      "comment" : "Title of the sticker picker sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stickers"
+          }
+        }
+      }
+    },
+    "sticker.sync.title" : {
+      "comment" : "Toggle label for syncing installed sticker packs to Nostr",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Installed Packs to Nostr"
+          }
+        }
+      }
+    },
+    "sticker.sync.warning" : {
+      "comment" : "Privacy warning explaining that Nostr sync publishes installed packs under the persistent identity",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
           }
         }
       }
@@ -75489,1043 +79544,6 @@
             "value" : "驗證"
           }
         }
-      }
-    },
-    "Voice notes are only available in mesh chats." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الملاحظات الصوتية متاحة فقط في محادثات الميش."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস নোট শুধু মেশ চ্যাটে উপলব্ধ।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachnachrichten sind nur im Mesh-Chat verfügbar."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voice notes are only available in mesh chats."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las notas de voz solo están disponibles en los chats de mesh."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پیام صوتی فقط در گفتگوهای مش در دسترس است."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ang mga voice note ay available lamang sa mga mesh chat."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les notes vocales sont uniquement disponibles dans les discussions mesh."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הערות קוליות זמינות רק בצ׳אט של mesh."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वॉइस नोट्स केवल मेश चैट में ही उपलब्ध हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catatan suara hanya tersedia di obrolan mesh."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le note vocali sono disponibili solo nelle chat mesh."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボイスメモはメッシュチャットでのみ利用できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 메모는 메쉬 채팅에서만 사용할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota suara hanya tersedia dalam sembang mesh."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भ्वाइस नोटहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spraaknotities zijn alleen beschikbaar in mesh-chats."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notatki głosowe są dostępne tylko na czatach mesh."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As notas de voz só estão disponíveis nos chats mesh."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As mensagens de voz só estão disponíveis nos chats mesh."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосовые сообщения доступны только в mesh-чатах."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Röstanteckningar är bara tillgängliga i mesh-chattar."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "குரல் குறிப்புகள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "บันทึกเสียงใช้งานได้เฉพาะในแชต mesh เท่านั้น"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sesli notlar yalnızca mesh sohbetlerinde kullanılabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосові нотатки доступні лише в mesh-чатах."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وائس نوٹس صرف میش چیٹس میں دستیاب ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghi chú giọng nói chỉ khả dụng trong các cuộc trò chuyện mesh."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音消息仅可在 mesh 聊天中使用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音訊息僅能在 mesh 聊天中使用。"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.title" : {
-      "comment" : "Section header (uppercase) for the app language picker in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اللغة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভাষা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SPRACHE"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LANGUAGE"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WIKA"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LANGUE"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שפה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषा"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BAHASA"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LINGUA"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BAHASA"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषा"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TAAL"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JĘZYK"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ЯЗЫК"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SPRÅK"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "மொழி"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ภาษา"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DİL"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "МОВА"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NGÔN NGỮ"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語言"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.picker_label" : {
-      "comment" : "Label of the app language picker row in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لغة التطبيق"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অ্যাপের ভাষা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Sprache"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "app language"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma de la app"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان برنامه"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wika ng app"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "langue de l'app"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שפת האפליקציה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐप की भाषा"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bahasa aplikasi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lingua dell'app"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの言語"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱 언어"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bahasa aplikasi"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एपको भाषा"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "app-taal"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "język aplikacji"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma da app"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma do app"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "язык приложения"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "appspråk"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "செயலியின் மொழி"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ภาษาของแอป"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "uygulama dili"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "мова застосунку"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایپ کی زبان"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ngôn ngữ ứng dụng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "應用程式語言"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.system" : {
-      "comment" : "Menu option that clears the in-app language override so the app follows the device language",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لغة النظام"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সিস্টেম ডিফল্ট"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemstandard"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "system default"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predeterminado del sistema"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پیش‌فرض سیستم"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "default ng system"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "réglage système"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ברירת המחדל של המערכת"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सिस्टम डिफ़ॉल्ट"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bawaan sistem"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predefinita di sistema"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムのデフォルト"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 기본값"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lalai sistem"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रणाली पूर्वनिर्धारित"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "systeemstandaard"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "domyślny systemowy"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predefinição do sistema"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "padrão do sistema"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "системный по умолчанию"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "systemstandard"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "கணினி இயல்புநிலை"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ค่าเริ่มต้นของระบบ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sistem varsayılanı"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "системна за замовчуванням"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سسٹم ڈیفالٹ"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mặc định hệ thống"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统默认"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統預設"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.restart_note" : {
-      "comment" : "Caption shown after the user picks a different app language; the change takes effect on next launch",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أعد تشغيل bitchat لتطبيق اللغة الجديدة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "নতুন ভাষা প্রয়োগ করতে bitchat পুনরায় চালু করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bitchat neu starten, um die neue Sprache zu übernehmen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "restart bitchat to apply the new language"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicia bitchat para aplicar el nuevo idioma"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای اعمال زبان جدید، bitchat را دوباره باز کنید"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "i-restart ang bitchat para mailapat ang bagong wika"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "redémarrez bitchat pour appliquer la nouvelle langue"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "יש להפעיל מחדש את bitchat כדי להחיל את השפה החדשה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नई भाषा लागू करने के लिए bitchat पुनः आरंभ करें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mulai ulang bitchat untuk menerapkan bahasa baru"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "riavvia bitchat per applicare la nuova lingua"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい言語を適用するには bitchat を再起動してください"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새 언어를 적용하려면 bitchat을 다시 시작하세요"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mulakan semula bitchat untuk menggunakan bahasa baharu"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नयाँ भाषा लागू गर्न bitchat पुनः सुरु गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "herstart bitchat om de nieuwe taal toe te passen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "uruchom bitchat ponownie, aby zastosować nowy język"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicie o bitchat para aplicar o novo idioma"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicie o bitchat para aplicar o novo idioma"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "перезапустите bitchat, чтобы применить новый язык"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "starta om bitchat för att använda det nya språket"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "புதிய மொழியைப் பயன்படுத்த bitchat-ஐ மீண்டும் தொடங்கவும்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีสตาร์ท bitchat เพื่อใช้ภาษาใหม่"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "yeni dili uygulamak için bitchat'i yeniden başlatın"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "перезапустіть bitchat, щоб застосувати нову мову"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نئی زبان لاگو کرنے کے لیے bitchat دوبارہ شروع کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "khởi động lại bitchat để áp dụng ngôn ngữ mới"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重启 bitchat 以应用新语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啟動 bitchat 以套用新語言"
-          }
-        }
-      }
-    },
-    "share_import.review.message" : {
-      "comment" : "Explains that shared content replaces the named destination's composer and is not sent automatically",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "هل تريد استبدال مسودة %@ بهذا المحتوى؟ لن يتم إرسال أي شيء تلقائيًا." } },
-        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "%@-এর খসড়াটি এই কনটেন্ট দিয়ে বদলাবেন? কিছুই স্বয়ংক্রিয়ভাবে পাঠানো হবে না।" } },
-        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Entwurf für %@ durch diesen Inhalt ersetzen? Es wird nichts automatisch gesendet." } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Replace the draft for %@ with this content? Nothing will be sent automatically." } },
-        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "¿Reemplazar el borrador de %@ con este contenido? No se enviará nada automáticamente." } },
-        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "پیش‌نویس %@ با این محتوا جایگزین شود؟ چیزی به‌طور خودکار ارسال نمی‌شود." } },
-        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Palitan ng content na ito ang draft para sa %@? Walang awtomatikong ipapadala." } },
-        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Remplacer le brouillon pour %@ par ce contenu ? Rien ne sera envoyé automatiquement." } },
-        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "להחליף את הטיוטה עבור %@ בתוכן הזה? שום דבר לא יישלח אוטומטית." } },
-        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ का ड्राफ़्ट इस सामग्री से बदलें? कुछ भी अपने आप नहीं भेजा जाएगा।" } },
-        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Ganti draf untuk %@ dengan konten ini? Tidak ada yang akan dikirim otomatis." } },
-        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Sostituire la bozza per %@ con questo contenuto? Nulla verrà inviato automaticamente." } },
-        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ の下書きをこの内容で置き換えますか？自動的には送信されません。" } },
-        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "%@의 초안을 이 콘텐츠로 바꾸시겠습니까? 자동으로 전송되지 않습니다." } },
-        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Gantikan draf untuk %@ dengan kandungan ini? Tiada apa-apa akan dihantar secara automatik." } },
-        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ को मस्यौदा यो सामग्रीले बदल्ने? केही पनि स्वचालित रूपमा पठाइने छैन।" } },
-        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Concept voor %@ vervangen door deze inhoud? Er wordt niets automatisch verzonden." } },
-        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Zastąpić szkic dla %@ tą treścią? Nic nie zostanie wysłane automatycznie." } },
-        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Substituir o rascunho para %@ por este conteúdo? Nada será enviado automaticamente." } },
-        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Substituir o rascunho de %@ por este conteúdo? Nada será enviado automaticamente." } },
-        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Заменить черновик для %@ этим содержимым? Ничего не будет отправлено автоматически." } },
-        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Ersätta utkastet för %@ med detta innehåll? Inget skickas automatiskt." } },
-        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ க்கான வரைவைக் இந்த உள்ளடக்கத்தால் மாற்றவா? எதுவும் தானாக அனுப்பப்படாது." } },
-        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "แทนที่ฉบับร่างสำหรับ %@ ด้วยเนื้อหานี้หรือไม่? จะไม่มีการส่งอัตโนมัติ" } },
-        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ taslağı bu içerikle değiştirilsin mi? Hiçbir şey otomatik olarak gönderilmez." } },
-        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Замінити чернетку для %@ цим вмістом? Нічого не буде надіслано автоматично." } },
-        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ کا مسودہ اس مواد سے بدلیں؟ کچھ بھی خودکار طور پر نہیں بھیجا جائے گا۔" } },
-        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Thay bản nháp cho %@ bằng nội dung này? Không có gì được tự động gửi." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "要用此内容替换 %@ 的草稿吗？内容不会自动发送。" } },
-        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "要用此內容取代 %@ 的草稿嗎？內容不會自動傳送。" } }
-      }
-    },
-    "share_import.review.title" : {
-      "comment" : "Title for reviewing content received from the share extension",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "مراجعة المحتوى المشترك" } },
-        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "শেয়ার করা কনটেন্ট পর্যালোচনা করুন" } },
-        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Geteilte Inhalte prüfen" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Review shared content" } },
-        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Revisar contenido compartido" } },
-        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "بازبینی محتوای هم‌رسانی‌شده" } },
-        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Suriin ang ibinahaging content" } },
-        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Vérifier le contenu partagé" } },
-        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "בדיקת תוכן משותף" } },
-        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "शेयर की गई सामग्री की समीक्षा करें" } },
-        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Tinjau konten yang dibagikan" } },
-        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Controlla il contenuto condiviso" } },
-        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "共有コンテンツを確認" } },
-        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "공유 콘텐츠 검토" } },
-        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Semak kandungan yang dikongsi" } },
-        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "साझा सामग्री समीक्षा गर्नुहोस्" } },
-        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Gedeelde inhoud bekijken" } },
-        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Sprawdź udostępnioną treść" } },
-        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Rever conteúdo partilhado" } },
-        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Revisar conteúdo compartilhado" } },
-        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Проверить общий контент" } },
-        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Granska delat innehåll" } },
-        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "பகிரப்பட்ட உள்ளடக்கத்தை மதிப்பாய்வு செய்" } },
-        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ตรวจสอบเนื้อหาที่แชร์" } },
-        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Paylaşılan içeriği gözden geçir" } },
-        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Переглянути спільний вміст" } },
-        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "شیئر کردہ مواد کا جائزہ لیں" } },
-        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Xem lại nội dung được chia sẻ" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "查看共享内容" } },
-        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "查看分享內容" } }
-      }
-    },
-    "share_import.review.use_in_composer" : {
-      "comment" : "Action that places reviewed shared content in the composer without sending it",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "استخدام في مسودة الرسالة" } },
-        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "বার্তার খসড়ায় ব্যবহার করুন" } },
-        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Im Nachrichtenentwurf verwenden" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Use in composer" } },
-        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar en el borrador" } },
-        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "استفاده در پیش‌نویس پیام" } },
-        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Gamitin sa draft" } },
-        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Utiliser dans le brouillon" } },
-        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "שימוש בטיוטה" } },
-        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "संदेश के ड्राफ़्ट में उपयोग करें" } },
-        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Gunakan di draf" } },
-        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Usa nella bozza" } },
-        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "下書きで使用" } },
-        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "초안에 사용" } },
-        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Gunakan dalam draf" } },
-        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "सन्देशको मस्यौदामा प्रयोग गर्नुहोस्" } },
-        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "In concept gebruiken" } },
-        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Użyj w szkicu" } },
-        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar no rascunho" } },
-        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar no rascunho" } },
-        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Использовать в черновике" } },
-        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Använd i utkast" } },
-        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "செய்தி வரைவில் பயன்படுத்து" } },
-        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ใช้ในฉบับร่าง" } },
-        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Taslakta kullan" } },
-        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Використати в чернетці" } },
-        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "پیغام کے مسودے میں استعمال کریں" } },
-        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Dùng trong bản nháp" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "用于草稿" } },
-        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "用於草稿" } }
       }
     }
   },

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -1,9 +1,2278 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "app_info.settings.relays.add" : {
+      "comment" : "Button that adds the typed relay address to the list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "যোগ করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "add"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "añadir"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "افزودن"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idagdag"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ajouter"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जोड़ें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tambah"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "aggiungi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tambah"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "थप"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "toevoegen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dodaj"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "adicionar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "adicionar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "добавить"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lägg till"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "சேர்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เพิ่ม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ekle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "додати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "شامل کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "thêm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.built_in" : {
+      "comment" : "Label marking a relay as one of the built-in relays, which cannot be removed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مدمج"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "বিল্ট-ইন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eingebaut"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "built in"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "داخلی"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "built in"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "intégré"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מובנה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अंतर्निर्मित"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bawaan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "組み込み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 제공"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "terbina dalam"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पूर्वनिर्मित"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ingebouwd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wbudowany"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "integrado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "встроенное"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "inbyggt"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "உள்ளமைந்தது"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "มาพร้อมแอป"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yerleşik"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "вбудований"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلٹ اِن"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tích hợp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.duplicate" : {
+      "comment" : "Error shown when the typed relay address is already in the list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هذا المرحّل موجود في القائمة بالفعل."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই রিলে আগেই তালিকায় আছে।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dieses relay steht schon in der liste."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "that relay is already in the list."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ese relay ya está en la lista."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این رله از قبل در فهرست است."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nasa listahan na ang relay na iyon."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ce relais est déjà dans la liste."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הממסר הזה כבר ברשימה."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वह रिले पहले से सूची में है।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay itu sudah ada di daftar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quel relay è già nell'elenco."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "そのリレーはすでにリストにあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그 릴레이는 이미 목록에 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay itu sudah ada dalam senarai."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "त्यो रिले पहिले नै सूचीमा छ।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "die relay staat al in de lijst."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ten relay już jest na liście."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "esse relé já está na lista."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "esse relay já está na lista."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "это реле уже в списке."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "det reläet finns redan i listan."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "அந்த ரிலே ஏற்கெனவே பட்டியலில் உள்ளது."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีเลย์นี้อยู่ในรายการแล้ว"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu röle listede zaten var."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "цей релей уже в списку."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ ریلے پہلے ہی فہرست میں ہے۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay đó đã có trong danh sách."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该中继已在列表中。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該中繼已在清單中。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.limit" : {
+      "comment" : "Error shown when the relay list is already at its maximum size; %d is that maximum",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك إضافة %d مرحّلات كحد أقصى."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "আপনি সর্বোচ্চ %d টি রিলে যোগ করতে পারেন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "du kannst bis zu %d relays hinzufügen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you can add up to %d relays."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "puedes añadir hasta %d relays."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "می‌توانید تا %d رله اضافه کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hanggang %d relay lang ang maaari mong idagdag."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tu peux ajouter jusqu'à %d relais."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "אפשר להוסיף עד %d ממסרים."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आप %d रिले तक जोड़ सकते हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kamu bisa menambahkan hingga %d relay."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "puoi aggiungere fino a %d relay."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーは最大%d件まで追加できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이는 최대 %d개까지 추가할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "anda boleh menambah sehingga %d relay."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "तिमी %d रिलेसम्म थप्न सक्छौ।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "je kunt tot %d relays toevoegen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "możesz dodać maksymalnie %d relay."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "podes adicionar até %d relés."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "você pode adicionar até %d relays."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "можно добавить до %d реле."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "du kan lägga till upp till %d reläer."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d ரிலேகள் வரை சேர்க்கலாம்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เพิ่มรีเลย์ได้สูงสุด %d รายการ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en fazla %d röle ekleyebilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "можна додати до %d релеїв."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آپ %d ریلے تک شامل کر سکتے ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bạn có thể thêm tối đa %d relay."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多可以添加 %d 个中继。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多可以加入 %d 個中繼。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.error.malformed" : {
+      "comment" : "Error shown when a typed relay address cannot be parsed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يبدو هذا عنوان مرحّل. جرّب wss://host."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এটি রিলের ঠিকানার মতো মনে হচ্ছে না। wss://host দিয়ে চেষ্টা করুন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "das sieht nicht wie eine relay-adresse aus. versuch wss://host."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "that doesn't look like a relay address. try wss://host."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eso no parece una dirección de relay. prueba wss://host."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این شبیه نشانی رله نیست. wss://host را امتحان کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mukhang hindi ito address ng relay. subukan ang wss://host."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ça ne ressemble pas à une adresse de relais. essaie wss://host."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "זה לא נראה כמו כתובת של ממסר. נסה wss://host."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह रिले का पता नहीं लगता। wss://host आज़माएँ।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "itu tidak tampak seperti alamat relay. coba wss://host."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non sembra l'indirizzo di un relay. prova wss://host."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーのアドレスではないようです。wss://host を試してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이 주소가 아닌 것 같습니다. wss://host 형식으로 시도하세요."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "itu tidak kelihatan seperti alamat relay. cuba wss://host."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यो रिलेको ठेगाना जस्तो देखिँदैन। wss://host प्रयास गर।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dat lijkt niet op een relay-adres. probeer wss://host."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "to nie wygląda na adres relay. spróbuj wss://host."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "isso não parece um endereço de relé. tenta wss://host."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "isso não parece um endereço de relay. tente wss://host."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "это не похоже на адрес реле. попробуй wss://host."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "det ser inte ut som en reläadress. prova wss://host."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இது ரிலே முகவரி போல் தெரியவில்லை. wss://host முயற்சிக்கவும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ดูเหมือนไม่ใช่ที่อยู่รีเลย์ ลอง wss://host"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu bir röle adresine benzemiyor. wss://host deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "це не схоже на адресу релея. спробуй wss://host."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ ریلے کا پتہ نہیں لگتا۔ wss://host آزمائیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "đó không giống địa chỉ relay. hãy thử wss://host."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这看起来不像中继地址。试试 wss://host。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這看起來不像中繼位址。試試 wss://host。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.placeholder" : {
+      "comment" : "Placeholder text in the field for adding a relay address",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay.example.com"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.remove" : {
+      "comment" : "Accessibility label for the button that removes an added relay",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة المرحّل"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "রিলে সরান"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay entfernen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remove relay"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quitar relay"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف رله"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alisin ang relay"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "retirer le relais"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הסר ממסר"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिले हटाएँ"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hapus relay"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rimuovi relay"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リレーを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "릴레이 제거"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "buang relay"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिले हटाउ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay verwijderen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "usuń relay"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remover relé"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "remover relay"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "удалить реле"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ta bort relä"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ரிலேயை நீக்கு"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ลบรีเลย์"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "röleyi kaldır"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "видалити релей"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریلے ہٹائیں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "xóa relay"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除中继"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除中繼"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.subtitle" : {
+      "comment" : "Subtitle explaining what the relay list is for and why someone would add a relay",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عندما لا تصل شبكة mesh إلى شخص، تنتقل الرسائل الخاصة عبر هذه المرحّلات. المرحّلات المدمجة عناوين معروفة يمكن لمرشّح الشبكة حجبها — لذا يمكنك إضافة مرحّلاتك الخاصة، بما في ذلك عناوين .onion."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মেশ কারও কাছে পৌঁছাতে না পারলে ব্যক্তিগত বার্তা এই রিলেগুলোর মধ্য দিয়ে যায়। বিল্ট-ইন রিলেগুলো সুপরিচিত ঠিকানা, যা নেটওয়ার্ক ফিল্টার আটকে দিতে পারে — তাই আপনি নিজের রিলে যোগ করতে পারেন, .onion ঠিকানাও।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wenn das mesh jemanden nicht erreicht, laufen private nachrichten über diese relays. die eingebauten sind bekannte adressen, die ein netzwerkfilter blockieren kann — du kannst also eigene hinzufügen, auch .onion-adressen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "when the mesh can't reach someone, private messages travel through these relays. the built-in ones are well-known addresses that a network filter can block, so you can add your own — including .onion addresses."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cuando el mesh no llega a alguien, los mensajes privados viajan por estos relays. los integrados son direcciones muy conocidas que un filtro de red puede bloquear, así que puedes añadir los tuyos — incluidas direcciones .onion."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وقتی مش به کسی نمی‌رسد، پیام‌های خصوصی از این رله‌ها می‌گذرند. رله‌های داخلی نشانی‌های شناخته‌شده‌ای هستند که یک صافی شبکه می‌تواند مسدودشان کند — پس می‌توانید رله‌های خودتان را اضافه کنید، از جمله نشانی‌های .onion."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kapag hindi maabot ng mesh ang isang tao, dumadaan ang mga pribadong mensahe sa mga relay na ito. ang mga built-in ay kilalang-kilalang address na kayang harangin ng filter ng network — kaya maaari kang magdagdag ng sarili mo, kasama ang mga .onion address."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quand le mesh ne joint pas quelqu'un, les messages privés passent par ces relais. ceux intégrés sont des adresses bien connues qu'un filtre réseau peut bloquer — tu peux donc ajouter les tiens, y compris des adresses .onion."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כשה-mesh לא מגיע למישהו, הודעות פרטיות עוברות דרך הממסרים האלה. הממסרים המובנים הם כתובות מוכרות שמסנן רשת יכול לחסום — אפשר להוסיף ממסרים משלך, כולל כתובות .onion."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "जब मेश किसी तक नहीं पहुँच पाता, तब निजी संदेश इन रिले से होकर जाते हैं। अंतर्निर्मित रिले जाने-पहचाने पते हैं जिन्हें नेटवर्क फ़िल्टर रोक सकता है — इसलिए आप अपने रिले जोड़ सकते हैं, .onion पते भी।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saat mesh tidak bisa menjangkau seseorang, pesan pribadi lewat relay ini. relay bawaan adalah alamat yang sudah dikenal luas dan bisa diblokir filter jaringan — jadi kamu bisa menambahkan relay sendiri, termasuk alamat .onion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando la mesh non raggiunge qualcuno, i messaggi privati passano da questi relay. quelli integrati sono indirizzi molto noti che un filtro di rete può bloccare — puoi quindi aggiungere i tuoi, anche indirizzi .onion."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "meshで相手に届かないとき、プライベートメッセージはこれらのリレーを通ります。組み込みのリレーはよく知られたアドレスで、ネットワークのフィルターにブロックされることがあります — 自分のリレー、.onionアドレスも追加できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh로 상대에게 닿지 않으면 비공개 메시지는 이 릴레이를 거칩니다. 기본 릴레이는 널리 알려진 주소여서 네트워크 필터가 차단할 수 있습니다 — 그래서 .onion 주소를 포함해 직접 릴레이를 추가할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "apabila mesh tidak dapat mencapai seseorang, pesan peribadi bergerak melalui relay ini. relay terbina dalam ialah alamat yang terkenal dan boleh dihalang oleh penapis rangkaian — jadi anda boleh menambah relay sendiri, termasuk alamat .onion."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh कसैसम्म पुग्न सक्दैन भने निजी सन्देश यी रिले मार्फत जान्छन्। पूर्वनिर्मित रिले सबैलाई थाहा भएका ठेगाना हुन्, जसलाई नेटवर्क फिल्टरले रोक्न सक्छ — त्यसैले तिमी आफ्नै रिले थप्न सक्छौ, .onion ठेगाना पनि।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "als de mesh iemand niet bereikt, gaan privéberichten via deze relays. de ingebouwde relays zijn bekende adressen die een netwerkfilter kan blokkeren — je kunt dus je eigen relays toevoegen, ook .onion-adressen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "gdy mesh nie dosięga kogoś, wiadomości prywatne idą przez te relay. wbudowane to powszechnie znane adresy, które filtr sieciowy może zablokować — możesz więc dodać własne, także adresy .onion."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando a mesh não chega a alguém, as mensagens privadas seguem por estes relés. os integrados são endereços bem conhecidos que um filtro de rede pode bloquear — por isso podes acrescentar os teus, incluindo endereços .onion."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quando o mesh não alcança alguém, as mensagens privadas passam por estes relays. os integrados são endereços conhecidos que um filtro de rede pode bloquear — então você pode adicionar os seus, inclusive endereços .onion."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "когда mesh не достаёт до человека, приватные сообщения идут через эти реле. встроенные — это широко известные адреса, которые может заблокировать сетевой фильтр, поэтому можно добавить свои, в том числе .onion-адреса."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "när mesh inte når fram till någon går privata meddelanden via dessa reläer. de inbyggda är välkända adresser som ett nätverksfilter kan blockera — du kan därför lägga till egna, även .onion-adresser."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh ஒருவரை எட்ட முடியாதபோது, தனிப்பட்ட செய்திகள் இந்த ரிலேகள் வழியாகச் செல்கின்றன. உள்ளமைந்த ரிலேகள் நன்கு அறியப்பட்ட முகவரிகள், அவற்றை நெட்வொர்க் வடிகட்டி தடுக்க முடியும் — எனவே .onion முகவரிகள் உட்பட உங்கள் சொந்த ரிலேகளைச் சேர்க்கலாம்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เมื่อ mesh ไปไม่ถึงใคร ข้อความส่วนตัวจะเดินทางผ่านรีเลย์เหล่านี้ รีเลย์ที่มาพร้อมแอปเป็นที่อยู่ที่รู้จักกันดีและตัวกรองเครือข่ายปิดกั้นได้ — คุณจึงเพิ่มรีเลย์ของตัวเองได้ รวมถึงที่อยู่ .onion"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh birine ulaşamadığında özel mesajlar bu rölelerden geçer. yerleşik röleler herkesin bildiği adreslerdir ve bir ağ filtresi bunları engelleyebilir — bu yüzden .onion adresleri de dahil kendi rölelerinizi ekleyebilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "коли mesh не дотягується до людини, приватні повідомлення йдуть через ці релеї. вбудовані — це добре відомі адреси, які може заблокувати мережевий фільтр, тож можна додати власні, зокрема .onion-адреси."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جب mesh کسی تک نہ پہنچ سکے تو نجی پیغامات ان ریلے سے گزرتے ہیں۔ بلٹ اِن ریلے مشہور پتے ہیں جنہیں نیٹ ورک فلٹر روک سکتا ہے — اس لیے آپ اپنے ریلے شامل کر سکتے ہیں، .onion پتے بھی۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "khi mesh không tới được ai đó, tin nhắn riêng đi qua các relay này. các relay tích hợp là những địa chỉ ai cũng biết nên bộ lọc mạng có thể chặn — vì vậy bạn có thể thêm relay của mình, kể cả địa chỉ .onion."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 mesh 无法触达某人时，私密消息会经这些中继传递。内置中继是众所周知的地址，网络过滤可以封锁它们 — 所以你可以添加自己的中继，包括 .onion 地址。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 mesh 無法觸及某人時，私密訊息會經這些中繼傳遞。內建中繼是眾所周知的位址，網路過濾可以封鎖它們 — 所以你可以加入自己的中繼，包括 .onion 位址。"
+          }
+        }
+      }
+    },
+    "app_info.settings.relays.title" : {
+      "comment" : "Title of the relay list editor in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مرحّلات الرسائل الخاصة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ব্যক্তিগত বার্তার রিলে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays für private nachrichten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "private message relays"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays para mensajes privados"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رله‌های پیام خصوصی"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mga relay para sa pribadong mensahe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relais pour messages privés"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ממסרים להודעות פרטיות"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजी संदेश रिले"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay pesan pribadi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay per messaggi privati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライベートメッセージのリレー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비공개 메시지 릴레이"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay pesan peribadi"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निजी सन्देशका रिले"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays voor privéberichten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay dla wiadomości prywatnych"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relés para mensagens privadas"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays para mensagens privadas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "реле для приватных сообщений"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reläer för privata meddelanden"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "தனிப்பட்ட செய்திகளுக்கான ரிலேகள்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีเลย์สำหรับข้อความส่วนตัว"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "özel mesaj röleleri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "релеї для приватних повідомлень"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نجی پیغامات کے ریلے"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay cho tin nhắn riêng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密消息中继"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密訊息中繼"
+          }
+        }
+      }
+    },
+    "app_info.settings.tor.off_warning" : {
+      "comment" : "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor متوقف: كل مرحّل تتصل به يمكنه رؤية عنوان IP الخاص بك، بما في ذلك المرحّلات التي تحمل رسائلك الخاصة."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor বন্ধ: আপনি যে রিলেতেই সংযুক্ত হন সেটি আপনার IP ঠিকানা দেখতে পায়, আপনার ব্যক্তিগত বার্তা বহনকারী রিলেগুলোও।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor ist aus: jedes relay, mit dem du dich verbindest, kann deine ip-adresse sehen, auch die relays, die deine privaten nachrichten tragen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor está desactivado: cada relay al que te conectas puede ver tu dirección IP, incluidos los relays que llevan tus mensajes privados."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor خاموش است: هر رله‌ای که به آن وصل می‌شوید می‌تواند نشانی IP شما را ببیند، از جمله رله‌هایی که پیام‌های خصوصی شما را می‌برند."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "naka-off ang tor: nakikita ng bawat relay na kinokonekta mo ang iyong IP address, kasama ang mga relay na nagdadala ng iyong mga pribadong mensahe."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor est désactivé : chaque relais auquel tu te connectes voit ton adresse ip, y compris les relais qui transportent tes messages privés."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor כבוי: כל ממסר שאתה מתחבר אליו רואה את כתובת ה-ip שלך, כולל ממסרים שנושאים את ההודעות הפרטיות שלך."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor बंद है: आप जिस भी रिले से जुड़ते हैं वह आपका IP पता देख सकता है, उनमें वे रिले भी शामिल हैं जो आपके निजी संदेश ले जाते हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor nonaktif: setiap relay yang kamu hubungi bisa melihat alamat ip-mu, termasuk relay yang membawa pesan pribadimu."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor è disattivato: ogni relay a cui ti colleghi può vedere il tuo indirizzo ip, compresi i relay che trasportano i tuoi messaggi privati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "torはオフです: 接続するすべてのリレーがあなたのipアドレスを見られます。プライベートメッセージを運ぶリレーも同じです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor가 꺼져 있습니다: 연결하는 모든 릴레이가 IP 주소를 볼 수 있고, 비공개 메시지를 운반하는 릴레이도 마찬가지입니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor tidak aktif: setiap relay yang anda sambung boleh melihat alamat ip anda, termasuk relay yang membawa pesan peribadi anda."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor बन्द छ: तिमी जोडिने हरेक रिलेले तिम्रो ip ठेगाना देख्न सक्छ, तिम्रा निजी सन्देश बोक्ने रिले पनि।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor staat uit: elke relay waarmee je verbindt kan je IP-adres zien, ook de relays die je privéberichten vervoeren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor jest wyłączony: każdy relay, z którym się łączysz, widzi twój adres IP, także te przenoszące twoje wiadomości prywatne."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "o Tor está desligado: cada relé a que te ligas consegue ver o teu endereço IP, incluindo os relés que transportam as tuas mensagens privadas."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "o tor está desligado: cada relay a que você se conecta consegue ver seu endereço ip, inclusive os relays que carregam suas mensagens privadas."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor выключен: каждое реле, к которому ты подключаешься, видит твой ip-адрес, включая реле, через которые идут твои приватные сообщения."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor är av: varje relä du ansluter till kan se din IP-adress, även reläerna som bär dina privata meddelanden."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor அணைந்திருக்கிறது: நீங்கள் இணைக்கும் ஒவ்வொரு ரிலேயும் உங்கள் IP முகவரியைப் பார்க்க முடியும், உங்கள் தனிப்பட்ட செய்திகளை எடுத்துச் செல்லும் ரிலேகளும் அதில் அடங்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor ปิดอยู่: ทุกรีเลย์ที่คุณเชื่อมต่อเห็นที่อยู่ IP ของคุณ รวมถึงรีเลย์ที่ส่งข้อความส่วนตัวของคุณ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tor kapalı: bağlandığınız her röle IP adresinizi görebilir, özel mesajlarınızı taşıyan röleler de dahil."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor вимкнено: кожен релей, до якого ти підключаєшся, бачить твою ip-адресу, включно з релеями, що несуть твої приватні повідомлення."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor بند ہے: آپ جس ریلے سے بھی جڑتے ہیں وہ آپ کا IP پتہ دیکھ سکتا ہے، اُن ریلے سمیت جو آپ کے نجی پیغامات لے جاتے ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor đang tắt: mọi relay bạn kết nối đều thấy địa chỉ IP của bạn, kể cả những relay mang tin nhắn riêng của bạn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor 已关闭：你连接的每个中继都能看到你的 IP 地址，包括承载你私密消息的中继。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tor 已關閉：你連線的每個中繼都能看到你的 IP 位址，包括承載你私密訊息的中繼。"
+          }
+        }
+      }
+    },
+    "app_info.settings.tor.subtitle" : {
+      "comment" : "Subtitle for the tor routing toggle in settings, explaining what it covers",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت. الموصى به: تشغيل."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে। সুপারিশ: চালু।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden. empfohlen: an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet. recomendado: activado."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد. توصیه: روشن."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet. inirerekomenda: naka-on."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet. recommandé : activé."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט. מומלץ: פעיל."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है। अनुशंसित: चालू।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet. disarankan: aktif."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet. consigliato: attivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。推奨: オン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다. 권장: 켜기."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet. disarankan: aktif."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ। सिफारिस: अन।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd. aanbevolen: aan."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet. zalecane: włączone."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет. рекомендуем включить."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet. rekommenderas: på."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும். பரிந்துரை: இயக்கவும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต แนะนำให้เปิด"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar. önerilen: açık."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет. рекомендовано ввімкнути."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔ تجویز: آن رکھیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet. khuyến nghị: bật."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。推荐：开启。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。推薦：開啟。"
+          }
+        }
+      }
+    },
+    "content.system.media_delete_refused" : {
+      "comment" : "System message shown in the affected chat when an explicit media delete or /clear was refused and bubbles/files were kept",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "تعذّر حذف بعض الوسائط. جرّب حذف الوسائط الأقدم أولاً." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "কিছু মিডিয়া মুছে ফেলা যায়নি। আগে পুরোনো মিডিয়া মুছে ফেলার চেষ্টা করুন।" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "einige medien konnten nicht gelöscht werden. versuche zuerst, ältere medien zu löschen." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "some media could not be deleted. try deleting older media first." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "no se pudieron eliminar algunos archivos multimedia. prueba a eliminar primero los más antiguos." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "برخی رسانه‌ها حذف نشدند. ابتدا رسانه‌های قدیمی‌تر را حذف کنید." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "hindi ma-delete ang ilang media. subukang i-delete muna ang mas lumang media." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "impossible de supprimer certains médias. essaie d'abord de supprimer les médias plus anciens." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "לא ניתן למחוק חלק מהמדיה. נסה קודם למחוק מדיה ישנה יותר." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "कुछ मीडिया हटाई नहीं जा सकी। पहले पुरानी मीडिया हटाने का प्रयास करें।" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "sebagian media tidak dapat dihapus. coba hapus media yang lebih lama dulu." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "impossibile eliminare alcuni contenuti multimediali. prova prima a eliminare quelli più vecchi." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "一部のメディアを削除できませんでした。先に古いメディアを削除してみてください。" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "일부 미디어를 삭제하지 못했습니다. 먼저 오래된 미디어를 삭제해 보세요." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "sesetengah media tidak dapat dipadamkan. cuba padamkan media yang lebih lama dahulu." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "केही मिडिया मेटाउन सकिएन। पहिले पुराना मिडिया मेटाउने प्रयास गर।" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "sommige media konden niet worden verwijderd. probeer eerst oudere media te verwijderen." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "nie udało się usunąć części multimediów. spróbuj najpierw usunąć starsze multimedia." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "não foi possível eliminar alguns ficheiros multimédia. tenta eliminar primeiro os mais antigos." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "não foi possível excluir algumas mídias. tente excluir primeiro as mídias mais antigas." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "не удалось удалить часть медиафайлов. попробуй сначала удалить более старые." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "vissa medier kunde inte raderas. prova att radera äldre medier först." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "சில ஊடகங்களை நீக்க முடியவில்லை. முதலில் பழைய ஊடகங்களை நீக்க முயற்சிக்கவும்." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ไม่สามารถลบสื่อบางรายการได้ ลองลบสื่อที่เก่ากว่าก่อน" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "bazı medya silinemedi. önce daha eski medyayı silmeyi dene." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "не вдалося видалити частину медіафайлів. спробуй спочатку видалити старіші." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "کچھ میڈیا حذف نہیں ہو سکا۔ پہلے پرانا میڈیا حذف کرنے کی کوشش کریں۔" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "không thể xóa một số phương tiện. hãy thử xóa phương tiện cũ hơn trước." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "部分媒体无法删除。请先尝试删除较早的媒体。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "部分媒體無法刪除。請先嘗試刪除較舊的媒體。" } }
+      }
+    },
+    "notification.action.wave" : {
+      "comment" : "Title of the notification action button that sends a friendly wave back to a nearby person",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لوّح 👋"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "হাত নাড়ুন 👋"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "winken 👋"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wave 👋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saludar 👋"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دست تکان دادن 👋"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kumaway 👋"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saluer 👋"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לנופף 👋"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हाथ हिलाएँ 👋"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "melambai 👋"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saluta 👋"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手を振る 👋"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "손 흔들기 👋"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lambai 👋"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "हात हल्लाउनुहोस् 👋"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zwaaien 👋"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pomachaj 👋"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "acenar 👋"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "acenar 👋"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "помахать 👋"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vinka 👋"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "கை அசைக்கவும் 👋"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "โบกมือ 👋"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "el salla 👋"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "помахати 👋"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہاتھ ہلائیں 👋"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vẫy tay 👋"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "挥手 👋"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "揮手 👋"
+          }
+        }
+      }
+    },
     "#%@" : {
       "comment" : "Non-localizable channel hashtag format used in code",
       "extractionState" : "manual",
+      "shouldTranslate" : false,
       "localizations" : {
         "fa" : {
           "stringUnit" : {
@@ -11,8 +2280,7 @@
             "value" : "#%@"
           }
         }
-      },
-      "shouldTranslate" : false
+      }
     },
     "%@" : {
       "comment" : "Non-localizable symbol used in code",
@@ -383,562 +2651,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活躍使用者 %@ 位"
-          }
-        }
-      }
-    },
-    "Choose an image" : {
-      "comment" : "A label displayed above a button that allows the user to choose an image to send.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختر صورة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "একটি ছবি নির্বাচন করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild auswählen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose an image"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige una imagen"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انتخاب تصویر"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumili ng larawan"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir une image"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "בחר תמונה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एक चित्र चुनें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih gambar"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli un’immagine"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像を選択"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지를 선택하세요"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih imej"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एउटा तस्वीर चयन गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kies een afbeelding"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz obraz"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolher uma imagem"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolha uma imagem"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите изображение"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Välj en bild"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ஒரு படத்தைத் தேர்ந்தெடுக்கவும்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เลือกภาพ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir görüntü seç"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виберіть зображення"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایک تصویر منتخب کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn một hình ảnh"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择图像"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇圖像"
-          }
-        }
-      }
-    },
-    "Images are only available in mesh chats." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الصور متاحة فقط في محادثات الميش."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ছবি শুধু মেশ চ্যাটে উপলব্ধ।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder sind nur im Mesh-Chat verfügbar."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Images are only available in mesh chats."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las imágenes solo están disponibles en los chats de mesh."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصاویر فقط در گفتگوهای مش در دسترس هستند."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ang mga larawan ay available lamang sa mga mesh chat."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les images sont uniquement disponibles dans les discussions mesh."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "תמונות זמינות רק בצ׳אט של mesh."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "चित्र केवल मेश चैट में ही उपलब्ध हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gambar hanya tersedia di obrolan mesh."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le immagini sono disponibili solo nelle chat mesh."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像はメッシュチャットでのみ利用できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지는 메쉬 채팅에서만 사용할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imej hanya tersedia dalam sembang mesh."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "तस्बिरहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afbeeldingen zijn alleen beschikbaar in mesh-chats."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obrazy są dostępne tylko na czatach mesh."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As imagens só estão disponíveis nos chats mesh."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As imagens só estão disponíveis nos chats mesh."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изображения доступны только в mesh-чатах."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder är bara tillgängliga i mesh-chattar."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "படங்கள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รูปภาพใช้งานได้เฉพาะในแชต mesh เท่านั้น"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Görseller yalnızca mesh sohbetlerinde kullanılabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зображення доступні лише в mesh-чатах."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصاویر صرف میش چیٹس میں دستیاب ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hình ảnh chỉ khả dụng trong các cuộc trò chuyện mesh."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片仅可在 mesh 聊天中使用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片僅能在 mesh 聊天中使用。"
-          }
-        }
-      }
-    },
-    "Voice notes are only available in mesh chats." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الملاحظات الصوتية متاحة فقط في محادثات الميش."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভয়েস নোট শুধু মেশ চ্যাটে উপলব্ধ।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachnachrichten sind nur im Mesh-Chat verfügbar."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voice notes are only available in mesh chats."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las notas de voz solo están disponibles en los chats de mesh."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پیام صوتی فقط در گفتگوهای مش در دسترس است."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ang mga voice note ay available lamang sa mga mesh chat."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les notes vocales sont uniquement disponibles dans les discussions mesh."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הערות קוליות זמינות רק בצ׳אט של mesh."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वॉइस नोट्स केवल मेश चैट में ही उपलब्ध हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catatan suara hanya tersedia di obrolan mesh."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le note vocali sono disponibili solo nelle chat mesh."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボイスメモはメッシュチャットでのみ利用できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 메모는 메쉬 채팅에서만 사용할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nota suara hanya tersedia dalam sembang mesh."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भ्वाइस नोटहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spraaknotities zijn alleen beschikbaar in mesh-chats."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notatki głosowe są dostępne tylko na czatach mesh."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As notas de voz só estão disponíveis nos chats mesh."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As mensagens de voz só estão disponíveis nos chats mesh."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосовые сообщения доступны только в mesh-чатах."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Röstanteckningar är bara tillgängliga i mesh-chattar."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "குரல் குறிப்புகள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "บันทึกเสียงใช้งานได้เฉพาะในแชต mesh เท่านั้น"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sesli notlar yalnızca mesh sohbetlerinde kullanılabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосові нотатки доступні лише в mesh-чатах."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وائس نوٹس صرف میش چیٹس میں دستیاب ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghi chú giọng nói chỉ khả dụng trong các cuộc trò chuyện mesh."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音消息仅可在 mesh 聊天中使用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音訊息僅能在 mesh 聊天中使用。"
           }
         }
       }
@@ -13174,750 +14886,6 @@
         }
       }
     },
-    "app_info.settings.language.picker_label" : {
-      "comment" : "Label of the app language picker row in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لغة التطبيق"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "অ্যাপের ভাষা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Sprache"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "app language"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma de la app"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان برنامه"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wika ng app"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "langue de l'app"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שפת האפליקציה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ऐप की भाषा"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bahasa aplikasi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lingua dell'app"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの言語"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱 언어"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bahasa aplikasi"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एपको भाषा"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "app-taal"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "język aplikacji"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma da app"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idioma do app"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "язык приложения"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "appspråk"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "செயலியின் மொழி"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ภาษาของแอป"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "uygulama dili"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "мова застосунку"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ایپ کی زبان"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ngôn ngữ ứng dụng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "應用程式語言"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.restart_note" : {
-      "comment" : "Caption shown after the user picks a different app language; the change takes effect on next launch",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أعد تشغيل bitchat لتطبيق اللغة الجديدة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "নতুন ভাষা প্রয়োগ করতে bitchat পুনরায় চালু করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bitchat neu starten, um die neue Sprache zu übernehmen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "restart bitchat to apply the new language"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicia bitchat para aplicar el nuevo idioma"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "برای اعمال زبان جدید، bitchat را دوباره باز کنید"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "i-restart ang bitchat para mailapat ang bagong wika"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "redémarrez bitchat pour appliquer la nouvelle langue"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "יש להפעיל מחדש את bitchat כדי להחיל את השפה החדשה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नई भाषा लागू करने के लिए bitchat पुनः आरंभ करें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mulai ulang bitchat untuk menerapkan bahasa baru"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "riavvia bitchat per applicare la nuova lingua"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい言語を適用するには bitchat を再起動してください"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새 언어를 적용하려면 bitchat을 다시 시작하세요"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mulakan semula bitchat untuk menggunakan bahasa baharu"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नयाँ भाषा लागू गर्न bitchat पुनः सुरु गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "herstart bitchat om de nieuwe taal toe te passen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "uruchom bitchat ponownie, aby zastosować nowy język"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicie o bitchat para aplicar o novo idioma"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reinicie o bitchat para aplicar o novo idioma"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "перезапустите bitchat, чтобы применить новый язык"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "starta om bitchat för att använda det nya språket"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "புதிய மொழியைப் பயன்படுத்த bitchat-ஐ மீண்டும் தொடங்கவும்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีสตาร์ท bitchat เพื่อใช้ภาษาใหม่"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "yeni dili uygulamak için bitchat'i yeniden başlatın"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "перезапустіть bitchat, щоб застосувати нову мову"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نئی زبان لاگو کرنے کے لیے bitchat دوبارہ شروع کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "khởi động lại bitchat để áp dụng ngôn ngữ mới"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重启 bitchat 以应用新语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啟動 bitchat 以套用新語言"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.system" : {
-      "comment" : "Menu option that clears the in-app language override so the app follows the device language",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لغة النظام"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "সিস্টেম ডিফল্ট"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemstandard"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "system default"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predeterminado del sistema"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "پیش‌فرض سیستم"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "default ng system"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "réglage système"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ברירת המחדל של המערכת"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सिस्टम डिफ़ॉल्ट"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bawaan sistem"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predefinita di sistema"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムのデフォルト"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 기본값"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lalai sistem"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "प्रणाली पूर्वनिर्धारित"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "systeemstandaard"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "domyślny systemowy"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "predefinição do sistema"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "padrão do sistema"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "системный по умолчанию"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "systemstandard"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "கணினி இயல்புநிலை"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ค่าเริ่มต้นของระบบ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sistem varsayılanı"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "системна за замовчуванням"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سسٹم ڈیفالٹ"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mặc định hệ thống"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统默认"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統預設"
-          }
-        }
-      }
-    },
-    "app_info.settings.language.title" : {
-      "comment" : "Section header (uppercase) for the app language picker in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اللغة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ভাষা"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SPRACHE"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LANGUAGE"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WIKA"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LANGUE"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שפה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषा"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BAHASA"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LINGUA"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BAHASA"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषा"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TAAL"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JĘZYK"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IDIOMA"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ЯЗЫК"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SPRÅK"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "மொழி"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ภาษา"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DİL"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "МОВА"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "زبان"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NGÔN NGỮ"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語言"
-          }
-        }
-      }
-    },
     "app_info.settings.privacy.title" : {
       "comment" : "Section header (uppercase) for privacy settings such as hiding notification previews",
       "extractionState" : "manual",
@@ -14100,2052 +15068,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱私"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.add" : {
-      "comment" : "Button that adds the typed relay address to the list",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "যোগ করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hinzufügen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "add"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "añadir"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "افزودن"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "idagdag"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ajouter"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הוסף"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जोड़ें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tambah"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "aggiungi"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tambah"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "थप"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "toevoegen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dodaj"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "adicionar"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "adicionar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "добавить"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lägg till"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "சேர்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เพิ่ม"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ekle"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "додати"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شامل کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "thêm"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加入"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.built_in" : {
-      "comment" : "Label marking a relay as one of the built-in relays, which cannot be removed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مدمج"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "বিল্ট-ইন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eingebaut"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "built in"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "داخلی"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "built in"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "intégré"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "מובנה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अंतर्निर्मित"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bawaan"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "組み込み"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기본 제공"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "terbina dalam"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पूर्वनिर्मित"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ingebouwd"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wbudowany"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "integrado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "встроенное"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "inbyggt"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "உள்ளமைந்தது"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "มาพร้อมแอป"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "yerleşik"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "вбудований"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "بلٹ اِن"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tích hợp"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "内置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "內建"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.duplicate" : {
-      "comment" : "Error shown when the typed relay address is already in the list",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذا المرحّل موجود في القائمة بالفعل."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এই রিলে আগেই তালিকায় আছে।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dieses relay steht schon in der liste."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "that relay is already in the list."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ese relay ya está en la lista."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این رله از قبل در فهرست است."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nasa listahan na ang relay na iyon."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ce relais est déjà dans la liste."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הממסר הזה כבר ברשימה."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वह रिले पहले से सूची में है।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay itu sudah ada di daftar."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quel relay è già nell'elenco."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "そのリレーはすでにリストにあります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그 릴레이는 이미 목록에 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay itu sudah ada dalam senarai."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "त्यो रिले पहिले नै सूचीमा छ।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "die relay staat al in de lijst."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ten relay już jest na liście."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "esse relé já está na lista."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "esse relay já está na lista."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "это реле уже в списке."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "det reläet finns redan i listan."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "அந்த ரிலே ஏற்கெனவே பட்டியலில் உள்ளது."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเลย์นี้อยู่ในรายการแล้ว"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bu röle listede zaten var."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "цей релей уже в списку."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ ریلے پہلے ہی فہرست میں ہے۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay đó đã có trong danh sách."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该中继已在列表中。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該中繼已在清單中。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.limit" : {
-      "comment" : "Error shown when the relay list is already at its maximum size; %d is that maximum",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يمكنك إضافة %d مرحّلات كحد أقصى."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "আপনি সর্বোচ্চ %d টি রিলে যোগ করতে পারেন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "du kannst bis zu %d relays hinzufügen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "you can add up to %d relays."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "puedes añadir hasta %d relays."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "می‌توانید تا %d رله اضافه کنید."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hanggang %d relay lang ang maaari mong idagdag."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tu peux ajouter jusqu'à %d relais."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "אפשר להוסיף עד %d ממסרים."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आप %d रिले तक जोड़ सकते हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kamu bisa menambahkan hingga %d relay."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "puoi aggiungere fino a %d relay."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーは最大%d件まで追加できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이는 최대 %d개까지 추가할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "anda boleh menambah sehingga %d relay."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "तिमी %d रिलेसम्म थप्न सक्छौ।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "je kunt tot %d relays toevoegen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "możesz dodać maksymalnie %d relay."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "podes adicionar até %d relés."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "você pode adicionar até %d relays."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "можно добавить до %d реле."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "du kan lägga till upp till %d reläer."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d ரிலேகள் வரை சேர்க்கலாம்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เพิ่มรีเลย์ได้สูงสุด %d รายการ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "en fazla %d röle ekleyebilirsiniz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "можна додати до %d релеїв."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "آپ %d ریلے تک شامل کر سکتے ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bạn có thể thêm tối đa %d relay."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最多可以添加 %d 个中继。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最多可以加入 %d 個中繼。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.error.malformed" : {
-      "comment" : "Error shown when a typed relay address cannot be parsed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يبدو هذا عنوان مرحّل. جرّب wss://host."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "এটি রিলের ঠিকানার মতো মনে হচ্ছে না। wss://host দিয়ে চেষ্টা করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "das sieht nicht wie eine relay-adresse aus. versuch wss://host."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "that doesn't look like a relay address. try wss://host."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eso no parece una dirección de relay. prueba wss://host."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "این شبیه نشانی رله نیست. wss://host را امتحان کنید."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mukhang hindi ito address ng relay. subukan ang wss://host."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ça ne ressemble pas à une adresse de relais. essaie wss://host."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "זה לא נראה כמו כתובת של ממסר. נסה wss://host."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह रिले का पता नहीं लगता। wss://host आज़माएँ।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "itu tidak tampak seperti alamat relay. coba wss://host."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non sembra l'indirizzo di un relay. prova wss://host."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーのアドレスではないようです。wss://host を試してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이 주소가 아닌 것 같습니다. wss://host 형식으로 시도하세요."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "itu tidak kelihatan seperti alamat relay. cuba wss://host."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यो रिलेको ठेगाना जस्तो देखिँदैन। wss://host प्रयास गर।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dat lijkt niet op een relay-adres. probeer wss://host."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "to nie wygląda na adres relay. spróbuj wss://host."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "isso não parece um endereço de relé. tenta wss://host."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "isso não parece um endereço de relay. tente wss://host."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "это не похоже на адрес реле. попробуй wss://host."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "det ser inte ut som en reläadress. prova wss://host."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "இது ரிலே முகவரி போல் தெரியவில்லை. wss://host முயற்சிக்கவும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ดูเหมือนไม่ใช่ที่อยู่รีเลย์ ลอง wss://host"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bu bir röle adresine benzemiyor. wss://host deneyin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "це не схоже на адресу релея. спробуй wss://host."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "یہ ریلے کا پتہ نہیں لگتا۔ wss://host آزمائیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "đó không giống địa chỉ relay. hãy thử wss://host."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这看起来不像中继地址。试试 wss://host。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這看起來不像中繼位址。試試 wss://host。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.placeholder" : {
-      "comment" : "Placeholder text in the field for adding a relay address",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wss://relay.example.com"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.remove" : {
-      "comment" : "Accessibility label for the button that removes an added relay",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة المرحّل"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "রিলে সরান"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay entfernen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remove relay"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quitar relay"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حذف رله"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "alisin ang relay"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "retirer le relais"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "הסר ממסר"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रिले हटाएँ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "hapus relay"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "rimuovi relay"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リレーを削除"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "릴레이 제거"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "buang relay"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रिले हटाउ"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay verwijderen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "usuń relay"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remover relé"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "remover relay"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "удалить реле"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ta bort relä"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ரிலேயை நீக்கு"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ลบรีเลย์"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "röleyi kaldır"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "видалити релей"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ریلے ہٹائیں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "xóa relay"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除中继"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除中繼"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.subtitle" : {
-      "comment" : "Subtitle explaining what the relay list is for and why someone would add a relay",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عندما لا تصل شبكة mesh إلى شخص، تنتقل الرسائل الخاصة عبر هذه المرحّلات. المرحّلات المدمجة عناوين معروفة يمكن لمرشّح الشبكة حجبها — لذا يمكنك إضافة مرحّلاتك الخاصة، بما في ذلك عناوين .onion."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "মেশ কারও কাছে পৌঁছাতে না পারলে ব্যক্তিগত বার্তা এই রিলেগুলোর মধ্য দিয়ে যায়। বিল্ট-ইন রিলেগুলো সুপরিচিত ঠিকানা, যা নেটওয়ার্ক ফিল্টার আটকে দিতে পারে — তাই আপনি নিজের রিলে যোগ করতে পারেন, .onion ঠিকানাও।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wenn das mesh jemanden nicht erreicht, laufen private nachrichten über diese relays. die eingebauten sind bekannte adressen, die ein netzwerkfilter blockieren kann — du kannst also eigene hinzufügen, auch .onion-adressen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "when the mesh can't reach someone, private messages travel through these relays. the built-in ones are well-known addresses that a network filter can block, so you can add your own — including .onion addresses."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "cuando el mesh no llega a alguien, los mensajes privados viajan por estos relays. los integrados son direcciones muy conocidas que un filtro de red puede bloquear, así que puedes añadir los tuyos — incluidas direcciones .onion."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وقتی مش به کسی نمی‌رسد، پیام‌های خصوصی از این رله‌ها می‌گذرند. رله‌های داخلی نشانی‌های شناخته‌شده‌ای هستند که یک صافی شبکه می‌تواند مسدودشان کند — پس می‌توانید رله‌های خودتان را اضافه کنید، از جمله نشانی‌های .onion."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kapag hindi maabot ng mesh ang isang tao, dumadaan ang mga pribadong mensahe sa mga relay na ito. ang mga built-in ay kilalang-kilalang address na kayang harangin ng filter ng network — kaya maaari kang magdagdag ng sarili mo, kasama ang mga .onion address."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quand le mesh ne joint pas quelqu'un, les messages privés passent par ces relais. ceux intégrés sont des adresses bien connues qu'un filtre réseau peut bloquer — tu peux donc ajouter les tiens, y compris des adresses .onion."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "כשה-mesh לא מגיע למישהו, הודעות פרטיות עוברות דרך הממסרים האלה. הממסרים המובנים הם כתובות מוכרות שמסנן רשת יכול לחסום — אפשר להוסיף ממסרים משלך, כולל כתובות .onion."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जब मेश किसी तक नहीं पहुँच पाता, तब निजी संदेश इन रिले से होकर जाते हैं। अंतर्निर्मित रिले जाने-पहचाने पते हैं जिन्हें नेटवर्क फ़िल्टर रोक सकता है — इसलिए आप अपने रिले जोड़ सकते हैं, .onion पते भी।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saat mesh tidak bisa menjangkau seseorang, pesan pribadi lewat relay ini. relay bawaan adalah alamat yang sudah dikenal luas dan bisa diblokir filter jaringan — jadi kamu bisa menambahkan relay sendiri, termasuk alamat .onion."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando la mesh non raggiunge qualcuno, i messaggi privati passano da questi relay. quelli integrati sono indirizzi molto noti che un filtro di rete può bloccare — puoi quindi aggiungere i tuoi, anche indirizzi .onion."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "meshで相手に届かないとき、プライベートメッセージはこれらのリレーを通ります。組み込みのリレーはよく知られたアドレスで、ネットワークのフィルターにブロックされることがあります — 自分のリレー、.onionアドレスも追加できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh로 상대에게 닿지 않으면 비공개 메시지는 이 릴레이를 거칩니다. 기본 릴레이는 널리 알려진 주소여서 네트워크 필터가 차단할 수 있습니다 — 그래서 .onion 주소를 포함해 직접 릴레이를 추가할 수 있습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "apabila mesh tidak dapat mencapai seseorang, pesan peribadi bergerak melalui relay ini. relay terbina dalam ialah alamat yang terkenal dan boleh dihalang oleh penapis rangkaian — jadi anda boleh menambah relay sendiri, termasuk alamat .onion."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh कसैसम्म पुग्न सक्दैन भने निजी सन्देश यी रिले मार्फत जान्छन्। पूर्वनिर्मित रिले सबैलाई थाहा भएका ठेगाना हुन्, जसलाई नेटवर्क फिल्टरले रोक्न सक्छ — त्यसैले तिमी आफ्नै रिले थप्न सक्छौ, .onion ठेगाना पनि।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "als de mesh iemand niet bereikt, gaan privéberichten via deze relays. de ingebouwde relays zijn bekende adressen die een netwerkfilter kan blokkeren — je kunt dus je eigen relays toevoegen, ook .onion-adressen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "gdy mesh nie dosięga kogoś, wiadomości prywatne idą przez te relay. wbudowane to powszechnie znane adresy, które filtr sieciowy może zablokować — możesz więc dodać własne, także adresy .onion."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando a mesh não chega a alguém, as mensagens privadas seguem por estes relés. os integrados são endereços bem conhecidos que um filtro de rede pode bloquear — por isso podes acrescentar os teus, incluindo endereços .onion."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "quando o mesh não alcança alguém, as mensagens privadas passam por estes relays. os integrados são endereços conhecidos que um filtro de rede pode bloquear — então você pode adicionar os seus, inclusive endereços .onion."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "когда mesh не достаёт до человека, приватные сообщения идут через эти реле. встроенные — это широко известные адреса, которые может заблокировать сетевой фильтр, поэтому можно добавить свои, в том числе .onion-адреса."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "när mesh inte når fram till någon går privata meddelanden via dessa reläer. de inbyggda är välkända adresser som ett nätverksfilter kan blockera — du kan därför lägga till egna, även .onion-adresser."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh ஒருவரை எட்ட முடியாதபோது, தனிப்பட்ட செய்திகள் இந்த ரிலேகள் வழியாகச் செல்கின்றன. உள்ளமைந்த ரிலேகள் நன்கு அறியப்பட்ட முகவரிகள், அவற்றை நெட்வொர்க் வடிகட்டி தடுக்க முடியும் — எனவே .onion முகவரிகள் உட்பட உங்கள் சொந்த ரிலேகளைச் சேர்க்கலாம்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เมื่อ mesh ไปไม่ถึงใคร ข้อความส่วนตัวจะเดินทางผ่านรีเลย์เหล่านี้ รีเลย์ที่มาพร้อมแอปเป็นที่อยู่ที่รู้จักกันดีและตัวกรองเครือข่ายปิดกั้นได้ — คุณจึงเพิ่มรีเลย์ของตัวเองได้ รวมถึงที่อยู่ .onion"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mesh birine ulaşamadığında özel mesajlar bu rölelerden geçer. yerleşik röleler herkesin bildiği adreslerdir ve bir ağ filtresi bunları engelleyebilir — bu yüzden .onion adresleri de dahil kendi rölelerinizi ekleyebilirsiniz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "коли mesh не дотягується до людини, приватні повідомлення йдуть через ці релеї. вбудовані — це добре відомі адреси, які може заблокувати мережевий фільтр, тож можна додати власні, зокрема .onion-адреси."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جب mesh کسی تک نہ پہنچ سکے تو نجی پیغامات ان ریلے سے گزرتے ہیں۔ بلٹ اِن ریلے مشہور پتے ہیں جنہیں نیٹ ورک فلٹر روک سکتا ہے — اس لیے آپ اپنے ریلے شامل کر سکتے ہیں، .onion پتے بھی۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "khi mesh không tới được ai đó, tin nhắn riêng đi qua các relay này. các relay tích hợp là những địa chỉ ai cũng biết nên bộ lọc mạng có thể chặn — vì vậy bạn có thể thêm relay của mình, kể cả địa chỉ .onion."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 mesh 无法触达某人时，私密消息会经这些中继传递。内置中继是众所周知的地址，网络过滤可以封锁它们 — 所以你可以添加自己的中继，包括 .onion 地址。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "當 mesh 無法觸及某人時，私密訊息會經這些中繼傳遞。內建中繼是眾所周知的位址，網路過濾可以封鎖它們 — 所以你可以加入自己的中繼，包括 .onion 位址。"
-          }
-        }
-      }
-    },
-    "app_info.settings.relays.title" : {
-      "comment" : "Title of the relay list editor in settings",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مرحّلات الرسائل الخاصة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ব্যক্তিগত বার্তার রিলে"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays für private nachrichten"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "private message relays"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays para mensajes privados"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رله‌های پیام خصوصی"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mga relay para sa pribadong mensahe"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relais pour messages privés"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ממסרים להודעות פרטיות"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजी संदेश रिले"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay pesan pribadi"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay per messaggi privati"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プライベートメッセージのリレー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "비공개 메시지 릴레이"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay pesan peribadi"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "निजी सन्देशका रिले"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays voor privéberichten"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay dla wiadomości prywatnych"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relés para mensagens privadas"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relays para mensagens privadas"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "реле для приватных сообщений"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reläer för privata meddelanden"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "தனிப்பட்ட செய்திகளுக்கான ரிலேகள்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเลย์สำหรับข้อความส่วนตัว"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "özel mesaj röleleri"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "релеї для приватних повідомлень"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نجی پیغامات کے ریلے"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "relay cho tin nhắn riêng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私密消息中继"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "私密訊息中繼"
-          }
-        }
-      }
-    },
-    "app_info.settings.tor.off_warning" : {
-      "comment" : "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor متوقف: كل مرحّل تتصل به يمكنه رؤية عنوان IP الخاص بك، بما في ذلك المرحّلات التي تحمل رسائلك الخاصة."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor বন্ধ: আপনি যে রিলেতেই সংযুক্ত হন সেটি আপনার IP ঠিকানা দেখতে পায়, আপনার ব্যক্তিগত বার্তা বহনকারী রিলেগুলোও।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor ist aus: jedes relay, mit dem du dich verbindest, kann deine ip-adresse sehen, auch die relays, die deine privaten nachrichten tragen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor está desactivado: cada relay al que te conectas puede ver tu dirección IP, incluidos los relays que llevan tus mensajes privados."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor خاموش است: هر رله‌ای که به آن وصل می‌شوید می‌تواند نشانی IP شما را ببیند، از جمله رله‌هایی که پیام‌های خصوصی شما را می‌برند."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "naka-off ang tor: nakikita ng bawat relay na kinokonekta mo ang iyong IP address, kasama ang mga relay na nagdadala ng iyong mga pribadong mensahe."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor est désactivé : chaque relais auquel tu te connectes voit ton adresse ip, y compris les relais qui transportent tes messages privés."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor כבוי: כל ממסר שאתה מתחבר אליו רואה את כתובת ה-ip שלך, כולל ממסרים שנושאים את ההודעות הפרטיות שלך."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor बंद है: आप जिस भी रिले से जुड़ते हैं वह आपका IP पता देख सकता है, उनमें वे रिले भी शामिल हैं जो आपके निजी संदेश ले जाते हैं।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor nonaktif: setiap relay yang kamu hubungi bisa melihat alamat ip-mu, termasuk relay yang membawa pesan pribadimu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor è disattivato: ogni relay a cui ti colleghi può vedere il tuo indirizzo ip, compresi i relay che trasportano i tuoi messaggi privati."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "torはオフです: 接続するすべてのリレーがあなたのipアドレスを見られます。プライベートメッセージを運ぶリレーも同じです。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor가 꺼져 있습니다: 연결하는 모든 릴레이가 IP 주소를 볼 수 있고, 비공개 메시지를 운반하는 릴레이도 마찬가지입니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor tidak aktif: setiap relay yang anda sambung boleh melihat alamat ip anda, termasuk relay yang membawa pesan peribadi anda."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor बन्द छ: तिमी जोडिने हरेक रिलेले तिम्रो ip ठेगाना देख्न सक्छ, तिम्रा निजी सन्देश बोक्ने रिले पनि।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor staat uit: elke relay waarmee je verbindt kan je IP-adres zien, ook de relays die je privéberichten vervoeren."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor jest wyłączony: każdy relay, z którym się łączysz, widzi twój adres IP, także te przenoszące twoje wiadomości prywatne."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "o Tor está desligado: cada relé a que te ligas consegue ver o teu endereço IP, incluindo os relés que transportam as tuas mensagens privadas."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "o tor está desligado: cada relay a que você se conecta consegue ver seu endereço ip, inclusive os relays que carregam suas mensagens privadas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor выключен: каждое реле, к которому ты подключаешься, видит твой ip-адрес, включая реле, через которые идут твои приватные сообщения."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor är av: varje relä du ansluter till kan se din IP-adress, även reläerna som bär dina privata meddelanden."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor அணைந்திருக்கிறது: நீங்கள் இணைக்கும் ஒவ்வொரு ரிலேயும் உங்கள் IP முகவரியைப் பார்க்க முடியும், உங்கள் தனிப்பட்ட செய்திகளை எடுத்துச் செல்லும் ரிலேகளும் அதில் அடங்கும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor ปิดอยู่: ทุกรีเลย์ที่คุณเชื่อมต่อเห็นที่อยู่ IP ของคุณ รวมถึงรีเลย์ที่ส่งข้อความส่วนตัวของคุณ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tor kapalı: bağlandığınız her röle IP adresinizi görebilir, özel mesajlarınızı taşıyan röleler de dahil."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor вимкнено: кожен релей, до якого ти підключаєшся, бачить твою ip-адресу, включно з релеями, що несуть твої приватні повідомлення."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor بند ہے: آپ جس ریلے سے بھی جڑتے ہیں وہ آپ کا IP پتہ دیکھ سکتا ہے، اُن ریلے سمیت جو آپ کے نجی پیغامات لے جاتے ہیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor đang tắt: mọi relay bạn kết nối đều thấy địa chỉ IP của bạn, kể cả những relay mang tin nhắn riêng của bạn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor 已关闭：你连接的每个中继都能看到你的 IP 地址，包括承载你私密消息的中继。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tor 已關閉：你連線的每個中繼都能看到你的 IP 位址，包括承載你私密訊息的中繼。"
-          }
-        }
-      }
-    },
-    "app_info.settings.tor.subtitle" : {
-      "comment" : "Subtitle for the tor routing toggle in settings, explaining what it covers",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت. الموصى به: تشغيل."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে। সুপারিশ: চালু।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden. empfohlen: an."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet. recomendado: activado."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد. توصیه: روشن."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet. inirerekomenda: naka-on."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet. recommandé : activé."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט. מומלץ: פעיל."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है। अनुशंसित: चालू।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet. disarankan: aktif."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet. consigliato: attivo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。推奨: オン"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다. 권장: 켜기."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet. disarankan: aktif."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ। सिफारिस: अन।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd. aanbevolen: aan."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet. zalecane: włączone."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет. рекомендуем включить."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet. rekommenderas: på."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும். பரிந்துரை: இயக்கவும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต แนะนำให้เปิด"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar. önerilen: açık."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет. рекомендовано ввімкнути."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔ تجویز: آن رکھیں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet. khuyến nghị: bật."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。推荐：开启。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。推薦：開啟。"
           }
         }
       }
@@ -17813,6 +16735,192 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "橋的另一端"
+          }
+        }
+      }
+    },
+    "Choose an image" : {
+      "comment" : "A label displayed above a button that allows the user to choose an image to send.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر صورة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "একটি ছবি নির্বাচন করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild auswählen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose an image"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige una imagen"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتخاب تصویر"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumili ng larawan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir une image"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "בחר תמונה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक चित्र चुनें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih gambar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli un’immagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지를 선택하세요"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih imej"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एउटा तस्वीर चयन गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kies een afbeelding"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz obraz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolher uma imagem"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolha uma imagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите изображение"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj en bild"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ஒரு படத்தைத் தேர்ந்தெடுக்கவும்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เลือกภาพ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir görüntü seç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть зображення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایک تصویر منتخب کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn một hình ảnh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择图像"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇圖像"
           }
         }
       }
@@ -23187,192 +22295,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 則新公告"
-          }
-        }
-      }
-    },
-    "content.accessibility.open_sticker_picker" : {
-      "comment" : "Accessibility label for the sticker picker button in the composer",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open the sticker picker"
           }
         }
       }
@@ -34344,192 +33266,6 @@
         }
       }
     },
-    "content.delivery.reason.not_delivered" : {
-      "comment" : "Failure reason shown when the router gave up delivering a message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "لم يُسلَّم"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "পৌঁছায়নি"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "nicht zugestellt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "not delivered"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no entregado"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحویل نشد"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "hindi naihatid"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "non livré"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "לא נמסר"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "डिलीवर नहीं हुआ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "tidak terkirim"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "non consegnato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未配信"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "전송되지 않음"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "tidak dihantar"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "डेलिभर भएन"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "niet bezorgd"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "nie dostarczono"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não entregue"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não entregue"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не доставлено"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "inte levererat"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "வழங்கப்படவில்லை"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ยังไม่ได้ส่ง"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "teslim edilmedi"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не доставлено"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "نہیں پہنچا"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "chưa gửi được"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未送达"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未送達"
-          }
-        }
-      }
-    },
     "content.delivery.reason.private_media_capability_unresolved" : {
       "comment" : "Failure reason shown when the peer's support for encrypted media could not be confirmed before sending",
       "extractionState" : "manual",
@@ -34898,6 +33634,192 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無法確認送達"
+          }
+        }
+      }
+    },
+    "content.delivery.reason.not_delivered" : {
+      "comment" : "Failure reason shown when the router gave up delivering a message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لم يُسلَّم"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "পৌঁছায়নি"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "nicht zugestellt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "not delivered"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no entregado"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحویل نشد"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "hindi naihatid"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "non livré"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא נמסר"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "डिलीवर नहीं हुआ"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tidak terkirim"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "non consegnato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未配信"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전송되지 않음"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tidak dihantar"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "डेलिभर भएन"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "niet bezorgd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "nie dostarczono"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não entregue"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "não entregue"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не доставлено"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "inte levererat"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "வழங்கப்படவில்லை"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ยังไม่ได้ส่ง"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "teslim edilmedi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "не доставлено"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نہیں پہنچا"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chưa gửi được"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未送达"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未送達"
           }
         }
       }
@@ -43071,192 +41993,6 @@
         }
       }
     },
-    "content.system.media_delete_refused" : {
-      "comment" : "System message shown in the affected chat when an explicit media delete or /clear was refused and bubbles/files were kept",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "تعذّر حذف بعض الوسائط. جرّب حذف الوسائط الأقدم أولاً."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "কিছু মিডিয়া মুছে ফেলা যায়নি। আগে পুরোনো মিডিয়া মুছে ফেলার চেষ্টা করুন।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "einige medien konnten nicht gelöscht werden. versuche zuerst, ältere medien zu löschen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "some media could not be deleted. try deleting older media first."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "no se pudieron eliminar algunos archivos multimedia. prueba a eliminar primero los más antiguos."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "برخی رسانه‌ها حذف نشدند. ابتدا رسانه‌های قدیمی‌تر را حذف کنید."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "hindi ma-delete ang ilang media. subukang i-delete muna ang mas lumang media."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "impossible de supprimer certains médias. essaie d'abord de supprimer les médias plus anciens."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "לא ניתן למחוק חלק מהמדיה. נסה קודם למחוק מדיה ישנה יותר."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "कुछ मीडिया हटाई नहीं जा सकी। पहले पुरानी मीडिया हटाने का प्रयास करें।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "sebagian media tidak dapat dihapus. coba hapus media yang lebih lama dulu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "impossibile eliminare alcuni contenuti multimediali. prova prima a eliminare quelli più vecchi."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "一部のメディアを削除できませんでした。先に古いメディアを削除してみてください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "일부 미디어를 삭제하지 못했습니다. 먼저 오래된 미디어를 삭제해 보세요."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "sesetengah media tidak dapat dipadamkan. cuba padamkan media yang lebih lama dahulu."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "केही मिडिया मेटाउन सकिएन। पहिले पुराना मिडिया मेटाउने प्रयास गर।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "sommige media konden niet worden verwijderd. probeer eerst oudere media te verwijderen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "nie udało się usunąć części multimediów. spróbuj najpierw usunąć starsze multimedia."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não foi possível eliminar alguns ficheiros multimédia. tenta eliminar primeiro os mais antigos."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "não foi possível excluir algumas mídias. tente excluir primeiro as mídias mais antigas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не удалось удалить часть медиафайлов. попробуй сначала удалить более старые."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "vissa medier kunde inte raderas. prova att radera äldre medier först."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "சில ஊடகங்களை நீக்க முடியவில்லை. முதலில் பழைய ஊடகங்களை நீக்க முயற்சிக்கவும்."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ไม่สามารถลบสื่อบางรายการได้ ลองลบสื่อที่เก่ากว่าก่อน"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "bazı medya silinemedi. önce daha eski medyayı silmeyi dene."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "не вдалося видалити частину медіафайлів. спробуй спочатку видалити старіші."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "کچھ میڈیا حذف نہیں ہو سکا۔ پہلے پرانا میڈیا حذف کرنے کی کوشش کریں۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "không thể xóa một số phương tiện. hãy thử xóa phương tiện cũ hơn trước."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "部分媒体无法删除。请先尝试删除较早的媒体。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "部分媒體無法刪除。請先嘗試刪除較舊的媒體。"
-          }
-        }
-      }
-    },
     "encryption.accessibility.establishing" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -50204,6 +48940,191 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "建立者"
+          }
+        }
+      }
+    },
+    "Images are only available in mesh chats." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الصور متاحة فقط في محادثات الميش."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ছবি শুধু মেশ চ্যাটে উপলব্ধ।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilder sind nur im Mesh-Chat verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Images are only available in mesh chats."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las imágenes solo están disponibles en los chats de mesh."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصاویر فقط در گفتگوهای مش در دسترس هستند."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ang mga larawan ay available lamang sa mga mesh chat."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les images sont uniquement disponibles dans les discussions mesh."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "תמונות זמינות רק בצ׳אט של mesh."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "चित्र केवल मेश चैट में ही उपलब्ध हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar hanya tersedia di obrolan mesh."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le immagini sono disponibili solo nelle chat mesh."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像はメッシュチャットでのみ利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지는 메쉬 채팅에서만 사용할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imej hanya tersedia dalam sembang mesh."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "तस्बिरहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afbeeldingen zijn alleen beschikbaar in mesh-chats."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obrazy są dostępne tylko na czatach mesh."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As imagens só estão disponíveis nos chats mesh."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As imagens só estão disponíveis nos chats mesh."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображения доступны только в mesh-чатах."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilder är bara tillgängliga i mesh-chattar."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "படங்கள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รูปภาพใช้งานได้เฉพาะในแชต mesh เท่านั้น"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görseller yalnızca mesh sohbetlerinde kullanılabilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зображення доступні лише в mesh-чатах."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصاویر صرف میش چیٹس میں دستیاب ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hình ảnh chỉ khả dụng trong các cuộc trò chuyện mesh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片仅可在 mesh 聊天中使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片僅能在 mesh 聊天中使用。"
           }
         }
       }
@@ -64345,192 +63266,6 @@
         }
       }
     },
-    "notification.action.wave" : {
-      "comment" : "Title of the notification action button that sends a friendly wave back to a nearby person",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لوّح 👋"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "হাত নাড়ুন 👋"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "winken 👋"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "wave 👋"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saludar 👋"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دست تکان دادن 👋"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kumaway 👋"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saluer 👋"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "לנופף 👋"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हाथ हिलाएँ 👋"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "melambai 👋"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saluta 👋"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手を振る 👋"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "손 흔들기 👋"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lambai 👋"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हात हल्लाउनुहोस् 👋"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "zwaaien 👋"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "pomachaj 👋"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "acenar 👋"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "acenar 👋"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "помахать 👋"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vinka 👋"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "கை அசைக்கவும் 👋"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "โบกมือ 👋"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "el salla 👋"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "помахати 👋"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ہاتھ ہلائیں 👋"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vẫy tay 👋"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "挥手 👋"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "揮手 👋"
-          }
-        }
-      }
-    },
     "notification.redacted.body" : {
       "comment" : "Lock-screen notification body shown in place of the message text when message previews are hidden",
       "extractionState" : "manual",
@@ -65641,2796 +64376,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存"
-          }
-        }
-      }
-    },
-    "share_import.review.message" : {
-      "comment" : "Explains that shared content replaces the named destination's composer and is not sent automatically",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "هل تريد استبدال مسودة %@ بهذا المحتوى؟ لن يتم إرسال أي شيء تلقائيًا."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@-এর খসড়াটি এই কনটেন্ট দিয়ে বদলাবেন? কিছুই স্বয়ংক্রিয়ভাবে পাঠানো হবে না।"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Entwurf für %@ durch diesen Inhalt ersetzen? Es wird nichts automatisch gesendet."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Replace the draft for %@ with this content? Nothing will be sent automatically."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "¿Reemplazar el borrador de %@ con este contenido? No se enviará nada automáticamente."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "پیش‌نویس %@ با این محتوا جایگزین شود؟ چیزی به‌طور خودکار ارسال نمی‌شود."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Palitan ng content na ito ang draft para sa %@? Walang awtomatikong ipapadala."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Remplacer le brouillon pour %@ par ce contenu ? Rien ne sera envoyé automatiquement."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "להחליף את הטיוטה עבור %@ בתוכן הזה? שום דבר לא יישלח אוטומטית."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ का ड्राफ़्ट इस सामग्री से बदलें? कुछ भी अपने आप नहीं भेजा जाएगा।"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ganti draf untuk %@ dengan konten ini? Tidak ada yang akan dikirim otomatis."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sostituire la bozza per %@ con questo contenuto? Nulla verrà inviato automaticamente."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ の下書きをこの内容で置き換えますか？自動的には送信されません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@의 초안을 이 콘텐츠로 바꾸시겠습니까? 자동으로 전송되지 않습니다."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gantikan draf untuk %@ dengan kandungan ini? Tiada apa-apa akan dihantar secara automatik."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ को मस्यौदा यो सामग्रीले बदल्ने? केही पनि स्वचालित रूपमा पठाइने छैन।"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Concept voor %@ vervangen door deze inhoud? Er wordt niets automatisch verzonden."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Zastąpić szkic dla %@ tą treścią? Nic nie zostanie wysłane automatycznie."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Substituir o rascunho para %@ por este conteúdo? Nada será enviado automaticamente."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Substituir o rascunho de %@ por este conteúdo? Nada será enviado automaticamente."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Заменить черновик для %@ этим содержимым? Ничего не будет отправлено автоматически."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ersätta utkastet för %@ med detta innehåll? Inget skickas automatiskt."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ க்கான வரைவைக் இந்த உள்ளடக்கத்தால் மாற்றவா? எதுவும் தானாக அனுப்பப்படாது."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "แทนที่ฉบับร่างสำหรับ %@ ด้วยเนื้อหานี้หรือไม่? จะไม่มีการส่งอัตโนมัติ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ taslağı bu içerikle değiştirilsin mi? Hiçbir şey otomatik olarak gönderilmez."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Замінити чернетку для %@ цим вмістом? Нічого не буде надіслано автоматично."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%@ کا مسودہ اس مواد سے بدلیں؟ کچھ بھی خودکار طور پر نہیں بھیجا جائے گا۔"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Thay bản nháp cho %@ bằng nội dung này? Không có gì được tự động gửi."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "要用此内容替换 %@ 的草稿吗？内容不会自动发送。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "要用此內容取代 %@ 的草稿嗎？內容不會自動傳送。"
-          }
-        }
-      }
-    },
-    "share_import.review.title" : {
-      "comment" : "Title for reviewing content received from the share extension",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "مراجعة المحتوى المشترك"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "শেয়ার করা কনটেন্ট পর্যালোচনা করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Geteilte Inhalte prüfen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Review shared content"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Revisar contenido compartido"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "بازبینی محتوای هم‌رسانی‌شده"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Suriin ang ibinahaging content"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Vérifier le contenu partagé"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "בדיקת תוכן משותף"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "शेयर की गई सामग्री की समीक्षा करें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tinjau konten yang dibagikan"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Controlla il contenuto condiviso"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "共有コンテンツを確認"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "공유 콘텐츠 검토"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Semak kandungan yang dikongsi"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "साझा सामग्री समीक्षा गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gedeelde inhoud bekijken"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sprawdź udostępnioną treść"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rever conteúdo partilhado"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Revisar conteúdo compartilhado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Проверить общий контент"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Granska delat innehåll"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "பகிரப்பட்ட உள்ளடக்கத்தை மதிப்பாய்வு செய்"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ตรวจสอบเนื้อหาที่แชร์"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Paylaşılan içeriği gözden geçir"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Переглянути спільний вміст"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "شیئر کردہ مواد کا جائزہ لیں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Xem lại nội dung được chia sẻ"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "查看共享内容"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "查看分享內容"
-          }
-        }
-      }
-    },
-    "share_import.review.use_in_composer" : {
-      "comment" : "Action that places reviewed shared content in the composer without sending it",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "استخدام في مسودة الرسالة"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "বার্তার খসড়ায় ব্যবহার করুন"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Im Nachrichtenentwurf verwenden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use in composer"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Usar en el borrador"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "استفاده در پیش‌نویس پیام"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gamitin sa draft"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Utiliser dans le brouillon"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "שימוש בטיוטה"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "संदेश के ड्राफ़्ट में उपयोग करें"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gunakan di draf"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Usa nella bozza"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "下書きで使用"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "초안에 사용"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gunakan dalam draf"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "सन्देशको मस्यौदामा प्रयोग गर्नुहोस्"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "In concept gebruiken"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Użyj w szkicu"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Usar no rascunho"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Usar no rascunho"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Использовать в черновике"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Använd i utkast"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "செய்தி வரைவில் பயன்படுத்து"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ใช้ในฉบับร่าง"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Taslakta kullan"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Використати в чернетці"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "پیغام کے مسودے میں استعمال کریں"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dùng trong bản nháp"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "用于草稿"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "用於草稿"
-          }
-        }
-      }
-    },
-    "sticker.accessibility.send" : {
-      "comment" : "Accessibility hint for tapping a sticker to send it",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send this sticker"
-          }
-        }
-      }
-    },
-    "sticker.install.button" : {
-      "comment" : "Button that installs the pasted sticker pack",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install"
-          }
-        }
-      }
-    },
-    "sticker.install.error.failed" : {
-      "comment" : "Error shown when a pack could not be fetched or installed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't load that pack. Check the coordinate or your connection and try again."
-          }
-        }
-      }
-    },
-    "sticker.install.error.invalid" : {
-      "comment" : "Error shown when a pasted pack coordinate is malformed",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>."
-          }
-        }
-      }
-    },
-    "sticker.install.loading" : {
-      "comment" : "Status shown while a pack is being fetched",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching pack…"
-          }
-        }
-      }
-    },
-    "sticker.install.placeholder" : {
-      "comment" : "Placeholder for the pack coordinate input field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30031:<pubkey>:<identifier>"
-          }
-        }
-      }
-    },
-    "sticker.install.title" : {
-      "comment" : "Section heading for installing a new sticker pack",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install a Pack"
-          }
-        }
-      }
-    },
-    "sticker.picker.empty" : {
-      "comment" : "Shown when no sticker packs are installed yet",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one."
-          }
-        }
-      }
-    },
-    "sticker.picker.section.installed" : {
-      "comment" : "Section heading for the installed sticker packs",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Packs"
-          }
-        }
-      }
-    },
-    "sticker.picker.title" : {
-      "comment" : "Title of the sticker picker sheet",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stickers"
-          }
-        }
-      }
-    },
-    "sticker.sync.title" : {
-      "comment" : "Toggle label for syncing installed sticker packs to Nostr",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Installed Packs to Nostr"
-          }
-        }
-      }
-    },
-    "sticker.sync.warning" : {
-      "comment" : "Privacy warning explaining that Nostr sync publishes installed packs under the persistent identity",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "bn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "fil" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ms" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ne" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ta" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default."
           }
         }
       }
@@ -79544,6 +75489,1511 @@
             "value" : "驗證"
           }
         }
+      }
+    },
+    "Voice notes are only available in mesh chats." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الملاحظات الصوتية متاحة فقط في محادثات الميش."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভয়েস নোট শুধু মেশ চ্যাটে উপলব্ধ।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachnachrichten sind nur im Mesh-Chat verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice notes are only available in mesh chats."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las notas de voz solo están disponibles en los chats de mesh."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیام صوتی فقط در گفتگوهای مش در دسترس است."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ang mga voice note ay available lamang sa mga mesh chat."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les notes vocales sont uniquement disponibles dans les discussions mesh."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הערות קוליות זמינות רק בצ׳אט של mesh."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वॉइस नोट्स केवल मेश चैट में ही उपलब्ध हैं।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan suara hanya tersedia di obrolan mesh."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le note vocali sono disponibili solo nelle chat mesh."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボイスメモはメッシュチャットでのみ利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "음성 메모는 메쉬 채팅에서만 사용할 수 있습니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota suara hanya tersedia dalam sembang mesh."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भ्वाइस नोटहरू केवल मेष च्याटमा मात्र उपलब्ध छन्।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spraaknotities zijn alleen beschikbaar in mesh-chats."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notatki głosowe są dostępne tylko na czatach mesh."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As notas de voz só estão disponíveis nos chats mesh."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As mensagens de voz só estão disponíveis nos chats mesh."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голосовые сообщения доступны только в mesh-чатах."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Röstanteckningar är bara tillgängliga i mesh-chattar."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "குரல் குறிப்புகள் மெஷ் உரையாடல்களில் மட்டுமே கிடைக்கும்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "บันทึกเสียงใช้งานได้เฉพาะในแชต mesh เท่านั้น"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesli notlar yalnızca mesh sohbetlerinde kullanılabilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Голосові нотатки доступні лише в mesh-чатах."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائس نوٹس صرف میش چیٹس میں دستیاب ہیں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghi chú giọng nói chỉ khả dụng trong các cuộc trò chuyện mesh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音消息仅可在 mesh 聊天中使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音訊息僅能在 mesh 聊天中使用。"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.title" : {
+      "comment" : "Section header (uppercase) for the app language picker in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اللغة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ভাষা"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SPRACHE"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANGUAGE"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WIKA"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANGUE"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שפה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषा"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BAHASA"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LINGUA"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BAHASA"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भाषा"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TAAL"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JĘZYK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDIOMA"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ЯЗЫК"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SPRÅK"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "மொழி"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ภาษา"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DİL"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "МОВА"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NGÔN NGỮ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語言"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.picker_label" : {
+      "comment" : "Label of the app language picker row in settings",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغة التطبيق"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অ্যাপের ভাষা"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Sprache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "app language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma de la app"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "زبان برنامه"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wika ng app"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "langue de l'app"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שפת האפליקציה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ऐप की भाषा"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bahasa aplikasi"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lingua dell'app"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリの言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 언어"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bahasa aplikasi"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एपको भाषा"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "app-taal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "język aplikacji"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma da app"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "idioma do app"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "язык приложения"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "appspråk"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "செயலியின் மொழி"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ภาษาของแอป"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uygulama dili"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мова застосунку"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپ کی زبان"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ngôn ngữ ứng dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "應用程式語言"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.system" : {
+      "comment" : "Menu option that clears the in-app language override so the app follows the device language",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لغة النظام"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "সিস্টেম ডিফল্ট"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemstandard"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "system default"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predeterminado del sistema"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیش‌فرض سیستم"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "default ng system"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "réglage système"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ברירת המחדל של המערכת"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सिस्टम डिफ़ॉल्ट"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bawaan sistem"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predefinita di sistema"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムのデフォルト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 기본값"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lalai sistem"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रणाली पूर्वनिर्धारित"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "systeemstandaard"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "domyślny systemowy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predefinição do sistema"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "padrão do sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "системный по умолчанию"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "systemstandard"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "கணினி இயல்புநிலை"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ค่าเริ่มต้นของระบบ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sistem varsayılanı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "системна за замовчуванням"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سسٹم ڈیفالٹ"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mặc định hệ thống"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統預設"
+          }
+        }
+      }
+    },
+    "app_info.settings.language.restart_note" : {
+      "comment" : "Caption shown after the user picks a different app language; the change takes effect on next launch",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعد تشغيل bitchat لتطبيق اللغة الجديدة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "নতুন ভাষা প্রয়োগ করতে bitchat পুনরায় চালু করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bitchat neu starten, um die neue Sprache zu übernehmen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "restart bitchat to apply the new language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicia bitchat para aplicar el nuevo idioma"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای اعمال زبان جدید، bitchat را دوباره باز کنید"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "i-restart ang bitchat para mailapat ang bagong wika"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "redémarrez bitchat pour appliquer la nouvelle langue"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "יש להפעיל מחדש את bitchat כדי להחיל את השפה החדשה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नई भाषा लागू करने के लिए bitchat पुनः आरंभ करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mulai ulang bitchat untuk menerapkan bahasa baru"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "riavvia bitchat per applicare la nuova lingua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい言語を適用するには bitchat を再起動してください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 언어를 적용하려면 bitchat을 다시 시작하세요"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mulakan semula bitchat untuk menggunakan bahasa baharu"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "नयाँ भाषा लागू गर्न bitchat पुनः सुरु गर्नुहोस्"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "herstart bitchat om de nieuwe taal toe te passen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uruchom bitchat ponownie, aby zastosować nowy język"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicie o bitchat para aplicar o novo idioma"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reinicie o bitchat para aplicar o novo idioma"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "перезапустите bitchat, чтобы применить новый язык"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "starta om bitchat för att använda det nya språket"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "புதிய மொழியைப் பயன்படுத்த bitchat-ஐ மீண்டும் தொடங்கவும்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รีสตาร์ท bitchat เพื่อใช้ภาษาใหม่"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yeni dili uygulamak için bitchat'i yeniden başlatın"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "перезапустіть bitchat, щоб застосувати нову мову"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نئی زبان لاگو کرنے کے لیے bitchat دوبارہ شروع کریں"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "khởi động lại bitchat để áp dụng ngôn ngữ mới"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重启 bitchat 以应用新语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動 bitchat 以套用新語言"
+          }
+        }
+      }
+    },
+    "share_import.review.message" : {
+      "comment" : "Explains that shared content replaces the named destination's composer and is not sent automatically",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "هل تريد استبدال مسودة %@ بهذا المحتوى؟ لن يتم إرسال أي شيء تلقائيًا." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "%@-এর খসড়াটি এই কনটেন্ট দিয়ে বদলাবেন? কিছুই স্বয়ংক্রিয়ভাবে পাঠানো হবে না।" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Entwurf für %@ durch diesen Inhalt ersetzen? Es wird nichts automatisch gesendet." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Replace the draft for %@ with this content? Nothing will be sent automatically." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "¿Reemplazar el borrador de %@ con este contenido? No se enviará nada automáticamente." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "پیش‌نویس %@ با این محتوا جایگزین شود؟ چیزی به‌طور خودکار ارسال نمی‌شود." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Palitan ng content na ito ang draft para sa %@? Walang awtomatikong ipapadala." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Remplacer le brouillon pour %@ par ce contenu ? Rien ne sera envoyé automatiquement." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "להחליף את הטיוטה עבור %@ בתוכן הזה? שום דבר לא יישלח אוטומטית." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ का ड्राफ़्ट इस सामग्री से बदलें? कुछ भी अपने आप नहीं भेजा जाएगा।" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Ganti draf untuk %@ dengan konten ini? Tidak ada yang akan dikirim otomatis." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Sostituire la bozza per %@ con questo contenuto? Nulla verrà inviato automaticamente." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ の下書きをこの内容で置き換えますか？自動的には送信されません。" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "%@의 초안을 이 콘텐츠로 바꾸시겠습니까? 자동으로 전송되지 않습니다." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Gantikan draf untuk %@ dengan kandungan ini? Tiada apa-apa akan dihantar secara automatik." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ को मस्यौदा यो सामग्रीले बदल्ने? केही पनि स्वचालित रूपमा पठाइने छैन।" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Concept voor %@ vervangen door deze inhoud? Er wordt niets automatisch verzonden." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Zastąpić szkic dla %@ tą treścią? Nic nie zostanie wysłane automatycznie." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Substituir o rascunho para %@ por este conteúdo? Nada será enviado automaticamente." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Substituir o rascunho de %@ por este conteúdo? Nada será enviado automaticamente." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Заменить черновик для %@ этим содержимым? Ничего не будет отправлено автоматически." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Ersätta utkastet för %@ med detta innehåll? Inget skickas automatiskt." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ க்கான வரைவைக் இந்த உள்ளடக்கத்தால் மாற்றவா? எதுவும் தானாக அனுப்பப்படாது." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "แทนที่ฉบับร่างสำหรับ %@ ด้วยเนื้อหานี้หรือไม่? จะไม่มีการส่งอัตโนมัติ" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ taslağı bu içerikle değiştirilsin mi? Hiçbir şey otomatik olarak gönderilmez." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Замінити чернетку для %@ цим вмістом? Нічого не буде надіслано автоматично." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "%@ کا مسودہ اس مواد سے بدلیں؟ کچھ بھی خودکار طور پر نہیں بھیجا جائے گا۔" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Thay bản nháp cho %@ bằng nội dung này? Không có gì được tự động gửi." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "要用此内容替换 %@ 的草稿吗？内容不会自动发送。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "要用此內容取代 %@ 的草稿嗎？內容不會自動傳送。" } }
+      }
+    },
+    "share_import.review.title" : {
+      "comment" : "Title for reviewing content received from the share extension",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "مراجعة المحتوى المشترك" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "শেয়ার করা কনটেন্ট পর্যালোচনা করুন" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Geteilte Inhalte prüfen" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Review shared content" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Revisar contenido compartido" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "بازبینی محتوای هم‌رسانی‌شده" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Suriin ang ibinahaging content" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Vérifier le contenu partagé" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "בדיקת תוכן משותף" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "शेयर की गई सामग्री की समीक्षा करें" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Tinjau konten yang dibagikan" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Controlla il contenuto condiviso" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "共有コンテンツを確認" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "공유 콘텐츠 검토" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Semak kandungan yang dikongsi" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "साझा सामग्री समीक्षा गर्नुहोस्" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Gedeelde inhoud bekijken" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Sprawdź udostępnioną treść" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Rever conteúdo partilhado" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Revisar conteúdo compartilhado" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Проверить общий контент" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Granska delat innehåll" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "பகிரப்பட்ட உள்ளடக்கத்தை மதிப்பாய்வு செய்" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ตรวจสอบเนื้อหาที่แชร์" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Paylaşılan içeriği gözden geçir" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Переглянути спільний вміст" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "شیئر کردہ مواد کا جائزہ لیں" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Xem lại nội dung được chia sẻ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "查看共享内容" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "查看分享內容" } }
+      }
+    },
+    "share_import.review.use_in_composer" : {
+      "comment" : "Action that places reviewed shared content in the composer without sending it",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "استخدام في مسودة الرسالة" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "বার্তার খসড়ায় ব্যবহার করুন" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Im Nachrichtenentwurf verwenden" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Use in composer" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar en el borrador" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "استفاده در پیش‌نویس پیام" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Gamitin sa draft" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Utiliser dans le brouillon" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "שימוש בטיוטה" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "संदेश के ड्राफ़्ट में उपयोग करें" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Gunakan di draf" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Usa nella bozza" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "下書きで使用" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "초안에 사용" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Gunakan dalam draf" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "सन्देशको मस्यौदामा प्रयोग गर्नुहोस्" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "In concept gebruiken" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Użyj w szkicu" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar no rascunho" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Usar no rascunho" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Использовать в черновике" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Använd i utkast" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "செய்தி வரைவில் பயன்படுத்து" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "ใช้ในฉบับร่าง" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Taslakta kullan" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Використати в чернетці" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "پیغام کے مسودے میں استعمال کریں" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Dùng trong bản nháp" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "用于草稿" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "用於草稿" } }
+      }
+    },
+    "content.accessibility.open_sticker_picker" : {
+      "comment" : "Accessibility label for the sticker picker button in the composer",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Open the sticker picker" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Open the sticker picker" } }
+      }
+    },
+    "sticker.accessibility.send" : {
+      "comment" : "Accessibility hint for tapping a sticker to send it",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Send this sticker" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Send this sticker" } }
+      }
+    },
+    "sticker.install.button" : {
+      "comment" : "Button that installs the pasted sticker pack",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Install" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Install" } }
+      }
+    },
+    "sticker.install.error.failed" : {
+      "comment" : "Error shown when a pack could not be fetched or installed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Couldn't load that pack. Check the coordinate or your connection and try again." } }
+      }
+    },
+    "sticker.install.error.invalid" : {
+      "comment" : "Error shown when a pasted pack coordinate is malformed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "That doesn't look like a pack coordinate. Use the format 30031:<pubkey>:<identifier>." } }
+      }
+    },
+    "sticker.install.loading" : {
+      "comment" : "Status shown while a pack is being fetched",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Fetching pack…" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Fetching pack…" } }
+      }
+    },
+    "sticker.install.placeholder" : {
+      "comment" : "Placeholder for the pack coordinate input field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "30031:<pubkey>:<identifier>" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "30031:<pubkey>:<identifier>" } }
+      }
+    },
+    "sticker.install.title" : {
+      "comment" : "Section heading for installing a new sticker pack",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Install a Pack" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Install a Pack" } }
+      }
+    },
+    "sticker.picker.empty" : {
+      "comment" : "Shown when no sticker packs are installed yet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "No sticker packs installed yet. Paste a pack coordinate below to add one." } }
+      }
+    },
+    "sticker.picker.section.installed" : {
+      "comment" : "Section heading for the installed sticker packs",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Installed Packs" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Installed Packs" } }
+      }
+    },
+    "sticker.picker.title" : {
+      "comment" : "Title of the sticker picker sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stickers" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Stickers" } }
+      }
+    },
+    "sticker.sync.title" : {
+      "comment" : "Toggle label for syncing installed sticker packs to Nostr",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sync Installed Packs to Nostr" } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "Sync Installed Packs to Nostr" } }
+      }
+    },
+    "sticker.sync.warning" : {
+      "comment" : "Privacy warning explaining that Nostr sync publishes installed packs under the persistent identity",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "bn" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "de" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "es" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "fa" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "fil" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "fr" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "he" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "hi" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "id" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "it" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ja" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ko" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ms" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ne" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "nl" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "pl" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "pt" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "pt-BR" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ru" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "sv" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ta" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "th" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "tr" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "uk" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "ur" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "vi" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } },
+        "zh-Hant" : { "stringUnit" : { "state" : "needs_review", "value" : "When on, your installed sticker packs are published to your persistent Nostr identity. Anyone watching your relays can see them. Off by default." } }
       }
     }
   },

--- a/bitchat/Models/BitchatMessage+Media.swift
+++ b/bitchat/Models/BitchatMessage+Media.swift
@@ -32,6 +32,11 @@ extension BitchatMessage {
         }
     }
 
+    /// A Sonar sticker reference if this message's content is a sticker wire
+    /// string (`\u{1F}sticker\u{1F}\u{2026}`), otherwise nil. Pure parse; never
+    /// touches the disk. Used by the message-row dispatcher.
+    var stickerRef: StickerRef? { StickerRefCodec.parse(content) }
+
     func mediaAttachment(for nickname: String) -> Media? {
         guard let baseDirectory = Cache.shared.filesDir else { return nil }
 

--- a/bitchat/Nostr/NostrProtocol.swift
+++ b/bitchat/Nostr/NostrProtocol.swift
@@ -34,6 +34,10 @@ struct NostrProtocol {
         /// recipient tag (`#x`). Regular (stored) kind so it survives until
         /// its NIP-40 expiration — the whole point is store-and-forward.
         case courierDrop = 1401
+        /// Sonar sticker-pack addressable events and the replaceable
+        /// installed-pack list (sonar-sticker-pack-v1). See docs/SONAR-STICKERS.md.
+        case stickerPack = 30031
+        case stickerPackList = 10031
     }
 
     /// Bound work before Base64-decoding either encrypted layer of an inbound
@@ -792,6 +796,28 @@ struct NostrEvent: Codable {
         self.sig = nil
         self.id = "" // Will be set during signing
     }
+
+    /// Construct an event with a raw integer kind (for kinds outside the
+    /// EventKind enum, e.g. outbound kind-30031/10031 sticker events and unit
+    /// tests). Does NOT enforce inbound tag limits; the security gate stays on
+    /// init(from:) for untrusted relay input.
+    init(
+        id: String = "",
+        pubkey: String,
+        createdAt: Int,
+        kind: Int,
+        tags: [[String]],
+        content: String,
+        sig: String? = nil
+    ) {
+        self.id = id
+        self.pubkey = pubkey
+        self.created_at = createdAt
+        self.kind = kind
+        self.tags = tags
+        self.content = content
+        self.sig = sig
+    }
     
     init(from dict: [String: Any]) throws {
         guard let pubkey = dict["pubkey"] as? String,
@@ -802,7 +828,7 @@ struct NostrEvent: Codable {
             throw NostrError.invalidEvent
         }
 
-        guard Self.isWithinInboundTagLimits(tags) else {
+        guard Self.isWithinInboundTagLimits(kind: kind, tags: tags) else {
             throw NostrError.invalidEvent
         }
         
@@ -818,7 +844,20 @@ struct NostrEvent: Codable {
     /// Bounds untrusted relay tag arrays so attackers cannot force large
     /// allocations or expensive joins on the inbound hot path.
     static func isWithinInboundTagLimits(_ tags: [[String]]) -> Bool {
-        guard tags.count <= TransportConfig.nostrMaxEventTags else { return false }
+        isWithinInboundTagLimits(kind: nil, tags: tags)
+    }
+
+    /// Kind-aware variant: Sonar sticker-pack kinds (30031/10031) may carry up
+    /// to ~200 sticker tags, so they get nostrMaxStickerPackEventTags.
+    static func isWithinInboundTagLimits(kind: Int?, tags: [[String]]) -> Bool {
+        let stickerKinds: Set<Int> = [
+            NostrProtocol.EventKind.stickerPack.rawValue,
+            NostrProtocol.EventKind.stickerPackList.rawValue
+        ]
+        let maxTags = (kind.map { stickerKinds.contains($0) } ?? false)
+            ? TransportConfig.nostrMaxStickerPackEventTags
+            : TransportConfig.nostrMaxEventTags
+        guard tags.count <= maxTags else { return false }
 
         for tag in tags {
             guard tag.count <= TransportConfig.nostrMaxEventTagValues else { return false }

--- a/bitchat/Protocols/PeerCapabilities+Local.swift
+++ b/bitchat/Protocols/PeerCapabilities+Local.swift
@@ -1,6 +1,15 @@
 import BitFoundation
 
 extension PeerCapabilities {
+    /// Understands and may send Sonar sticker references (`␟sticker␟…`
+    /// message content; see `docs/SONAR-STICKERS.md`).
+    ///
+    /// Bit 10 stays reserved (`nonDestructiveNoiseReplacement`, kept
+    /// decodable in BitFoundation), so stickers takes bit 11. The canonical
+    /// bitfield lives in `localPackages/BitFoundation/.../PeerCapabilities.swift`;
+    /// this declaration should move there with the next BitFoundation bump.
+    static let stickers = PeerCapabilities(rawValue: 1 << 11)
+
     /// Capabilities this build advertises in its announce packets.
     /// Each feature adds its bit here when it ships.
     static let localSupported: PeerCapabilities = [
@@ -8,6 +17,7 @@ extension PeerCapabilities {
         .prekeys,
         .groups,
         .privateMedia,
-        .privateMediaReceipts
+        .privateMediaReceipts,
+        .stickers
     ]
 }

--- a/bitchat/Protocols/PeerCapabilities+Local.swift
+++ b/bitchat/Protocols/PeerCapabilities+Local.swift
@@ -1,14 +1,14 @@
 import BitFoundation
 
 extension PeerCapabilities {
-    /// Understands and may send Sonar sticker references (`␟sticker␟…`
-    /// message content; see `docs/SONAR-STICKERS.md`).
-    ///
-    /// Bit 10 stays reserved (`nonDestructiveNoiseReplacement`, kept
-    /// decodable in BitFoundation), so stickers takes bit 11. The canonical
-    /// bitfield lives in `localPackages/BitFoundation/.../PeerCapabilities.swift`;
-    /// this declaration should move there with the next BitFoundation bump.
-    static let stickers = PeerCapabilities(rawValue: 1 << 11)
+    // NOTE: a `.stickers` bit is RESERVED at bit 13 but intentionally not
+    // declared or advertised in v1 — sticker refs ride as ordinary message
+    // content and need no capability negotiation (old clients render the
+    // literal text; see `docs/SONAR-STICKERS.md`). Bit 11 is claimed by
+    // #1107 (double ratchet) and bit 12 by #1438 (spray recovery); bit 10
+    // stays reserved (`nonDestructiveNoiseReplacement`). Declare the bit
+    // here — or in BitFoundation on the next bump — when inline-BLE sticker
+    // delivery (Approach B) ships.
 
     /// Capabilities this build advertises in its announce packets.
     /// Each feature adds its bit here when it ships.
@@ -17,7 +17,6 @@ extension PeerCapabilities {
         .prekeys,
         .groups,
         .privateMedia,
-        .privateMediaReceipts,
-        .stickers
+        .privateMediaReceipts
     ]
 }

--- a/bitchat/Protocols/StickerRefCodec.swift
+++ b/bitchat/Protocols/StickerRefCodec.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// A reference to a single sticker inside a Sonar sticker pack, carried as
+/// ordinary message content.
+///
+/// Interop-identical to sonar-ffi's `mesh_sticker_content` /
+/// `mesh_parse_sticker_content`: a ref encodes to
+/// `␟sticker␟<pack-coordinate>␟<shortcode>␟<plaintext-sha256>`
+/// where `␟` is ASCII Unit Separator (0x1F). The full upstream pack spec
+/// lives at https://sonarprivacy.xyz/docs#SONAR-STICKERS.
+struct StickerRef: Equatable, Sendable {
+    /// Nostr addressable coordinate of the pack: `30031:<64 lowercase hex pubkey>:<identifier>`.
+    let packCoordinate: String
+    /// Sticker shortcode within the pack: 1-64 chars of `[A-Za-z0-9_]`.
+    let shortcode: String
+    /// Lowercase hex SHA-256 of the decrypted sticker plaintext (64 chars).
+    let plaintextSha256: String
+
+    /// Validated factory. Returns nil unless every field matches the wire
+    /// shape exactly; encoding an invalid ref is not representable.
+    init?(packCoordinate: String, shortcode: String, plaintextSha256: String) {
+        guard StickerRef.isValidCoordinate(packCoordinate),
+              StickerRef.isValidShortcode(shortcode),
+              StickerRef.isValidSha256(plaintextSha256)
+        else { return nil }
+        self.packCoordinate = packCoordinate
+        self.shortcode = shortcode
+        self.plaintextSha256 = plaintextSha256
+    }
+
+    /// The wire-format message content for this ref.
+    var content: String { StickerRefCodec.encode(self) }
+
+    // MARK: - Validation helpers (reused by the pack service)
+
+    /// `30031:<64 lowercase hex>:<identifier>` where identifier is 1-80
+    /// chars of `[A-Za-z0-9._-]`.
+    static func isValidCoordinate(_ value: String) -> Bool {
+        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts[0] == "30031" else { return false }
+        guard isLowerHex(parts[1], count: 64) else { return false }
+        let identifier = parts[2]
+        guard (1...80).contains(identifier.count) else { return false }
+        return identifier.allSatisfy { byte in
+            byte.isASCII && (byte.isLetter || byte.isNumber || byte == "." || byte == "_" || byte == "-")
+        }
+    }
+
+    /// 1-64 chars of `[A-Za-z0-9_]`.
+    static func isValidShortcode(_ value: String) -> Bool {
+        guard (1...64).contains(value.count) else { return false }
+        return value.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_") }
+    }
+
+    /// Exactly 64 lowercase hex chars.
+    static func isValidSha256(_ value: String) -> Bool {
+        isLowerHex(Substring(value), count: 64)
+    }
+
+    private static func isLowerHex(_ value: Substring, count: Int) -> Bool {
+        guard value.count == count else { return false }
+        return value.allSatisfy { ($0 >= "0" && $0 <= "9") || ($0 >= "a" && $0 <= "f") }
+    }
+}
+
+/// Pure-Swift codec for the Sonar sticker-ref wire format, byte-identical to
+/// sonar-ffi's `mesh_sticker_content` / `mesh_parse_sticker_content`.
+enum StickerRefCodec {
+    /// ASCII Unit Separator; field delimiter and leading sentinel.
+    static let separator: Character = "\u{1F}"
+
+    /// `\u{1F}sticker\u{1F}<coordinate>\u{1F}<shortcode>\u{1F}<sha256>`
+    static func encode(_ ref: StickerRef) -> String {
+        "\u{1F}sticker\u{1F}\(ref.packCoordinate)\u{1F}\(ref.shortcode)\u{1F}\(ref.plaintextSha256)"
+    }
+
+    /// Parses message content into a ref. Returns nil for anything that is
+    /// not exactly five `\u{1F}`-separated fields with an empty leading
+    /// field, the literal tag `sticker`, and three validated fields.
+    ///
+    /// This parses attacker-controlled mesh content: it must never crash and
+    /// must never accept a malformed ref, so old clients render the literal
+    /// text instead of a bogus sticker.
+    static func parse(_ content: String) -> StickerRef? {
+        let parts = content.split(separator: separator, maxSplits: 4, omittingEmptySubsequences: false)
+        guard parts.count == 5, parts[0].isEmpty, parts[1] == "sticker" else { return nil }
+        return StickerRef(
+            packCoordinate: String(parts[2]),
+            shortcode: String(parts[3]),
+            plaintextSha256: String(parts[4])
+        )
+    }
+}

--- a/bitchat/Services/NotificationService.swift
+++ b/bitchat/Services/NotificationService.swift
@@ -228,9 +228,21 @@ final class NotificationService {
         requestDeliverer.add(request)
     }
     
+    /// Maps a sticker wire string to a clean notification body so the raw
+    /// `\u{1F}sticker\u{1F}\u{2026}` reference never reaches the lock screen.
+    /// Plain text and other content pass through unchanged.
+    private func displayBody(forContent content: String) -> String {
+        if StickerRefCodec.parse(content) != nil {
+            // Plain string, matching the file's notification-body convention
+            // (e.g. "🔒 DM from …"); avoids leaking the raw ref to the lock screen.
+            return "🎟 Sticker"
+        }
+        return content
+    }
+
     func sendMentionNotification(from sender: String, message: String) {
         let title = hidePreviews ? Redacted.mentionTitle : "🫵 you were mentioned by \(sender)"
-        let body = hidePreviews ? Redacted.body : message
+        let body = hidePreviews ? Redacted.body : displayBody(forContent: message)
         let identifier = "mention-\(UUID().uuidString)"
 
         sendLocalNotification(title: title, body: body, identifier: identifier)
@@ -238,7 +250,7 @@ final class NotificationService {
 
     func sendPrivateMessageNotification(from sender: String, message: String, peerID: PeerID) {
         let title = hidePreviews ? Redacted.directMessageTitle : "🔒 DM from \(sender)"
-        let body = hidePreviews ? Redacted.body : message
+        let body = hidePreviews ? Redacted.body : displayBody(forContent: message)
         let identifier = "private-\(UUID().uuidString)"
         // Routing payload, not display copy: `userInfo` never reaches the lock
         // screen, and the conversation to open still has to be identifiable.

--- a/bitchat/Services/StickerCache.swift
+++ b/bitchat/Services/StickerCache.swift
@@ -131,7 +131,7 @@ actor StickerCache {
     /// Returns cached bytes for a hash, or nil. Invalid hash shapes return nil
     /// (never throw, never touch the disk path builder with untrusted input).
     func data(for sha256: String) -> Data? {
-        guard StickerRefValidation.isValidSha256(sha256) else { return nil }
+        guard StickerRef.isValidSha256(sha256) else { return nil }
         let url: URL
         if let entry = index[sha256] {
             url = fileURL(forHash: sha256, extension: entry.fileExtension)
@@ -151,7 +151,7 @@ actor StickerCache {
     /// On-disk location of a cached sticker, for renderers that prefer a file
     /// URL (animated webp/gif). Nil when not cached or the hash shape is invalid.
     func fileURL(for sha256: String) -> URL? {
-        guard StickerRefValidation.isValidSha256(sha256) else { return nil }
+        guard StickerRef.isValidSha256(sha256) else { return nil }
         if let entry = index[sha256] {
             let url = fileURL(forHash: sha256, extension: entry.fileExtension)
             return fileManager.fileExists(atPath: url.path) ? url : nil
@@ -165,7 +165,7 @@ actor StickerCache {
     /// Verifies the SHA-256 of `data` BEFORE writing anything. Rejects invalid
     /// hash shapes (traversal guard) and payloads over 4 MiB.
     func store(_ data: Data, sha256: String, mime: String) throws {
-        guard StickerRefValidation.isValidSha256(sha256) else { throw Error.invalidSHA256 }
+        guard StickerRef.isValidSha256(sha256) else { throw Error.invalidSHA256 }
         guard data.count <= Self.maxStickerBytes else { throw Error.stickerTooLarge }
         let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
         guard digest == sha256 else { throw Error.hashMismatch }
@@ -177,7 +177,10 @@ actor StickerCache {
             fileExtension: ext,
             size: data.count
         )
-        persistIndex()
+        // Mutation: persist immediately (not throttled) so a restart within
+        // the 5s read-throttle window can still discover the file — the read
+        // path only checks the extension-bearing name via the index.
+        persistIndex(force: true)
         evictIfNeeded(protecting: sha256)
     }
 
@@ -193,7 +196,7 @@ actor StickerCache {
         mime: String = "",
         using downloader: @escaping Downloader
     ) async throws -> Data {
-        guard StickerRefValidation.isValidSha256(sha256) else { throw Error.invalidSHA256 }
+        guard StickerRef.isValidSha256(sha256) else { throw Error.invalidSHA256 }
         if let cached = data(for: sha256) { return cached }
         if let retryAfter = negativeCache[sha256], now() < retryAfter {
             throw Error.negativeCacheBackoff(retryAfter: retryAfter)
@@ -201,12 +204,18 @@ actor StickerCache {
         if let existing = inFlight[sha256] {
             return try await existing.value
         }
-        let task = Task { try await downloader(url) }
+        // The shared in-flight task includes verification + storage, so every
+        // concurrent caller receives bytes whose hash was checked — a follower
+        // must never observe the raw, unverified download.
+        let task = Task { [self, downloader] in
+            let data = try await downloader(url)
+            try store(data, sha256: sha256, mime: mime)
+            return data
+        }
         inFlight[sha256] = task
         do {
             let data = try await task.value
             inFlight.removeValue(forKey: sha256)
-            try store(data, sha256: sha256, mime: mime)
             negativeCache.removeValue(forKey: sha256)
             failureCounts.removeValue(forKey: sha256)
             return data
@@ -271,7 +280,7 @@ actor StickerCache {
             index.removeValue(forKey: hash)
             total -= entry.size
         }
-        persistIndex()
+        persistIndex(force: true)
     }
 
     /// Index writes are throttled on the read path (one disk write per 5s at

--- a/bitchat/Services/StickerCache.swift
+++ b/bitchat/Services/StickerCache.swift
@@ -1,0 +1,285 @@
+//
+// StickerCache.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import CryptoKit
+
+/// Shared on-disk locations for the Sonar sticker feature.
+///
+/// Everything lives under `Application Support/files/stickers/` — the same
+/// `files` tree that `BLEIncomingFileStore.panicWipe` removes, so sticker
+/// data is covered by panic wipe without any extra wiring.
+enum StickerStoragePaths {
+    static func filesDirectory(
+        base: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let root = try base ?? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let dir = root.appendingPathComponent("files", isDirectory: true)
+        try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    static func stickersDirectory(
+        base: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let dir = try filesDirectory(base: base, fileManager: fileManager)
+            .appendingPathComponent("stickers", isDirectory: true)
+        try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}
+
+/// Content-addressed disk cache for sticker image bytes.
+///
+/// Layout: `Application Support/files/stickers/<sha256>[.<ext>]`. The file name
+/// is the lowercase hex SHA-256 of the plaintext (validated as strictly
+/// `[0-9a-f]{64}` before any path join, so traversal is impossible), plus an
+/// optional extension derived from the declared MIME type.
+///
+/// Last-access bookkeeping for LRU eviction lives in a small JSON sidecar
+/// (`_index.json`) inside the same directory. Chosen over extended attributes
+/// because xattrs do not survive some backup/restore and file-copy paths and
+/// are awkward to inspect in tests; a sidecar keeps all cache state in one
+/// directory that panic wipe already removes.
+///
+/// The negative cache (failed hash → next-retry timestamp, exponential backoff
+/// from 30s capped at 30min) is intentionally in-memory only: a restart simply
+/// resets backoff, which is acceptable for a cache.
+actor StickerCache {
+    enum Error: Swift.Error, Equatable {
+        /// Hash string is not strictly `[0-9a-f]{64}` (includes traversal attempts).
+        case invalidSHA256
+        /// SHA-256 of the supplied bytes does not match the claimed hash.
+        case hashMismatch
+        /// Sticker bytes exceed the 4 MiB hard cap.
+        case stickerTooLarge
+        /// A previous fetch failed recently; backoff has not elapsed yet.
+        case negativeCacheBackoff(retryAfter: Date)
+    }
+
+    static let maxStickerBytes = 4 * 1024 * 1024
+    static let defaultMaxCacheBytes = 100 * 1024 * 1024
+    static let negativeCacheInitialDelay: TimeInterval = 30
+    static let negativeCacheMaxDelay: TimeInterval = 30 * 60
+
+    typealias Downloader = @Sendable (URL) async throws -> Data
+
+    private struct IndexEntry: Codable {
+        var lastAccess: TimeInterval
+        var fileExtension: String?
+        var size: Int
+    }
+
+    private let stickersDirectory: URL
+    private let indexURL: URL
+    private let maxCacheBytes: Int
+    private let fileManager: FileManager
+    private let now: @Sendable () -> Date
+
+    // No default value: assigned exactly once in init (a later mutation of a
+    // defaulted property from the nonisolated init is an error in Swift 6 mode).
+    private var index: [String: IndexEntry]
+    private var inFlight: [String: Task<Data, Swift.Error>] = [:]
+    private var failureCounts: [String: Int] = [:]
+    private var negativeCache: [String: Date] = [:]
+    private var lastIndexPersist: Date = .distantPast
+
+    init(
+        baseDirectory: URL? = nil,
+        maxCacheBytes: Int = StickerCache.defaultMaxCacheBytes,
+        fileManager: FileManager = .default,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        let dir = (try? StickerStoragePaths.stickersDirectory(base: baseDirectory, fileManager: fileManager))
+            ?? fileManager.temporaryDirectory
+                .appendingPathComponent("bitchat-stickers-\(UUID().uuidString)", isDirectory: true)
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.stickersDirectory = dir
+        self.indexURL = dir.appendingPathComponent("_index.json", isDirectory: false)
+        self.maxCacheBytes = maxCacheBytes
+        self.fileManager = fileManager
+        self.now = now
+        // Load the LRU sidecar and drop entries whose file disappeared
+        // (e.g. manual cleanup). Done inline: actor inits are nonisolated, so
+        // isolated helper calls from here are an error in Swift 6 mode.
+        var initialIndex: [String: IndexEntry] = [:]
+        if let data = try? Data(contentsOf: self.indexURL),
+           let decoded = try? JSONDecoder().decode([String: IndexEntry].self, from: data) {
+            initialIndex = decoded
+        }
+        for (hash, entry) in initialIndex
+        where !fileManager.fileExists(atPath: Self.fileURL(in: dir, forHash: hash, extension: entry.fileExtension).path) {
+            initialIndex.removeValue(forKey: hash)
+        }
+        self.index = initialIndex
+    }
+
+    // MARK: - Reads
+
+    /// Returns cached bytes for a hash, or nil. Invalid hash shapes return nil
+    /// (never throw, never touch the disk path builder with untrusted input).
+    func data(for sha256: String) -> Data? {
+        guard StickerRefValidation.isValidSha256(sha256) else { return nil }
+        let url: URL
+        if let entry = index[sha256] {
+            url = fileURL(forHash: sha256, extension: entry.fileExtension)
+        } else {
+            url = fileURL(forHash: sha256, extension: nil)
+        }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        index[sha256] = IndexEntry(
+            lastAccess: now().timeIntervalSince1970,
+            fileExtension: index[sha256]?.fileExtension,
+            size: data.count
+        )
+        persistIndex()
+        return data
+    }
+
+    /// On-disk location of a cached sticker, for renderers that prefer a file
+    /// URL (animated webp/gif). Nil when not cached or the hash shape is invalid.
+    func fileURL(for sha256: String) -> URL? {
+        guard StickerRefValidation.isValidSha256(sha256) else { return nil }
+        if let entry = index[sha256] {
+            let url = fileURL(forHash: sha256, extension: entry.fileExtension)
+            return fileManager.fileExists(atPath: url.path) ? url : nil
+        }
+        let bare = fileURL(forHash: sha256, extension: nil)
+        return fileManager.fileExists(atPath: bare.path) ? bare : nil
+    }
+
+    // MARK: - Writes
+
+    /// Verifies the SHA-256 of `data` BEFORE writing anything. Rejects invalid
+    /// hash shapes (traversal guard) and payloads over 4 MiB.
+    func store(_ data: Data, sha256: String, mime: String) throws {
+        guard StickerRefValidation.isValidSha256(sha256) else { throw Error.invalidSHA256 }
+        guard data.count <= Self.maxStickerBytes else { throw Error.stickerTooLarge }
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        guard digest == sha256 else { throw Error.hashMismatch }
+        let ext = Self.fileExtension(for: mime)
+        let url = fileURL(forHash: sha256, extension: ext)
+        try data.write(to: url, options: .atomic)
+        index[sha256] = IndexEntry(
+            lastAccess: now().timeIntervalSince1970,
+            fileExtension: ext,
+            size: data.count
+        )
+        persistIndex()
+        evictIfNeeded(protecting: sha256)
+    }
+
+    // MARK: - Fetch with coalescing + negative cache
+
+    /// Returns cached bytes when present; otherwise coalesces concurrent calls
+    /// per hash onto a single in-flight download, stores the result (which
+    /// re-verifies the hash), and applies exponential-backoff negative caching
+    /// to failures (30s initial, doubling, capped at 30min).
+    func fetch(
+        sha256: String,
+        url: URL,
+        mime: String = "",
+        using downloader: @escaping Downloader
+    ) async throws -> Data {
+        guard StickerRefValidation.isValidSha256(sha256) else { throw Error.invalidSHA256 }
+        if let cached = data(for: sha256) { return cached }
+        if let retryAfter = negativeCache[sha256], now() < retryAfter {
+            throw Error.negativeCacheBackoff(retryAfter: retryAfter)
+        }
+        if let existing = inFlight[sha256] {
+            return try await existing.value
+        }
+        let task = Task { try await downloader(url) }
+        inFlight[sha256] = task
+        do {
+            let data = try await task.value
+            inFlight.removeValue(forKey: sha256)
+            try store(data, sha256: sha256, mime: mime)
+            negativeCache.removeValue(forKey: sha256)
+            failureCounts.removeValue(forKey: sha256)
+            return data
+        } catch {
+            inFlight.removeValue(forKey: sha256)
+            recordFailure(for: sha256)
+            throw error
+        }
+    }
+
+    // MARK: - Wipe
+
+    /// Removes every cached sticker and all bookkeeping. In-flight downloads
+    /// are left to finish (their `store` re-verifies and re-creates entries).
+    func removeAll() {
+        try? fileManager.removeItem(at: stickersDirectory)
+        try? fileManager.createDirectory(at: stickersDirectory, withIntermediateDirectories: true)
+        index.removeAll()
+        negativeCache.removeAll()
+        failureCounts.removeAll()
+        lastIndexPersist = .distantPast
+    }
+
+    // MARK: - Internals
+
+    static func fileExtension(for mime: String) -> String? {
+        switch mime {
+        case "image/webp": return "webp"
+        case "image/png", "image/apng": return "png" // APNG carries a PNG signature/container
+        case "image/gif": return "gif"
+        default: return nil
+        }
+    }
+
+    private nonisolated static func fileURL(in directory: URL, forHash hash: String, extension ext: String?) -> URL {
+        let name = ext.map { "\(hash).\($0)" } ?? hash
+        return directory.appendingPathComponent(name, isDirectory: false)
+    }
+
+    private nonisolated func fileURL(forHash hash: String, extension ext: String?) -> URL {
+        Self.fileURL(in: stickersDirectory, forHash: hash, extension: ext)
+    }
+
+    private func recordFailure(for hash: String) {
+        let count = (failureCounts[hash] ?? 0) + 1
+        failureCounts[hash] = count
+        let delay = min(
+            Self.negativeCacheInitialDelay * pow(2.0, Double(count - 1)),
+            Self.negativeCacheMaxDelay
+        )
+        negativeCache[hash] = now().addingTimeInterval(delay)
+    }
+
+    private func evictIfNeeded(protecting protectedHash: String? = nil) {
+        var total = index.values.reduce(0) { $0 + $1.size }
+        guard total > maxCacheBytes else { return }
+        // Oldest last-access first.
+        for (hash, entry) in index.sorted(by: { $0.value.lastAccess < $1.value.lastAccess }) {
+            guard total > maxCacheBytes else { break }
+            if hash == protectedHash { continue }
+            try? fileManager.removeItem(at: fileURL(forHash: hash, extension: entry.fileExtension))
+            index.removeValue(forKey: hash)
+            total -= entry.size
+        }
+        persistIndex()
+    }
+
+    /// Index writes are throttled on the read path (one disk write per 5s at
+    /// most) and forced on mutations, so hot render loops don't thrash the disk.
+    private func persistIndex(force: Bool = false) {
+        guard force || now().timeIntervalSince(lastIndexPersist) > 5 else { return }
+        guard let data = try? JSONEncoder().encode(index) else { return }
+        try? data.write(to: indexURL, options: .atomic)
+        lastIndexPersist = now()
+    }
+}

--- a/bitchat/Services/StickerInstallStore.swift
+++ b/bitchat/Services/StickerInstallStore.swift
@@ -31,6 +31,10 @@ actor StickerInstallStore {
     static let listEventKind = 10031
     static let syncEnabledDefaultsKey = "stickerInstallStore.syncEnabled"
 
+    /// App-wide shared instance (state is on disk + UserDefaults, but one
+    /// actor keeps in-memory `installed` coherent across views).
+    static let shared = StickerInstallStore()
+
     typealias RelayQuery = @Sendable (NostrFilter) async -> [NostrEvent]
     typealias EventPublisher = @Sendable (NostrEvent) async throws -> Void
     typealias IdentityProvider = @Sendable () throws -> NostrIdentity
@@ -90,7 +94,7 @@ actor StickerInstallStore {
         if let data = try? Data(contentsOf: self.storageURL),
            let coordinates = try? JSONDecoder().decode([String].self, from: data) {
             initial = Self.dedupePreservingOrder(
-                coordinates.filter { StickerRefValidation.isValidCoordinate($0) }
+                coordinates.filter { StickerRef.isValidCoordinate($0) }
             )
         }
         self.installed = initial
@@ -101,7 +105,7 @@ actor StickerInstallStore {
     /// Appends a coordinate (first-seen order, no duplicates), persists, and
     /// publishes the updated list only when `syncEnabled` is true.
     func install(_ coordinate: String) async throws {
-        guard StickerRefValidation.isValidCoordinate(coordinate) else {
+        guard StickerRef.isValidCoordinate(coordinate) else {
             throw StickerInstallError.invalidCoordinate
         }
         guard !installed.contains(coordinate) else { return }
@@ -137,7 +141,7 @@ actor StickerInstallStore {
         else { return [] }
         let coordinates = latest.tags.compactMap { tag -> String? in
             guard tag.count >= 2, tag[0] == "a",
-                  StickerRefValidation.isValidCoordinate(tag[1])
+                  StickerRef.isValidCoordinate(tag[1])
             else { return nil }
             return tag[1]
         }

--- a/bitchat/Services/StickerInstallStore.swift
+++ b/bitchat/Services/StickerInstallStore.swift
@@ -1,0 +1,199 @@
+//
+// StickerInstallStore.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import BitLogger
+import Foundation
+
+/// Local + relay-synced list of installed Sonar sticker packs (Nostr kind
+/// 10031, `a` tags of `30031:<author>:<d>` coordinates).
+///
+/// The ordered list is persisted locally as JSON under
+/// `Application Support/files/stickers/` so panic wipe covers it. Relay
+/// publishing is strictly opt-in: `syncEnabled` defaults to false and
+/// `publishInstalledList()` refuses to run while it is false — nothing about
+/// the installed list leaves the device until the user turns sync on.
+///
+/// Local mutations always succeed locally; a publish failure is logged, never
+/// rolled back.
+actor StickerInstallStore {
+    enum StickerInstallError: Swift.Error, Equatable {
+        /// `publishInstalledList()` was called while `syncEnabled` is false.
+        case syncDisabled
+        case identityUnavailable
+        case invalidCoordinate
+    }
+
+    static let listEventKind = 10031
+    static let syncEnabledDefaultsKey = "stickerInstallStore.syncEnabled"
+
+    typealias RelayQuery = @Sendable (NostrFilter) async -> [NostrEvent]
+    typealias EventPublisher = @Sendable (NostrEvent) async throws -> Void
+    typealias IdentityProvider = @Sendable () throws -> NostrIdentity
+
+    private let storageURL: URL
+    private let defaults: UserDefaults
+    private let identityProvider: IdentityProvider
+    private let relayQuery: RelayQuery
+    private let publisher: EventPublisher
+    private let fileManager: FileManager
+    private let now: @Sendable () -> Date
+
+    /// Ordered installed pack coordinates, deduplicated in first-seen order.
+    /// No default value: assigned exactly once in init (Swift 6 init isolation).
+    private(set) var installed: [String]
+
+    /// Opt-in gate for kind-10031 list sync. Default false.
+    var syncEnabled: Bool {
+        get { defaults.object(forKey: Self.syncEnabledDefaultsKey) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: Self.syncEnabledDefaultsKey) }
+    }
+
+    init(
+        baseDirectory: URL? = nil,
+        defaults: UserDefaults = .standard,
+        identityProvider: @escaping IdentityProvider = {
+            guard let identity = try NostrIdentityBridge().getCurrentNostrIdentity() else {
+                throw StickerInstallError.identityUnavailable
+            }
+            return identity
+        },
+        relayQuery: @escaping RelayQuery = { filter in
+            await StickerRelayQuery.oneShot(filter: filter)
+        },
+        publisher: @escaping EventPublisher = { event in
+            // nil relay set = built-in default relays (never geo relays). The
+            // manager's own fail-closed queueing applies while Tor bootstraps.
+            await MainActor.run { NostrRelayManager.shared.sendEvent(event) }
+        },
+        fileManager: FileManager = .default,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        let dir = (try? StickerStoragePaths.stickersDirectory(base: baseDirectory, fileManager: fileManager))
+            ?? fileManager.temporaryDirectory
+                .appendingPathComponent("bitchat-stickers-\(UUID().uuidString)", isDirectory: true)
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.storageURL = dir.appendingPathComponent("installed-packs.json", isDirectory: false)
+        self.defaults = defaults
+        self.identityProvider = identityProvider
+        self.relayQuery = relayQuery
+        self.publisher = publisher
+        self.fileManager = fileManager
+        self.now = now
+        // Loaded inline: actor inits are nonisolated, so isolated helper calls
+        // from here are an error in Swift 6 mode.
+        var initial: [String] = []
+        if let data = try? Data(contentsOf: self.storageURL),
+           let coordinates = try? JSONDecoder().decode([String].self, from: data) {
+            initial = Self.dedupePreservingOrder(
+                coordinates.filter { StickerRefValidation.isValidCoordinate($0) }
+            )
+        }
+        self.installed = initial
+    }
+
+    // MARK: - Local mutations
+
+    /// Appends a coordinate (first-seen order, no duplicates), persists, and
+    /// publishes the updated list only when `syncEnabled` is true.
+    func install(_ coordinate: String) async throws {
+        guard StickerRefValidation.isValidCoordinate(coordinate) else {
+            throw StickerInstallError.invalidCoordinate
+        }
+        guard !installed.contains(coordinate) else { return }
+        installed.append(coordinate)
+        persist()
+        await publishIfSyncEnabled()
+    }
+
+    func uninstall(_ coordinate: String) async {
+        guard installed.contains(coordinate) else { return }
+        installed.removeAll { $0 == coordinate }
+        persist()
+        await publishIfSyncEnabled()
+    }
+
+    func installedPacks() -> [String] { installed }
+
+    // MARK: - Relay sync (kind 10031)
+
+    /// Fetches the canonical identity's latest kind-10031 event from the
+    /// default relay set and returns its `a`-tag coordinates (validated,
+    /// deduplicated in first-seen order). Empty when no event exists.
+    func fetchInstalledList() async throws -> [String] {
+        let identity = try identityProvider()
+        var filter = NostrFilter()
+        filter.kinds = [Self.listEventKind]
+        filter.authors = [identity.publicKeyHex]
+        filter.limit = 5
+        let events = await relayQuery(filter)
+        guard let latest = events
+            .filter({ $0.kind == Self.listEventKind && $0.pubkey == identity.publicKeyHex })
+            .max(by: { $0.created_at < $1.created_at })
+        else { return [] }
+        let coordinates = latest.tags.compactMap { tag -> String? in
+            guard tag.count >= 2, tag[0] == "a",
+                  StickerRefValidation.isValidCoordinate(tag[1])
+            else { return nil }
+            return tag[1]
+        }
+        return Self.dedupePreservingOrder(coordinates)
+    }
+
+    /// Union of local and relay state, preserving first-seen order (local
+    /// entries first). Call on launch when sync is enabled.
+    func mergeInstalledFromNetwork() async throws {
+        let remote = try await fetchInstalledList()
+        installed = Self.dedupePreservingOrder(installed + remote)
+        persist()
+    }
+
+    /// Publishes the local list as a signed kind-10031 event (empty content,
+    /// `a` tags) to the default relay set. REFUSES while `syncEnabled` is
+    /// false — the caller must gate this on the explicit opt-in setting.
+    func publishInstalledList() async throws {
+        guard syncEnabled else { throw StickerInstallError.syncDisabled }
+        let identity = try identityProvider()
+        let unsigned = try NostrEvent(from: [
+            "pubkey": identity.publicKeyHex,
+            "created_at": Int(now().timeIntervalSince1970),
+            "kind": Self.listEventKind,
+            "tags": installed.map { ["a", $0] },
+            "content": ""
+        ])
+        let signed = try unsigned.sign(with: identity.schnorrSigningKey())
+        try await publisher(signed)
+    }
+
+    // MARK: - Internals
+
+    private func publishIfSyncEnabled() async {
+        guard syncEnabled else { return }
+        do {
+            try await publishInstalledList()
+        } catch {
+            SecureLogger.error(
+                "⚠️ Failed to publish sticker install list: \(error.localizedDescription)",
+                category: .session
+            )
+        }
+    }
+
+    static func dedupePreservingOrder(_ coordinates: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for coordinate in coordinates where seen.insert(coordinate).inserted {
+            result.append(coordinate)
+        }
+        return result
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(installed) else { return }
+        try? data.write(to: storageURL, options: .atomic)
+    }
+}

--- a/bitchat/Services/StickerPackService.swift
+++ b/bitchat/Services/StickerPackService.swift
@@ -1,0 +1,488 @@
+//
+// StickerPackService.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Combine
+import Foundation
+import ImageIO
+import Tor
+
+// MARK: - LOCAL STUB for StickerRefCodec validators
+//
+// `bitchat/Protocols/StickerRefCodec.swift` (owned by a parallel delegate) is
+// expected to provide `StickerRef` plus `StickerRefCodec.isValidCoordinate /
+// isValidShortcode / isValidSha256`. Until that file lands, the validator
+// shapes are stubbed here so the services layer compiles and stays testable.
+// A later pass should re-point these at the codec (or have the codec call
+// these) — do NOT duplicate them further.
+enum StickerRefValidation {
+    /// Strictly `[0-9a-f]{64}` — safe to use as a file name after this passes.
+    static func isValidSha256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { $0.isHexDigit } && value == value.lowercased()
+    }
+
+    /// Nostr pubkey hex has the same shape as a sha256 hex string.
+    static func isValidPubkeyHex(_ value: String) -> Bool { isValidSha256(value) }
+
+    /// Shortcode: `[a-z0-9_-]{1,64}`.
+    static func isValidShortcode(_ value: String) -> Bool {
+        guard (1...64).contains(value.count) else { return false }
+        return value.allSatisfy { c in
+            c.isASCII && ((c.isLetter && c.isLowercase) || c.isNumber || c == "_" || c == "-")
+        }
+    }
+
+    /// `d` identifier: printable ASCII except whitespace, 1...256 chars.
+    static func isValidPackIdentifier(_ value: String) -> Bool {
+        guard (1...256).contains(value.count) else { return false }
+        return value.unicodeScalars.allSatisfy { (0x21...0x7E).contains($0.value) }
+    }
+
+    /// Pack coordinate: `30031:<author-pubkey-hex>:<d-identifier>`.
+    static func isValidCoordinate(_ value: String) -> Bool {
+        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts[0] == "30031" else { return false }
+        return isValidPubkeyHex(String(parts[1])) && isValidPackIdentifier(String(parts[2]))
+    }
+}
+
+// MARK: - Models
+
+struct StickerDimensions: Codable, Equatable, Sendable {
+    let width: Int
+    let height: Int
+}
+
+struct Sticker: Codable, Equatable, Sendable, Identifiable {
+    let shortcode: String
+    let url: URL
+    /// Lowercase hex SHA-256 of the plaintext bytes (also present in `url.path`).
+    let sha256: String
+    /// One of image/webp, image/png, image/apng, image/gif.
+    let mime: String
+    let dim: StickerDimensions?
+    let alt: String?
+    let emoji: String?
+
+    var id: String { shortcode }
+}
+
+struct StickerPack: Codable, Equatable, Sendable, Identifiable {
+    /// `30031:<author-pubkey-hex>:<d-identifier>`.
+    let coordinate: String
+    let authorPubkey: String
+    let identifier: String
+    let title: String
+    let description: String?
+    let coverURL: URL?
+    let createdAt: Date
+    let stickers: [Sticker]
+
+    var id: String { coordinate }
+}
+
+// MARK: - One-shot relay queries
+
+/// One-shot, EOSE-bounded Nostr queries used by the sticker services.
+///
+/// Goes through `NostrRelayManager.shared`, so the global network-activation
+/// gate and the manager's own Tor fail-closed queueing apply; `relayUrls: nil`
+/// targets the built-in default relay set (damus/nos.lol/primal/offchain +
+/// user-added), never the geo relays.
+enum StickerRelayQuery {
+    @MainActor
+    static func oneShot(
+        filter: NostrFilter,
+        timeout: TimeInterval = 10
+    ) async -> [NostrEvent] {
+        await withCheckedContinuation { continuation in
+            let query = StickerOneShotQuery(continuation: continuation)
+            query.start(filter: filter, timeout: timeout)
+        }
+    }
+}
+
+@MainActor
+private final class StickerOneShotQuery {
+    private var events: [NostrEvent] = []
+    private var continuation: CheckedContinuation<[NostrEvent], Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(continuation: CheckedContinuation<[NostrEvent], Never>) {
+        self.continuation = continuation
+    }
+
+    func start(filter: NostrFilter, timeout: TimeInterval) {
+        let id = "sticker-oneshot-\(UUID().uuidString)"
+        NostrRelayManager.shared.subscribe(
+            filter: filter,
+            id: id,
+            relayUrls: nil,
+            handler: { [weak self] event in
+                Task { @MainActor in self?.events.append(event) }
+            },
+            onEOSE: { [weak self] in
+                Task { @MainActor in self?.finish(id: id) }
+            }
+        )
+        timeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            self?.finish(id: id) // no-op if EOSE already finished
+        }
+    }
+
+    private func finish(id: String) {
+        guard let continuation else { return }
+        self.continuation = nil
+        timeoutTask?.cancel()
+        NostrRelayManager.shared.unsubscribe(id: id)
+        continuation.resume(returning: events)
+    }
+}
+
+// MARK: - Service
+
+/// Resolves Sonar sticker packs (Nostr kind 30031, format
+/// `sonar-sticker-pack-v1`) and downloads/caches sticker images.
+///
+/// Rendering never hits the network synchronously: pack metadata is cached in
+/// memory (plus a small JSON sidecar) with a 24h TTL, and image bytes come
+/// from `StickerCache` whenever possible. All internet access is Tor-aware and
+/// fail-closed (see `makeTorDownloader`).
+@MainActor
+final class StickerPackService: ObservableObject {
+    typealias RelayQuery = @Sendable (NostrFilter) async -> [NostrEvent]
+    typealias Downloader = @Sendable (URL) async throws -> Data
+
+    enum StickerPackError: Swift.Error, Equatable {
+        case packNotFound
+        case invalidCoordinate
+        /// Network activation gate is closed (no permission/favorites/offline).
+        case networkNotAllowed
+        /// Tor preference is on but Tor failed to become ready. Fail-closed:
+        /// the fetch is refused rather than leaked to clearnet.
+        case torNotReady
+        case downloadTooLarge
+        case mimeMismatch
+        case invalidImageData
+    }
+
+    nonisolated static let packEventKind = 30031
+    nonisolated static let packFormatValue = "sonar-sticker-pack-v1"
+    nonisolated static let maxStickersPerPack = 200
+    nonisolated static let maxImageDimension = 4096
+    nonisolated static let metadataTTL: TimeInterval = 24 * 60 * 60
+    nonisolated static let allowedMimes: Set<String> = ["image/webp", "image/png", "image/apng", "image/gif"]
+
+    static let shared = StickerPackService()
+
+    /// Pack metadata keyed by coordinate, for synchronous render lookups.
+    @Published private(set) var packs: [String: StickerPack] = [:]
+    private var packFetchedAt: [String: Date] = [:]
+
+    private let cache: StickerCache
+    private let relayQuery: RelayQuery
+    private let downloader: Downloader
+    private let networkActivationAllowed: @Sendable () async -> Bool
+    private let now: @Sendable () -> Date
+    private let metadataURL: URL?
+
+    init(
+        cache: StickerCache = StickerCache(),
+        relayQuery: @escaping RelayQuery = { filter in
+            await StickerRelayQuery.oneShot(filter: filter)
+        },
+        downloader: @escaping Downloader = StickerPackService.makeTorDownloader(),
+        networkActivationAllowed: @escaping @Sendable () async -> Bool = {
+            await NetworkActivationService.shared.activationAllowed
+        },
+        metadataURL: URL? = try? StickerStoragePaths.stickersDirectory()
+            .appendingPathComponent("pack-metadata.json", isDirectory: false),
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.cache = cache
+        self.relayQuery = relayQuery
+        self.downloader = downloader
+        self.networkActivationAllowed = networkActivationAllowed
+        self.metadataURL = metadataURL
+        self.now = now
+        loadMetadata()
+    }
+
+    // MARK: - Pack event parsing (pure, spec-validating)
+
+    /// Parses and fully validates a kind-30031 `sonar-sticker-pack-v1` event.
+    /// Any spec violation rejects the whole pack (returns nil).
+    nonisolated static func parsePackEvent(_ event: NostrEvent) -> StickerPack? {
+        guard event.kind == packEventKind else { return nil }
+        guard StickerRefValidation.isValidPubkeyHex(event.pubkey) else { return nil }
+        guard event.tags.contains(where: {
+            $0.count >= 2 && $0[0] == "pack_format" && $0[1] == packFormatValue
+        }) else { return nil }
+
+        guard let dTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "d" }),
+              StickerRefValidation.isValidPackIdentifier(dTag[1]) else { return nil }
+        let identifier = dTag[1]
+
+        guard let titleTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "title" }),
+              titleTag[1].utf8.count <= 256,
+              !titleTag[1].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+
+        let description = event.tags.first(where: { $0.count >= 2 && $0[0] == "description" })?[1]
+
+        var coverURL: URL? = nil
+        if let imageTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "image" }) {
+            guard let url = validatedHTTPSURL(imageTag[1]) else { return nil }
+            coverURL = url
+        }
+
+        let stickerTags = event.tags.filter { $0.count >= 2 && $0[0] == "sticker" }
+        guard (1...maxStickersPerPack).contains(stickerTags.count) else { return nil }
+
+        var seenShortcodes = Set<String>()
+        var seenHashes = Set<String>()
+        var stickers: [Sticker] = []
+        stickers.reserveCapacity(stickerTags.count)
+
+        for tag in stickerTags {
+            // ["sticker", shortcode, url, sha256, mime, dim?, alt?, emoji?]
+            guard tag.count >= 5 else { return nil }
+            let shortcode = tag[1]
+            let hash = tag[3]
+            let mime = tag[4]
+            guard StickerRefValidation.isValidShortcode(shortcode) else { return nil }
+            guard StickerRefValidation.isValidSha256(hash) else { return nil }
+            guard allowedMimes.contains(mime) else { return nil }
+            guard let url = validatedStickerURL(tag[2], sha256: hash) else { return nil }
+
+            var dim: StickerDimensions? = nil
+            if tag.count >= 6, !tag[5].isEmpty {
+                guard let parsed = parseDimensions(tag[5]) else { return nil }
+                dim = parsed
+            }
+            let alt = tag.count >= 7 ? tag[6] : nil
+            let emoji = tag.count >= 8 ? tag[7] : nil
+
+            guard seenShortcodes.insert(shortcode).inserted else { return nil }
+            guard seenHashes.insert(hash).inserted else { return nil }
+            stickers.append(Sticker(
+                shortcode: shortcode, url: url, sha256: hash,
+                mime: mime, dim: dim, alt: alt, emoji: emoji
+            ))
+        }
+
+        return StickerPack(
+            coordinate: "30031:\(event.pubkey):\(identifier)",
+            authorPubkey: event.pubkey,
+            identifier: identifier,
+            title: titleTag[1],
+            description: description,
+            coverURL: coverURL,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(event.created_at)),
+            stickers: stickers
+        )
+    }
+
+    /// HTTPS-only, no embedded credentials.
+    nonisolated static func validatedHTTPSURL(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              url.scheme?.lowercased() == "https",
+              url.host != nil,
+              url.user == nil, url.password == nil
+        else { return nil }
+        return url
+    }
+
+    /// Sticker asset URL: HTTPS-only and the path must contain the lowercase
+    /// sha256 (binds the URL to the pinned hash).
+    nonisolated static func validatedStickerURL(_ raw: String, sha256: String) -> URL? {
+        guard let url = validatedHTTPSURL(raw),
+              url.path.lowercased().contains(sha256)
+        else { return nil }
+        return url
+    }
+
+    /// `WxH` with both dimensions in 1...4096.
+    nonisolated static func parseDimensions(_ raw: String) -> StickerDimensions? {
+        let parts = raw.split(separator: "x", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let w = Int(parts[0]), let h = Int(parts[1]),
+              (1...maxImageDimension).contains(w),
+              (1...maxImageDimension).contains(h)
+        else { return nil }
+        return StickerDimensions(width: w, height: h)
+    }
+
+    // MARK: - Pack fetching
+
+    /// Fetches a pack by author + identifier, preferring the 24h metadata
+    /// cache. Relay queries are one-shot (EOSE-bounded, ~10s timeout) on the
+    /// built-in default relay set; the latest `created_at` wins.
+    func fetchPack(authorPubkeyHex: String, identifier: String) async throws -> StickerPack {
+        guard StickerRefValidation.isValidPubkeyHex(authorPubkeyHex),
+              StickerRefValidation.isValidPackIdentifier(identifier)
+        else { throw StickerPackError.invalidCoordinate }
+        let coordinate = "30031:\(authorPubkeyHex):\(identifier)"
+
+        if let cached = packs[coordinate],
+           let fetchedAt = packFetchedAt[coordinate],
+           now().timeIntervalSince(fetchedAt) < Self.metadataTTL {
+            return cached
+        }
+
+        // NOTE: NostrFilter.tagFilters is fileprivate, so a server-side "#d"
+        // filter cannot be expressed from this file. We query by kind+author
+        // and filter the identifier client-side. A follow-up could add a
+        // `NostrFilter.stickerPack(author:identifier:)` factory next to the
+        // other factories in NostrRelayManager.swift.
+        var filter = NostrFilter()
+        filter.kinds = [Self.packEventKind]
+        filter.authors = [authorPubkeyHex]
+        filter.limit = 20
+
+        let events = await relayQuery(filter)
+        let candidates = events
+            .compactMap(Self.parsePackEvent)
+            .filter { $0.authorPubkey == authorPubkeyHex && $0.identifier == identifier }
+        guard let latest = candidates.max(by: { $0.createdAt < $1.createdAt }) else {
+            throw StickerPackError.packNotFound
+        }
+
+        packs[coordinate] = latest
+        packFetchedAt[coordinate] = now()
+        persistMetadata()
+        return latest
+    }
+
+    /// Synchronous cache-only lookup for renderers — never queries the network.
+    func cachedPack(forCoordinate coordinate: String) -> StickerPack? {
+        packs[coordinate]
+    }
+
+    // MARK: - Image fetching
+
+    /// Returns sticker bytes from the disk cache when present; otherwise
+    /// downloads through the Tor-aware fail-closed pipeline (network-activation
+    /// gate → streamed 4 MiB cap → MIME sniff vs declared → CGImageSource
+    /// dimension check) and stores them in `StickerCache`, which re-verifies
+    /// the sha256 and applies negative-cache backoff to failures.
+    func imageData(for sticker: Sticker) async throws -> Data {
+        if let data = await cache.data(for: sticker.sha256) { return data }
+        return try await cache.fetch(
+            sha256: sticker.sha256,
+            url: sticker.url,
+            mime: sticker.mime
+        ) { [downloader, networkActivationAllowed] url in
+            guard await networkActivationAllowed() else {
+                throw StickerPackError.networkNotAllowed
+            }
+            let data = try await downloader(url)
+            try Self.validateDownloadedImage(data, declaredMime: sticker.mime)
+            return data
+        }
+    }
+
+    /// Pack-edit attack guard: a ref is only trustworthy when the CURRENT pack
+    /// still contains BOTH the shortcode and the pinned plaintext hash. When
+    /// this is false the caller must render an "untrusted sticker" placeholder.
+    nonisolated func validateStickerRef(
+        packCoordinate: String,
+        shortcode: String,
+        plaintextSha256: String,
+        against pack: StickerPack
+    ) -> Bool {
+        guard pack.coordinate == packCoordinate else { return false }
+        return pack.stickers.contains {
+            $0.shortcode == shortcode && $0.sha256 == plaintextSha256
+        }
+    }
+
+    // MARK: - Download validation
+
+    /// Size cap, MIME byte-sniff vs declared type (APNG sniffs as PNG — both
+    /// carry the PNG signature), and CGImageSource dimension check (≤4096²).
+    nonisolated static func validateDownloadedImage(_ data: Data, declaredMime: String) throws {
+        guard !data.isEmpty, data.count <= StickerCache.maxStickerBytes else {
+            throw StickerPackError.downloadTooLarge
+        }
+        let sniffOK: Bool
+        switch declaredMime {
+        case "image/webp": sniffOK = MimeType.webp.matches(data: data)
+        case "image/png", "image/apng": sniffOK = MimeType.png.matches(data: data)
+        case "image/gif": sniffOK = MimeType.gif.matches(data: data)
+        default: sniffOK = false
+        }
+        guard sniffOK else { throw StickerPackError.mimeMismatch }
+
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, options),
+              CGImageSourceGetType(source) != nil,
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = props[kCGImagePropertyPixelWidth] as? Int,
+              let height = props[kCGImagePropertyPixelHeight] as? Int,
+              width >= 1, height >= 1,
+              width <= maxImageDimension, height <= maxImageDimension
+        else { throw StickerPackError.invalidImageData }
+    }
+
+    /// Default downloader: all traffic through `TorURLSession.shared.session`,
+    /// fail-closed on the Tor preference (mirrors GeoRelayDirectory): when Tor
+    /// is wanted but not ready, the fetch is refused — never clearnet.
+    /// Content-Length is not trusted; bytes are counted as they arrive.
+    nonisolated static func makeTorDownloader() -> Downloader {
+        { url in
+            if NetworkActivationService.persistedTorPreference() {
+                guard await TorManager.shared.awaitReady() else {
+                    throw StickerPackError.torNotReady
+                }
+            }
+            let session = TorURLSession.shared.session
+            let (bytes, response) = try await session.bytes(from: url)
+            guard let http = response as? HTTPURLResponse,
+                  (200...299).contains(http.statusCode)
+            else { throw URLError(.badServerResponse) }
+            var data = Data()
+            for try await byte in bytes {
+                guard data.count < StickerCache.maxStickerBytes else {
+                    throw StickerPackError.downloadTooLarge
+                }
+                data.append(byte)
+            }
+            return data
+        }
+    }
+
+    // MARK: - Metadata persistence (24h TTL, small JSON sidecar)
+
+    private struct PersistedMetadata: Codable {
+        var packs: [String: StickerPack]
+        var fetchedAt: [String: Date]
+    }
+
+    private func persistMetadata() {
+        guard let metadataURL,
+              let data = try? JSONEncoder().encode(
+                  PersistedMetadata(packs: packs, fetchedAt: packFetchedAt)
+              ) else { return }
+        try? data.write(to: metadataURL, options: .atomic)
+    }
+
+    private func loadMetadata() {
+        guard let metadataURL,
+              let data = try? Data(contentsOf: metadataURL),
+              let decoded = try? JSONDecoder().decode(PersistedMetadata.self, from: data)
+        else { return }
+        let reference = now()
+        for (coordinate, fetchedAt) in decoded.fetchedAt
+        where reference.timeIntervalSince(fetchedAt) < Self.metadataTTL {
+            guard let pack = decoded.packs[coordinate] else { continue }
+            packs[coordinate] = pack
+            packFetchedAt[coordinate] = fetchedAt
+        }
+    }
+}

--- a/bitchat/Services/StickerPackService.swift
+++ b/bitchat/Services/StickerPackService.swift
@@ -11,44 +11,12 @@ import Foundation
 import ImageIO
 import Tor
 
-// MARK: - LOCAL STUB for StickerRefCodec validators
-//
-// `bitchat/Protocols/StickerRefCodec.swift` (owned by a parallel delegate) is
-// expected to provide `StickerRef` plus `StickerRefCodec.isValidCoordinate /
-// isValidShortcode / isValidSha256`. Until that file lands, the validator
-// shapes are stubbed here so the services layer compiles and stays testable.
-// A later pass should re-point these at the codec (or have the codec call
-// these) — do NOT duplicate them further.
-enum StickerRefValidation {
-    /// Strictly `[0-9a-f]{64}` — safe to use as a file name after this passes.
-    static func isValidSha256(_ value: String) -> Bool {
-        value.count == 64 && value.allSatisfy { $0.isHexDigit } && value == value.lowercased()
-    }
-
-    /// Nostr pubkey hex has the same shape as a sha256 hex string.
-    static func isValidPubkeyHex(_ value: String) -> Bool { isValidSha256(value) }
-
-    /// Shortcode: `[a-z0-9_-]{1,64}`.
-    static func isValidShortcode(_ value: String) -> Bool {
-        guard (1...64).contains(value.count) else { return false }
-        return value.allSatisfy { c in
-            c.isASCII && ((c.isLetter && c.isLowercase) || c.isNumber || c == "_" || c == "-")
-        }
-    }
-
-    /// `d` identifier: printable ASCII except whitespace, 1...256 chars.
-    static func isValidPackIdentifier(_ value: String) -> Bool {
-        guard (1...256).contains(value.count) else { return false }
-        return value.unicodeScalars.allSatisfy { (0x21...0x7E).contains($0.value) }
-    }
-
-    /// Pack coordinate: `30031:<author-pubkey-hex>:<d-identifier>`.
-    static func isValidCoordinate(_ value: String) -> Bool {
-        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
-        guard parts.count == 3, parts[0] == "30031" else { return false }
-        return isValidPubkeyHex(String(parts[1])) && isValidPackIdentifier(String(parts[2]))
-    }
-}
+// Validation of coordinates, shortcodes, and hashes lives in exactly one
+// place: `StickerRef` (bitchat/Protocols/StickerRefCodec.swift), the wire
+// codec. Pack parsing round-trips candidate values through the codec's
+// validators so the pack layer and the wire layer can never drift apart —
+// a pack is only installable when every sticker shortcode it declares can
+// actually be encoded into a wire reference.
 
 // MARK: - Models
 
@@ -111,12 +79,19 @@ private final class StickerOneShotQuery {
     private var events: [NostrEvent] = []
     private var continuation: CheckedContinuation<[NostrEvent], Never>?
     private var timeoutTask: Task<Void, Never>?
+    /// Deliberate self-retain. The relay handlers and the timeout task capture
+    /// `self` weakly, so without this the query would deallocate as soon as
+    /// the `withCheckedContinuation` closure in `oneShot` returns — and
+    /// neither EOSE nor the timeout could ever resume the continuation,
+    /// hanging every uncached pack lookup forever. Broken in `finish`.
+    private var selfRetain: StickerOneShotQuery?
 
     init(continuation: CheckedContinuation<[NostrEvent], Never>) {
         self.continuation = continuation
     }
 
     func start(filter: NostrFilter, timeout: TimeInterval) {
+        selfRetain = self
         let id = "sticker-oneshot-\(UUID().uuidString)"
         NostrRelayManager.shared.subscribe(
             filter: filter,
@@ -141,6 +116,7 @@ private final class StickerOneShotQuery {
         timeoutTask?.cancel()
         NostrRelayManager.shared.unsubscribe(id: id)
         continuation.resume(returning: events)
+        selfRetain = nil
     }
 }
 
@@ -166,6 +142,9 @@ final class StickerPackService: ObservableObject {
         /// Tor preference is on but Tor failed to become ready. Fail-closed:
         /// the fetch is refused rather than leaked to clearnet.
         case torNotReady
+        /// A recent fetch for this pack came up empty; exponential backoff
+        /// has not elapsed yet. In-memory only (a restart resets it).
+        case packFetchBackoff(retryAfter: Date)
         case downloadTooLarge
         case mimeMismatch
         case invalidImageData
@@ -183,6 +162,11 @@ final class StickerPackService: ObservableObject {
     /// Pack metadata keyed by coordinate, for synchronous render lookups.
     @Published private(set) var packs: [String: StickerPack] = [:]
     private var packFetchedAt: [String: Date] = [:]
+    /// Negative cache for pack fetches: coordinate → do-not-retry-until.
+    /// In-memory only (a restart simply resets backoff), mirroring
+    /// `StickerCache`'s failure policy.
+    private var packFailureCounts: [String: Int] = [:]
+    private var packNegativeCache: [String: Date] = [:]
 
     private let cache: StickerCache
     private let relayQuery: RelayQuery
@@ -219,14 +203,17 @@ final class StickerPackService: ObservableObject {
     /// Any spec violation rejects the whole pack (returns nil).
     nonisolated static func parsePackEvent(_ event: NostrEvent) -> StickerPack? {
         guard event.kind == packEventKind else { return nil }
-        guard StickerRefValidation.isValidPubkeyHex(event.pubkey) else { return nil }
+        guard StickerRef.isValidSha256(event.pubkey) else { return nil }
         guard event.tags.contains(where: {
             $0.count >= 2 && $0[0] == "pack_format" && $0[1] == packFormatValue
         }) else { return nil }
 
-        guard let dTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "d" }),
-              StickerRefValidation.isValidPackIdentifier(dTag[1]) else { return nil }
+        guard let dTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "d" }) else { return nil }
         let identifier = dTag[1]
+        let coordinate = "30031:\(event.pubkey):\(identifier)"
+        // Round-trip through the wire codec: a pack is only valid when its
+        // coordinate is exactly one a StickerRef can express.
+        guard StickerRef.isValidCoordinate(coordinate) else { return nil }
 
         guard let titleTag = event.tags.first(where: { $0.count >= 2 && $0[0] == "title" }),
               titleTag[1].utf8.count <= 256,
@@ -255,8 +242,8 @@ final class StickerPackService: ObservableObject {
             let shortcode = tag[1]
             let hash = tag[3]
             let mime = tag[4]
-            guard StickerRefValidation.isValidShortcode(shortcode) else { return nil }
-            guard StickerRefValidation.isValidSha256(hash) else { return nil }
+            guard StickerRef.isValidShortcode(shortcode) else { return nil }
+            guard StickerRef.isValidSha256(hash) else { return nil }
             guard allowedMimes.contains(mime) else { return nil }
             guard let url = validatedStickerURL(tag[2], sha256: hash) else { return nil }
 
@@ -277,7 +264,7 @@ final class StickerPackService: ObservableObject {
         }
 
         return StickerPack(
-            coordinate: "30031:\(event.pubkey):\(identifier)",
+            coordinate: coordinate,
             authorPubkey: event.pubkey,
             identifier: identifier,
             title: titleTag[1],
@@ -322,17 +309,24 @@ final class StickerPackService: ObservableObject {
 
     /// Fetches a pack by author + identifier, preferring the 24h metadata
     /// cache. Relay queries are one-shot (EOSE-bounded, ~10s timeout) on the
-    /// built-in default relay set; the latest `created_at` wins.
+    /// built-in default relay set; the latest `created_at` wins. Misses are
+    /// negative-cached with exponential backoff (30s → 30min, in-memory) so a
+    /// missing/dead pack is not re-queried on every render — each retry would
+    /// be a repeat read beacon to the relays.
     func fetchPack(authorPubkeyHex: String, identifier: String) async throws -> StickerPack {
-        guard StickerRefValidation.isValidPubkeyHex(authorPubkeyHex),
-              StickerRefValidation.isValidPackIdentifier(identifier)
-        else { throw StickerPackError.invalidCoordinate }
         let coordinate = "30031:\(authorPubkeyHex):\(identifier)"
+        // Round-trip through the wire codec (see parsePackEvent).
+        guard StickerRef.isValidCoordinate(coordinate)
+        else { throw StickerPackError.invalidCoordinate }
 
         if let cached = packs[coordinate],
            let fetchedAt = packFetchedAt[coordinate],
            now().timeIntervalSince(fetchedAt) < Self.metadataTTL {
             return cached
+        }
+
+        if let retryAfter = packNegativeCache[coordinate], now() < retryAfter {
+            throw StickerPackError.packFetchBackoff(retryAfter: retryAfter)
         }
 
         // NOTE: NostrFilter.tagFilters is fileprivate, so a server-side "#d"
@@ -350,13 +344,28 @@ final class StickerPackService: ObservableObject {
             .compactMap(Self.parsePackEvent)
             .filter { $0.authorPubkey == authorPubkeyHex && $0.identifier == identifier }
         guard let latest = candidates.max(by: { $0.createdAt < $1.createdAt }) else {
+            recordPackFailure(for: coordinate)
             throw StickerPackError.packNotFound
         }
 
         packs[coordinate] = latest
         packFetchedAt[coordinate] = now()
+        packFailureCounts.removeValue(forKey: coordinate)
+        packNegativeCache.removeValue(forKey: coordinate)
         persistMetadata()
         return latest
+    }
+
+    /// In-memory exponential backoff for failed pack fetches (30s initial,
+    /// doubling, capped at 30min — same policy as `StickerCache`).
+    private func recordPackFailure(for coordinate: String) {
+        let count = (packFailureCounts[coordinate] ?? 0) + 1
+        packFailureCounts[coordinate] = count
+        let delay = min(
+            StickerCache.negativeCacheInitialDelay * pow(2.0, Double(count - 1)),
+            StickerCache.negativeCacheMaxDelay
+        )
+        packNegativeCache[coordinate] = now().addingTimeInterval(delay)
     }
 
     /// Synchronous cache-only lookup for renderers — never queries the network.

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -98,6 +98,9 @@ enum TransportConfig {
     // Reject oversized/untrusted relay frames before JSON parse / store.
     static let nostrMaxInboundMessageBytes: Int = 256 * 1024
     static let nostrMaxEventTags: Int = 64
+    // Sonar sticker packs can carry up to 200 stickers (1 tag each) plus
+    // metadata, so kind 30031/10031 events get a higher inbound tag cap.
+    static let nostrMaxStickerPackEventTags: Int = 220
     static let nostrMaxEventTagValues: Int = 16
     static let nostrMaxEventTagValueBytes: Int = 1024
     // Bounded per-relay inbound frame buffer. Each relay connection owns its

--- a/bitchat/ViewModels/Extensions/ChatViewModel+Stickers.swift
+++ b/bitchat/ViewModels/Extensions/ChatViewModel+Stickers.swift
@@ -1,0 +1,63 @@
+// ChatViewModel+Stickers.swift
+// bitchat
+//
+// Sonar sticker send support for ChatViewModel.
+
+import BitFoundation
+import BitLogger
+import Foundation
+
+/// Sonar sticker send + service accessors for `ChatViewModel`.
+///
+/// A sticker is an ordinary text message whose content is the `StickerRef`
+/// wire string (`␟sticker␟<coordinate>␟<shortcode>␟<sha256>`). It rides the
+/// same private/public router as plain text, so sending only needs to build
+/// the validated ref and hand its `.content` to `sendMessage(_:)` — the
+/// existing dispatch (selected DM peer vs active public/geohash channel)
+/// decides exactly where it lands, identical to typing the message.
+extension ChatViewModel {
+
+    /// Shared pack metadata + image resolver (see `StickerPackService`).
+    var stickerPackService: StickerPackService { .shared }
+
+    /// Installed-pack list + opt-in Nostr sync (kind 10031).
+    ///
+    /// `StickerInstallStore` persists its installed list and `syncEnabled`
+    /// flag to `UserDefaults.standard` and a deterministic file under
+    /// Application Support, so every instance observes the same state. A
+    /// Swift extension cannot add a stored property, so this returns a fresh
+    /// instance per access — actor construction is cheap (it reads one JSON
+    /// sidecar) and the persisted state is shared. This keeps `AppRuntime`
+    /// wiring untouched, since the store works with no constructor args
+    /// (it builds its own `NostrIdentityBridge` internally).
+    var stickerInstallStore: StickerInstallStore { StickerInstallStore() }
+
+    /// Sends a sticker reference as an ordinary message in the current
+    /// conversation (selected private peer, public mesh, or geohash channel).
+    ///
+    /// Routing reuses `sendMessage(_:)`, which already dispatches to the
+    /// selected private peer or the active public channel — exactly the
+    /// conversation the picker was presented in. `peerID` is accepted for API
+    /// clarity; the actual target matches where a plain text send would land,
+    /// which is how existing sends (private and public) already work.
+    @MainActor
+    func sendSticker(
+        packCoordinate: String,
+        shortcode: String,
+        plaintextSha256: String,
+        to peerID: PeerID?
+    ) {
+        guard let ref = StickerRef(
+            packCoordinate: packCoordinate,
+            shortcode: shortcode,
+            plaintextSha256: plaintextSha256
+        ) else {
+            SecureLogger.warning(
+                "Sticker send rejected: invalid ref fields",
+                category: .session
+            )
+            return
+        }
+        sendMessage(ref.content)
+    }
+}

--- a/bitchat/ViewModels/Extensions/ChatViewModel+Stickers.swift
+++ b/bitchat/ViewModels/Extensions/ChatViewModel+Stickers.swift
@@ -30,7 +30,7 @@ extension ChatViewModel {
     /// sidecar) and the persisted state is shared. This keeps `AppRuntime`
     /// wiring untouched, since the store works with no constructor args
     /// (it builds its own `NostrIdentityBridge` internally).
-    var stickerInstallStore: StickerInstallStore { StickerInstallStore() }
+    var stickerInstallStore: StickerInstallStore { StickerInstallStore.shared }
 
     /// Sends a sticker reference as an ordinary message in the current
     /// conversation (selected private peer, public mesh, or geohash channel).

--- a/bitchat/Views/ContentComposerView.swift
+++ b/bitchat/Views/ContentComposerView.swift
@@ -25,6 +25,11 @@ struct ContentComposerView: View {
     @Binding var showMacImagePicker: Bool
     #endif
 
+    /// When non-nil the composer shows a sticker button that opens the Sonar
+    /// sticker picker. Optional (nil) so the DM composer in ContentSheetViews
+    /// compiles unchanged; the public composer passes this closure.
+    var onShowStickerPicker: (() -> Void)? = nil
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             if conversationUIModel.showAutocomplete && !conversationUIModel.autocompleteSuggestions.isEmpty {
@@ -103,6 +108,9 @@ struct ContentComposerView: View {
 
                     if conversationUIModel.canSendMediaInCurrentContext {
                         attachmentButton
+                        if onShowStickerPicker != nil {
+                            stickerButton
+                        }
                     }
 
                     sendOrMicButton
@@ -267,6 +275,19 @@ private extension ContentComposerView {
             String(localized: "content.accessibility.choose_photo", comment: "Accessibility label for the macOS photo picker button")
         )
         #endif
+    }
+
+    var stickerButton: some View {
+        Button(action: { onShowStickerPicker?() }) {
+            Image(systemName: "face.smiling")
+                .font(.bitchatSystem(size: 22))
+                .foregroundColor(composerAccentColor)
+                .frame(width: 36, height: 36)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+            String(localized: "content.accessibility.open_sticker_picker", comment: "Accessibility label for the sticker picker button in the composer")
+        )
     }
 
     @ViewBuilder

--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -427,6 +427,7 @@ private extension ContentPeopleListView {
 
 private struct ContentPrivateChatSheetView: View {
     @EnvironmentObject private var privateConversationModel: PrivateConversationModel
+    @EnvironmentObject private var conversationUIModel: ConversationUIModel
 
     @Binding var showSidebar: Bool
     @Binding var messageText: String
@@ -441,6 +442,7 @@ private struct ContentPrivateChatSheetView: View {
     @Binding var autocompleteDebounceTimer: Timer?
     @Environment(\.appTheme) private var theme
     @ThemedPalette private var palette
+    @State private var showStickerPicker = false
 
     let headerHeight: CGFloat
     let onSendMessage: () -> Void
@@ -553,7 +555,8 @@ private struct ContentPrivateChatSheetView: View {
                 autocompleteDebounceTimer: $autocompleteDebounceTimer,
                 onSendMessage: onSendMessage,
                 showImagePicker: $showImagePicker,
-                imagePickerSourceType: $imagePickerSourceType
+                imagePickerSourceType: $imagePickerSourceType,
+                onShowStickerPicker: { showStickerPicker = true }
             )
             #else
             ContentComposerView(
@@ -562,9 +565,18 @@ private struct ContentPrivateChatSheetView: View {
                 voiceRecordingVM: voiceRecordingVM,
                 autocompleteDebounceTimer: $autocompleteDebounceTimer,
                 onSendMessage: onSendMessage,
-                showMacImagePicker: $showMacImagePicker
+                showMacImagePicker: $showMacImagePicker,
+                onShowStickerPicker: { showStickerPicker = true }
             )
             #endif
+        }
+        .sheet(isPresented: $showStickerPicker) {
+            // conversationUIModel routes to the selected private peer while
+            // this sheet is up, exactly like the public composer's picker.
+            StickerPickerSheet { ref in
+                showStickerPicker = false
+                conversationUIModel.sendMessage(ref.content)
+            }
         }
         .themedSheetBackground()
         .foregroundColor(palette.primary)

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -114,6 +114,7 @@ struct ContentView: View {
     #else
     @State private var showMacImagePicker = false
     #endif
+    @State private var showStickerPicker = false
     @ScaledMetric(relativeTo: .body) private var headerHeight: CGFloat = 44
     @ScaledMetric(relativeTo: .subheadline) private var headerPeerIconSize: CGFloat = 11
     @ScaledMetric(relativeTo: .subheadline) private var headerPeerCountFontSize: CGFloat = 12
@@ -375,6 +376,12 @@ struct ContentView: View {
                 ImagePreviewView(url: url)
             }
         }
+        .sheet(isPresented: $showStickerPicker) {
+            StickerPickerSheet { ref in
+                showStickerPicker = false
+                conversationUIModel.sendMessage(ref.content)
+            }
+        }
         .alert("Recording Error", isPresented: rootVoiceAlertBinding, actions: {
             Button("common.ok", role: .cancel) {}
             if voiceRecordingVM.state == .permissionDenied {
@@ -501,7 +508,8 @@ struct ContentView: View {
             autocompleteDebounceTimer: $autocompleteDebounceTimer,
             onSendMessage: sendMessage,
             showImagePicker: $showImagePicker,
-            imagePickerSourceType: $imagePickerSourceType
+            imagePickerSourceType: $imagePickerSourceType,
+            onShowStickerPicker: { showStickerPicker = true }
         )
         #else
         ContentComposerView(
@@ -510,7 +518,8 @@ struct ContentView: View {
             voiceRecordingVM: voiceRecordingVM,
             autocompleteDebounceTimer: $autocompleteDebounceTimer,
             onSendMessage: sendMessage,
-            showMacImagePicker: $showMacImagePicker
+            showMacImagePicker: $showMacImagePicker,
+            onShowStickerPicker: { showStickerPicker = true }
         )
         #endif
     }

--- a/bitchat/Views/Media/StickerMessageView.swift
+++ b/bitchat/Views/Media/StickerMessageView.swift
@@ -19,6 +19,11 @@ struct StickerMessageView: View {
 
     enum LoadState: Equatable {
         case loading, ready(Data), missing, untrusted
+        /// Pack is not installed and was never consented to: render a
+        /// placeholder and fetch only on explicit tap (privacy — an on-render
+        /// fetch of an uninstalled pack is a read beacon that tells the
+        /// sender/relays/Blossom host exactly when the message was viewed).
+        case needsConsent
     }
     @State private var loadState: LoadState = .loading
 
@@ -36,7 +41,14 @@ struct StickerMessageView: View {
             content(for: loadState)
                 .frame(maxWidth: stickerSize, maxHeight: stickerSize)
                 .onTapGesture {
-                    if loadState == .missing || loadState == .untrusted { Task { await resolve() } }
+                    switch loadState {
+                    case .needsConsent, .missing:
+                        Task { await resolve(userConsented: true) }
+                    case .untrusted:
+                        Task { await resolve() }
+                    case .loading, .ready:
+                        break
+                    }
                 }
         }
         .frame(maxWidth: .infinity, alignment: isFromMe ? .trailing : .leading)
@@ -48,6 +60,8 @@ struct StickerMessageView: View {
         switch state {
         case .loading:
             placeholder(symbol: "sparkles", tint: palette.secondary)
+        case .needsConsent:
+            placeholder(symbol: "arrow.down.circle", tint: palette.secondary)
         case .missing:
             placeholder(symbol: "photo", tint: palette.secondary)
         case .untrusted:
@@ -88,7 +102,7 @@ struct StickerMessageView: View {
     }
     #endif
 
-    private func resolve() async {
+    private func resolve(userConsented: Bool = false) async {
         guard let ref = StickerRefCodec.parse(message.content) else {
             loadState = .missing
             return
@@ -96,6 +110,18 @@ struct StickerMessageView: View {
         let service = StickerPackService.shared
         var pack = service.cachedPack(forCoordinate: ref.packCoordinate)
         if pack == nil {
+            // Privacy gate: fetching an UNINSTALLED pack on render is the
+            // app's first inbound-message-triggers-network path — a read
+            // beacon that leaks view timing (and, in DMs, conversation
+            // metadata) to relays and Blossom hosts. Installed packs (user
+            // opted in) resolve automatically; anything else requires an
+            // explicit tap.
+            let isInstalled = await StickerInstallStore.shared.installedPacks()
+                .contains(ref.packCoordinate)
+            guard isInstalled || userConsented else {
+                loadState = .needsConsent
+                return
+            }
             let parts = ref.packCoordinate.split(separator: ":", omittingEmptySubsequences: false)
             if parts.count == 3 {
                 pack = try? await service.fetchPack(authorPubkeyHex: String(parts[1]), identifier: String(parts[2]))

--- a/bitchat/Views/Media/StickerMessageView.swift
+++ b/bitchat/Views/Media/StickerMessageView.swift
@@ -1,0 +1,122 @@
+//
+//  StickerMessageView.swift
+//  bitchat
+//
+//  Renders a Sonar sticker message row. A sticker is an ordinary chat message
+//  whose content is the StickerRef wire string; this view resolves the
+//  referenced pack + image bytes (Tor-routed, disk-cached by StickerPackService)
+//  and degrades to a clean placeholder when offline or unresolvable.
+//
+
+import SwiftUI
+import BitFoundation
+
+struct StickerMessageView: View {
+    @EnvironmentObject private var conversationUIModel: ConversationUIModel
+    @Environment(\.appTheme) private var theme
+    @ThemedPalette private var palette
+    let message: BitchatMessage
+
+    enum LoadState: Equatable {
+        case loading, ready(Data), missing, untrusted
+    }
+    @State private var loadState: LoadState = .loading
+
+    private let stickerSize: CGFloat = 160
+
+    var body: some View {
+        let isFromMe = conversationUIModel.isMediaMessageFromCurrentUser(message)
+        HStack(alignment: .bottom, spacing: 4) {
+            if message.isPrivate {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 8))
+                    .foregroundColor(palette.secondary.opacity(0.6))
+                    .padding(.bottom, 4)
+            }
+            content(for: loadState)
+                .frame(maxWidth: stickerSize, maxHeight: stickerSize)
+                .onTapGesture {
+                    if loadState == .missing || loadState == .untrusted { Task { await resolve() } }
+                }
+        }
+        .frame(maxWidth: .infinity, alignment: isFromMe ? .trailing : .leading)
+        .task(id: message.id) { await resolve() }
+    }
+
+    @ViewBuilder
+    private func content(for state: LoadState) -> some View {
+        switch state {
+        case .loading:
+            placeholder(symbol: "sparkles", tint: palette.secondary)
+        case .missing:
+            placeholder(symbol: "photo", tint: palette.secondary)
+        case .untrusted:
+            placeholder(symbol: "exclamationmark.triangle", tint: palette.alertRed)
+        case .ready(let data):
+            stickerImage(data)
+        }
+    }
+
+    private func placeholder(symbol: String, tint: Color) -> some View {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(palette.secondary.opacity(0.12))
+            .overlay(
+                Image(systemName: symbol)
+                    .font(.system(size: 28))
+                    .foregroundColor(tint.opacity(0.7))
+            )
+    }
+
+    @ViewBuilder
+    private func stickerImage(_ data: Data) -> some View {
+        if let img = Self.platformImage(data) {
+            img.resizable()
+                .scaledToFit()
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        } else {
+            placeholder(symbol: "photo", tint: palette.secondary)
+        }
+    }
+
+    #if os(iOS)
+    private static func platformImage(_ data: Data) -> Image? {
+        UIImage(data: data).map { Image(uiImage: $0) }
+    }
+    #else
+    private static func platformImage(_ data: Data) -> Image? {
+        NSImage(data: data).map { Image(nsImage: $0) }
+    }
+    #endif
+
+    private func resolve() async {
+        guard let ref = StickerRefCodec.parse(message.content) else {
+            loadState = .missing
+            return
+        }
+        let service = StickerPackService.shared
+        var pack = service.cachedPack(forCoordinate: ref.packCoordinate)
+        if pack == nil {
+            let parts = ref.packCoordinate.split(separator: ":", omittingEmptySubsequences: false)
+            if parts.count == 3 {
+                pack = try? await service.fetchPack(authorPubkeyHex: String(parts[1]), identifier: String(parts[2]))
+            }
+        }
+        guard let pack else { loadState = .missing; return }
+        guard service.validateStickerRef(
+            packCoordinate: ref.packCoordinate,
+            shortcode: ref.shortcode,
+            plaintextSha256: ref.plaintextSha256,
+            against: pack
+        ) else { loadState = .untrusted; return }
+        guard let sticker = pack.stickers.first(where: { $0.shortcode == ref.shortcode }) else {
+            loadState = .untrusted
+            return
+        }
+        do {
+            let bytes = try await service.imageData(for: sticker)
+            loadState = .ready(bytes)
+        } catch {
+            loadState = .missing
+        }
+    }
+}

--- a/bitchat/Views/MessageListView.swift
+++ b/bitchat/Views/MessageListView.swift
@@ -500,6 +500,8 @@ private extension MessageListView {
                 systemMessageRow(message)
             } else if let media = conversationUIModel.mediaAttachment(for: message) {
                 MediaMessageView(message: message, media: media, imagePreviewURL: $imagePreviewURL)
+            } else if StickerRefCodec.parse(message.content) != nil {
+                StickerMessageView(message: message)
             } else {
                 TextMessageView(message: message)
             }

--- a/bitchat/Views/StickerPickerSheet.swift
+++ b/bitchat/Views/StickerPickerSheet.swift
@@ -29,7 +29,7 @@ struct StickerPickerSheet: View {
 
     /// New instances share persisted state (UserDefaults + deterministic
     /// file), so this is consistent with the store held by `ChatViewModel`.
-    private let installStore = StickerInstallStore()
+    private let installStore = StickerInstallStore.shared
     private let packService = StickerPackService.shared
 
     @State private var installedPacks: [StickerPack] = []
@@ -256,6 +256,16 @@ struct StickerPickerSheet: View {
                         newValue,
                         forKey: StickerInstallStore.syncEnabledDefaultsKey
                     )
+                    if newValue {
+                        // Enabling sync must actually synchronize: import the
+                        // remote list (so a second device's packs arrive),
+                        // then publish the merged local list. Failures are
+                        // logged inside the store; the toggle stays on.
+                        Task {
+                            try? await installStore.mergeInstalledFromNetwork()
+                            try? await installStore.publishInstalledList()
+                        }
+                    }
                 }
             )) {
                 Text(String(localized: "sticker.sync.title", comment: "Toggle label for syncing installed sticker packs to Nostr"))

--- a/bitchat/Views/StickerPickerSheet.swift
+++ b/bitchat/Views/StickerPickerSheet.swift
@@ -1,0 +1,355 @@
+// StickerPickerSheet.swift
+// bitchat
+//
+// Sonar sticker picker: browse installed packs, install new ones by
+// coordinate, and opt in to Nostr list sync.
+
+import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+/// Sonar sticker picker sheet.
+///
+/// Shows installed packs as a thumbnail grid (load each pack's images off the
+/// main actor via `StickerPackService`), lets the user paste a pack
+/// coordinate (`30031:<pubkey>:<identifier>`) to install a new one, and
+/// exposes the opt-in "sync installed packs to Nostr" toggle with a privacy
+/// warning. Picking a sticker invokes `onPick` with the validated `StickerRef`
+/// and dismisses.
+struct StickerPickerSheet: View {
+    /// Called with the picked sticker's wire-format ref; the sheet dismisses
+    /// itself immediately after.
+    let onPick: (StickerRef) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @ThemedPalette private var palette
+
+    /// New instances share persisted state (UserDefaults + deterministic
+    /// file), so this is consistent with the store held by `ChatViewModel`.
+    private let installStore = StickerInstallStore()
+    private let packService = StickerPackService.shared
+
+    @State private var installedPacks: [StickerPack] = []
+    @State private var selectedIndex: Int = 0
+    @State private var imageDataCache: [String: Data] = [:]
+
+    @State private var installInput: String = ""
+    @State private var installPhase: InstallPhase = .idle
+
+    /// Mirrors `StickerInstallStore.syncEnabled` (a UserDefaults flag) so the
+    /// toggle binds synchronously; the store reads the same key.
+    @State private var syncEnabled: Bool = UserDefaults.standard
+        .object(forKey: StickerInstallStore.syncEnabledDefaultsKey) as? Bool ?? false
+
+    private enum InstallPhase: Equatable {
+        case idle
+        case loading
+        case error(String)
+    }
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 4)
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                header
+                Divider()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        installedSection
+                        installSection
+                        syncSection
+                    }
+                    .padding(16)
+                }
+            }
+            #if os(macOS)
+            .frame(minWidth: 420, minHeight: 480)
+            #endif
+        }
+        #if os(iOS)
+        .navigationViewStyle(.stack)
+        #endif
+        .task { await refreshInstalled() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text(String(localized: "sticker.picker.title", comment: "Title of the sticker picker sheet"))
+                .bitchatFont(size: 18)
+            Spacer()
+            SheetCloseButton { dismiss() }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Installed packs
+
+    private var installedSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "sticker.picker.section.installed", comment: "Section heading for the installed sticker packs"))
+                .bitchatFont(size: 13, weight: .semibold)
+                .foregroundColor(palette.secondary)
+
+            if installedPacks.isEmpty {
+                Text(String(localized: "sticker.picker.empty", comment: "Shown when no sticker packs are installed yet"))
+                    .bitchatFont(size: 12)
+                    .foregroundColor(palette.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 24)
+            } else {
+                packTabs
+                if installedPacks.indices.contains(selectedIndex) {
+                    stickerGrid(for: installedPacks[selectedIndex])
+                }
+            }
+        }
+    }
+
+    private var packTabs: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Array(installedPacks.enumerated()), id: \.element.id) { index, pack in
+                    Button {
+                        selectedIndex = index
+                    } label: {
+                        Text(pack.title)
+                            .bitchatFont(
+                                size: 12,
+                                weight: selectedIndex == index ? .semibold : .regular
+                            )
+                            .foregroundColor(selectedIndex == index ? palette.primary : palette.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(
+                                        selectedIndex == index
+                                            ? palette.accent.opacity(0.18)
+                                            : palette.background.opacity(0.4)
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func stickerGrid(for pack: StickerPack) -> some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(pack.stickers) { sticker in
+                stickerCell(sticker, pack: pack)
+            }
+        }
+    }
+
+    private func stickerCell(_ sticker: Sticker, pack: StickerPack) -> some View {
+        Button {
+            guard let ref = StickerRef(
+                packCoordinate: pack.coordinate,
+                shortcode: sticker.shortcode,
+                plaintextSha256: sticker.sha256
+            ) else { return }
+            onPick(ref)
+            dismiss()
+        } label: {
+            Group {
+                if let data = imageDataCache[sticker.sha256],
+                   let image = StickerPickerSheet.platformImage(from: data) {
+                    image.resizable().scaledToFit()
+                } else {
+                    ProgressView().scaleEffect(0.8)
+                }
+            }
+            .frame(width: 64, height: 64)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(palette.background.opacity(0.3))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(sticker.emoji ?? sticker.shortcode)
+        .accessibilityHint(
+            String(localized: "sticker.accessibility.send", comment: "Accessibility hint for tapping a sticker to send it")
+        )
+        .task(id: sticker.sha256) {
+            await loadImage(for: sticker)
+        }
+    }
+
+    // MARK: - Install a pack
+
+    private var installSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "sticker.install.title", comment: "Section heading for installing a new sticker pack"))
+                .bitchatFont(size: 13, weight: .semibold)
+                .foregroundColor(palette.secondary)
+
+            HStack(spacing: 8) {
+                TextField(
+                    String(localized: "sticker.install.placeholder", comment: "Placeholder for the pack coordinate input field"),
+                    text: $installInput
+                )
+                .textFieldStyle(.plain)
+                .bitchatFont(size: 12)
+                .foregroundColor(palette.primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(palette.secondary.opacity(0.3))
+                )
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                #endif
+
+                Button(action: { Task { await installPack() } }) {
+                    Text(String(localized: "sticker.install.button", comment: "Button that installs the pasted sticker pack"))
+                        .bitchatFont(size: 12, weight: .medium)
+                }
+                .disabled(
+                    installPhase == .loading
+                        || installInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+            }
+
+            switch installPhase {
+            case .idle:
+                EmptyView()
+            case .loading:
+                HStack(spacing: 6) {
+                    ProgressView().scaleEffect(0.7)
+                    Text(String(localized: "sticker.install.loading", comment: "Status shown while a pack is being fetched"))
+                        .bitchatFont(size: 11)
+                        .foregroundColor(palette.secondary)
+                }
+            case .error(let message):
+                Text(message)
+                    .bitchatFont(size: 11)
+                    .foregroundColor(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Nostr sync
+
+    private var syncSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: Binding(
+                get: { syncEnabled },
+                set: { newValue in
+                    syncEnabled = newValue
+                    // Mirror the store's UserDefaults-backed flag directly;
+                    // the store reads this same key when deciding to publish.
+                    UserDefaults.standard.set(
+                        newValue,
+                        forKey: StickerInstallStore.syncEnabledDefaultsKey
+                    )
+                }
+            )) {
+                Text(String(localized: "sticker.sync.title", comment: "Toggle label for syncing installed sticker packs to Nostr"))
+                    .bitchatFont(size: 13, weight: .medium)
+                    .foregroundColor(palette.primary)
+            }
+            .toggleStyle(.switch)
+
+            Text(String(localized: "sticker.sync.warning", comment: "Privacy warning explaining that Nostr sync publishes installed packs under the persistent identity"))
+                .bitchatFont(size: 11)
+                .foregroundColor(palette.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(palette.background.opacity(0.3))
+        )
+    }
+
+    // MARK: - Actions
+
+    private func refreshInstalled() async {
+        let coordinates = await installStore.installedPacks()
+        var packs: [StickerPack] = []
+        for coordinate in coordinates {
+            if let cached = packService.cachedPack(forCoordinate: coordinate) {
+                packs.append(cached)
+                continue
+            }
+            let parts = coordinate.split(separator: ":", omittingEmptySubsequences: false)
+            guard parts.count == 3 else { continue }
+            let author = String(parts[1])
+            let identifier = String(parts[2])
+            if let pack = try? await packService.fetchPack(
+                authorPubkeyHex: author,
+                identifier: identifier
+            ) {
+                packs.append(pack)
+            }
+        }
+        installedPacks = packs
+        if !installedPacks.indices.contains(selectedIndex) {
+            selectedIndex = 0
+        }
+    }
+
+    private func installPack() async {
+        let trimmed = installInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard StickerRef.isValidCoordinate(trimmed) else {
+            installPhase = .error(
+                String(localized: "sticker.install.error.invalid", comment: "Error shown when a pasted pack coordinate is malformed")
+            )
+            return
+        }
+        installPhase = .loading
+        let parts = trimmed.split(separator: ":", omittingEmptySubsequences: false)
+        let author = String(parts[1])
+        let identifier = String(parts[2])
+        do {
+            // Fetch first so an invalid/unreachable coordinate fails before we
+            // record an install the user can't render.
+            _ = try await packService.fetchPack(authorPubkeyHex: author, identifier: identifier)
+            try await installStore.install(trimmed)
+            installInput = ""
+            installPhase = .idle
+            await refreshInstalled()
+        } catch {
+            installPhase = .error(
+                String(localized: "sticker.install.error.failed", comment: "Error shown when a pack could not be fetched or installed")
+            )
+        }
+    }
+
+    private func loadImage(for sticker: Sticker) async {
+        guard imageDataCache[sticker.sha256] == nil else { return }
+        if let data = try? await packService.imageData(for: sticker) {
+            imageDataCache[sticker.sha256] = data
+        }
+    }
+}
+
+// MARK: - Cross-platform image bridging
+
+#if os(iOS)
+private extension StickerPickerSheet {
+    static func platformImage(from data: Data) -> Image? {
+        UIImage(data: data).map { Image(uiImage: $0) }
+    }
+}
+#elseif os(macOS)
+private extension StickerPickerSheet {
+    static func platformImage(from data: Data) -> Image? {
+        NSImage(data: data).map { Image(nsImage: $0) }
+    }
+}
+#endif

--- a/bitchatTests/Protocols/StickerRefCodecTests.swift
+++ b/bitchatTests/Protocols/StickerRefCodecTests.swift
@@ -1,0 +1,148 @@
+//
+// StickerRefCodecTests.swift
+// bitchatTests
+//
+// Tests for the Sonar sticker-ref wire codec: round-trip, sonar-ffi parity
+// vectors, strict shape rejection, and adversarial (separator-only / huge /
+// emoji) input. The codec parses attacker-controlled mesh content, so
+// "never crash" matters as much as "parse correctly".
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+struct StickerRefCodecTests {
+
+    // MARK: - Builders
+
+    private let pubkey = String(repeating: "ab", count: 32) // 64 lowercase hex
+    private let sha256 = String(repeating: "deadbeef", count: 8) // 64 lowercase hex
+
+    private func makeRef(
+        coordinate: String? = nil,
+        shortcode: String = "wave",
+        hash: String? = nil
+    ) -> StickerRef? {
+        StickerRef(
+            packCoordinate: coordinate ?? "30031:\(pubkey):my-pack",
+            shortcode: shortcode,
+            plaintextSha256: hash ?? sha256
+        )
+    }
+
+    // MARK: - Round trip
+
+    @Test func encodeParseRoundTrip() {
+        let ref = makeRef()
+        #expect(ref != nil)
+        let parsed = StickerRefCodec.parse(StickerRefCodec.encode(ref!))
+        #expect(parsed == ref)
+        #expect(ref!.content == StickerRefCodec.encode(ref!))
+    }
+
+    // MARK: - sonar-ffi parity vectors
+
+    @Test func encodeMatchesSonarFfiBytes() {
+        // mesh_sticker_content output must be byte-identical.
+        let ref = makeRef()!
+        let expected = "\u{1F}sticker\u{1F}30031:\(pubkey):my-pack\u{1F}wave\u{1F}\(sha256)"
+        #expect(StickerRefCodec.encode(ref) == expected)
+        #expect(StickerRefCodec.encode(ref).hasPrefix("\u{1F}sticker\u{1F}"))
+    }
+
+    @Test func parseAcceptsSonarFfiEncodedContent() {
+        // Hand-built exactly as mesh_parse_sticker_content would see it.
+        let wire = "\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}wave\u{1F}\(sha256)"
+        let ref = StickerRefCodec.parse(wire)
+        #expect(ref == makeRef(coordinate: "30031:\(pubkey):pack"))
+    }
+
+    // MARK: - Not a sticker at all
+
+    @Test func rejectsNonStickerContent() {
+        #expect(StickerRefCodec.parse("hello world") == nil)
+        #expect(StickerRefCodec.parse("") == nil)
+        #expect(StickerRefCodec.parse("sticker:fake") == nil)
+        // "sticker" tag without the leading Unit Separator sentinel.
+        #expect(StickerRefCodec.parse("sticker\u{1F}30031:\(pubkey):pack\u{1F}wave\u{1F}\(sha256)") == nil)
+        // Right tag, wrong sentinel position.
+        #expect(StickerRefCodec.parse("x\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}wave\u{1F}\(sha256)") == nil)
+    }
+
+    // MARK: - Coordinate validation
+
+    @Test func rejectsBadCoordinates() {
+        func ref(with coordinate: String) -> StickerRef? { makeRef(coordinate: coordinate) }
+
+        #expect(ref(with: "30032:\(pubkey):pack") == nil)              // wrong kind
+        #expect(ref(with: "30031:\(pubkey.uppercased()):pack") == nil) // uppercase hex
+        #expect(ref(with: "30031:\(String(pubkey.dropLast())):pack") == nil) // short pubkey
+        #expect(ref(with: "30031:\(pubkey)00:pack") == nil)            // long pubkey
+        #expect(ref(with: "30031:\(pubkey):bad id") == nil)            // space in identifier
+        #expect(ref(with: "30031:\(pubkey):bad/id") == nil)            // slash in identifier
+        #expect(ref(with: "30031:\(pubkey):") == nil)                  // empty identifier
+        #expect(ref(with: "30031:\(pubkey):\(String(repeating: "a", count: 81))") == nil) // 81-char identifier
+        #expect(ref(with: "30031:\(pubkey)") == nil)                   // missing identifier field
+        #expect(ref(with: ":\(pubkey):pack") == nil)                   // empty kind
+    }
+
+    @Test func acceptsCoordinateBoundaryIdentifiers() {
+        #expect(makeRef(coordinate: "30031:\(pubkey):a") != nil)
+        #expect(makeRef(coordinate: "30031:\(pubkey):\(String(repeating: "a", count: 80))") != nil)
+        #expect(makeRef(coordinate: "30031:\(pubkey):A-Z_a.z-09") != nil)
+    }
+
+    // MARK: - Shortcode validation
+
+    @Test func rejectsBadShortcodes() {
+        #expect(makeRef(shortcode: "") == nil)
+        #expect(makeRef(shortcode: String(repeating: "w", count: 65)) == nil)
+        #expect(makeRef(shortcode: "wavé") == nil)   // non-ASCII
+        #expect(makeRef(shortcode: "so-wave") == nil) // dash not allowed
+        #expect(makeRef(shortcode: "so wave") == nil)
+    }
+
+    @Test func acceptsShortcodeBoundaries() {
+        #expect(makeRef(shortcode: "a") != nil)
+        #expect(makeRef(shortcode: String(repeating: "w", count: 64)) != nil)
+        #expect(makeRef(shortcode: "Wave_09") != nil)
+    }
+
+    // MARK: - SHA-256 validation
+
+    @Test func rejectsBadSha256() {
+        #expect(makeRef(hash: String(repeating: "a", count: 63)) == nil)
+        #expect(makeRef(hash: String(repeating: "a", count: 65)) == nil)
+        #expect(makeRef(hash: sha256.uppercased()) == nil)
+        #expect(makeRef(hash: String(repeating: "g", count: 64)) == nil) // non-hex
+    }
+
+    // MARK: - Field count / framing
+
+    @Test func rejectsWrongFieldCounts() {
+        let base = "\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}wave\u{1F}\(sha256)"
+        #expect(StickerRefCodec.parse(base + "\u{1F}extra") == nil)      // trailing field
+        #expect(StickerRefCodec.parse(base + "\u{1F}\u{1F}\u{1F}") == nil) // >4 splits
+        #expect(StickerRefCodec.parse("\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}wave") == nil) // missing hash
+        #expect(StickerRefCodec.parse("\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}\u{1F}\(sha256)") == nil) // empty shortcode field
+    }
+
+    // MARK: - Never-crash fuzz-ish
+
+    @Test func pathologicalInputsNeverCrashAndNeverParse() {
+        let cases = [
+            String(repeating: "\u{1F}", count: 5),                       // all separators
+            String(repeating: "\u{1F}", count: 4096),
+            "\u{1F}sticker" + String(repeating: "\u{1F}", count: 100),
+            String(repeating: "a", count: 100_000),                      // very long
+            "\u{1F}sticker\u{1F}🌊🌊🌊\u{1F}🌊\u{1F}🌊",                 // emoji fields
+            "\u{1F}sticker\u{1F}30031:\(pubkey):pack\u{1F}wave\u{1F}\(sha256)\u{1F}",
+            "\u{1F}sticker\u{1F}\u{1F}\u{1F}\u{1F}",
+            "sticker\u{1F}\u{1F}\u{1F}\u{1F}\u{1F}",
+        ]
+        for content in cases {
+            #expect(StickerRefCodec.parse(content) == nil)
+        }
+    }
+}

--- a/bitchatTests/Services/StickerCacheTests.swift
+++ b/bitchatTests/Services/StickerCacheTests.swift
@@ -220,4 +220,66 @@ struct StickerCacheTests {
         // And the result was persisted.
         #expect(await cache.data(for: hash) == bytes)
     }
+
+    @Test("concurrent followers never receive unverified bytes: a hash mismatch fails every waiter")
+    func concurrentFollowersObserveValidationFailure() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let pinned = String(repeating: "1", count: 64)
+        let url = URL(string: "https://cdn.example.com/stickers/\(pinned).webp")!
+        let calls = Counter()
+
+        let downloader: StickerCache.Downloader = { _ in
+            calls.value += 1
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            return Data("tampered".utf8) // does not hash to `pinned`
+        }
+
+        async let first = cache.fetch(sha256: pinned, url: url, mime: "image/webp", using: downloader)
+        async let second = cache.fetch(sha256: pinned, url: url, mime: "image/webp", using: downloader)
+
+        // Verification+storage happens INSIDE the shared in-flight task, so
+        // the follower cannot render the raw, unverified payload: it observes
+        // the same hashMismatch as the caller that initiated the download.
+        do {
+            _ = try await first
+            Issue.record("expected hashMismatch for the initiating fetch")
+        } catch StickerCache.Error.hashMismatch {} catch {
+            Issue.record("expected hashMismatch, got \(error)")
+        }
+        do {
+            _ = try await second
+            Issue.record("expected hashMismatch for the coalesced follower")
+        } catch StickerCache.Error.hashMismatch {} catch {
+            Issue.record("expected hashMismatch, got \(error)")
+        }
+        #expect(calls.value == 1)
+        #expect(await cache.data(for: pinned) == nil)
+    }
+
+    @Test("store persists the index immediately: a restart inside the throttle window still discovers files")
+    func storePersistsIndexWithinThrottleWindow() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let clock = MutableClock()
+        let cache = StickerCache(baseDirectory: dir, now: clock.now)
+
+        let bytesA = Data("alpha".utf8)
+        let hashA = sha256Hex(bytesA)
+        try await cache.store(bytesA, sha256: hashA, mime: "image/webp")
+        // Second store lands inside the 5s read-path throttle window.
+        clock.current = clock.current.addingTimeInterval(1)
+        let bytesB = Data("bravo".utf8)
+        let hashB = sha256Hex(bytesB)
+        try await cache.store(bytesB, sha256: hashB, mime: "image/webp")
+
+        // Simulated restart: a fresh cache over the same directory must
+        // discover BOTH extension-bearing files through the persisted index —
+        // the read path only finds `<hash>.<ext>` via an index entry.
+        let restarted = StickerCache(baseDirectory: dir, now: clock.now)
+        #expect(await restarted.data(for: hashA) == bytesA)
+        #expect(await restarted.data(for: hashB) == bytesB)
+    }
 }

--- a/bitchatTests/Services/StickerCacheTests.swift
+++ b/bitchatTests/Services/StickerCacheTests.swift
@@ -1,0 +1,223 @@
+//
+// StickerCacheTests.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import CryptoKit
+import Foundation
+import Testing
+@testable import bitchat
+
+@Suite("StickerCache Tests")
+struct StickerCacheTests {
+
+    // MARK: - Helpers
+
+    private final class MutableClock: @unchecked Sendable {
+        var current: Date = Date(timeIntervalSince1970: 1_000)
+        func now() -> Date { current }
+    }
+
+    private final class Counter: @unchecked Sendable {
+        var value = 0
+    }
+
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sticker-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Tests
+
+    @Test("store → data round-trip returns identical bytes")
+    func storeThenReadRoundTrip() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let bytes = Data("hello sticker".utf8)
+        let hash = sha256Hex(bytes)
+        try await cache.store(bytes, sha256: hash, mime: "image/webp")
+
+        let read = await cache.data(for: hash)
+        #expect(read == bytes)
+        // Extension is derived from the MIME type.
+        let fileURL = await cache.fileURL(for: hash)
+        #expect(fileURL?.lastPathComponent == "\(hash).webp")
+    }
+
+    @Test("mismatched hash throws before writing and leaves no file")
+    func mismatchedHashRejectedBeforeWrite() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let bytes = Data("actual bytes".utf8)
+        let wrongHash = String(repeating: "f", count: 64)
+
+        await #expect(throws: StickerCache.Error.hashMismatch) {
+            try await cache.store(bytes, sha256: wrongHash, mime: "image/png")
+        }
+
+        let stickersDir = dir.appendingPathComponent("files/stickers", isDirectory: true)
+        let contents = (try? FileManager.default.contentsOfDirectory(atPath: stickersDir.path)) ?? []
+        #expect(contents.isEmpty)
+        #expect(await cache.data(for: wrongHash) == nil)
+    }
+
+    @Test("payloads over 4 MiB are rejected")
+    func oversizedRejected() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let big = Data(repeating: 0xAB, count: StickerCache.maxStickerBytes + 1)
+        let hash = sha256Hex(big)
+        await #expect(throws: StickerCache.Error.stickerTooLarge) {
+            try await cache.store(big, sha256: hash, mime: "image/webp")
+        }
+        #expect(await cache.data(for: hash) == nil)
+    }
+
+    @Test("path-traversal and malformed hash strings are rejected")
+    func traversalRejected() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+        let bytes = Data("x".utf8)
+
+        let bad = [
+            "../\(String(repeating: "a", count: 61))",
+            "\(String(repeating: "a", count: 32))/../\(String(repeating: "b", count: 27))",
+            String(repeating: "A", count: 64), // uppercase is not a valid file name
+            String(repeating: "g", count: 64), // not hex
+            String(repeating: "a", count: 63), // too short
+            "a/a" + String(repeating: "0", count: 61)
+        ]
+        for hash in bad {
+            await #expect(throws: StickerCache.Error.invalidSHA256) {
+                try await cache.store(bytes, sha256: hash, mime: "image/png")
+            }
+            #expect(await cache.data(for: hash) == nil)
+        }
+    }
+
+    @Test("removeAll clears cached bytes and negative-cache state")
+    func removeAllClears() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let bytes = Data("wipe me".utf8)
+        let hash = sha256Hex(bytes)
+        try await cache.store(bytes, sha256: hash, mime: "image/gif")
+        #expect(await cache.data(for: hash) != nil)
+
+        await cache.removeAll()
+        #expect(await cache.data(for: hash) == nil)
+        #expect(await cache.fileURL(for: hash) == nil)
+    }
+
+    @Test("LRU eviction removes the oldest last-access entry first")
+    func lruEvictsOldestAccess() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let clock = MutableClock()
+        // Cap of 100 bytes: three 40-byte stickers cannot all fit.
+        let cache = StickerCache(baseDirectory: dir, maxCacheBytes: 100, now: clock.now)
+
+        let aBytes = Data(repeating: 0xA1, count: 40)
+        let bBytes = Data(repeating: 0xB2, count: 40)
+        let cBytes = Data(repeating: 0xC3, count: 40)
+        let a = sha256Hex(aBytes)
+        let b = sha256Hex(bBytes)
+        let c = sha256Hex(cBytes)
+
+        clock.current = Date(timeIntervalSince1970: 1)
+        try await cache.store(aBytes, sha256: a, mime: "image/png")
+        clock.current = Date(timeIntervalSince1970: 2)
+        try await cache.store(bBytes, sha256: b, mime: "image/png")
+        // Touch A so B becomes the oldest last-access entry.
+        clock.current = Date(timeIntervalSince1970: 3)
+        _ = await cache.data(for: a)
+        clock.current = Date(timeIntervalSince1970: 4)
+        try await cache.store(cBytes, sha256: c, mime: "image/png")
+
+        #expect(await cache.data(for: b) == nil) // evicted
+        #expect(await cache.data(for: a) != nil)
+        #expect(await cache.data(for: c) != nil)
+    }
+
+    @Test("negative cache blocks immediate refetch after a failure")
+    func negativeCacheBackoffBlocksRefetch() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let hash = String(repeating: "1", count: 64)
+        let url = URL(string: "https://cdn.example.com/stickers/\(hash).webp")!
+        let calls = Counter()
+
+        await #expect(throws: URLError.self) {
+            _ = try await cache.fetch(sha256: hash, url: url) { _ in
+                calls.value += 1
+                throw URLError(.notConnectedToInternet)
+            }
+        }
+        #expect(calls.value == 1)
+
+        // Immediate retry must short-circuit without invoking the downloader.
+        do {
+            _ = try await cache.fetch(sha256: hash, url: url) { _ in
+                calls.value += 1
+                return Data()
+            }
+            Issue.record("expected negativeCacheBackoff error")
+        } catch let StickerCache.Error.negativeCacheBackoff(retryAfter) {
+            #expect(retryAfter > Date())
+        }
+        #expect(calls.value == 1)
+    }
+
+    @Test("concurrent fetches for the same hash coalesce onto one download")
+    func fetchCoalescesInFlight() async throws {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
+        let cache = StickerCache(baseDirectory: dir)
+
+        let bytes = Data("coalesced".utf8)
+        let hash = sha256Hex(bytes)
+        let url = URL(string: "https://cdn.example.com/stickers/\(hash).webp")!
+        let calls = Counter()
+
+        async let first = cache.fetch(sha256: hash, url: url, mime: "image/webp") { _ in
+            calls.value += 1
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            return bytes
+        }
+        async let second = cache.fetch(sha256: hash, url: url, mime: "image/webp") { _ in
+            calls.value += 1
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            return bytes
+        }
+
+        let results = try await [first, second]
+        #expect(results == [bytes, bytes])
+        #expect(calls.value == 1)
+        // And the result was persisted.
+        #expect(await cache.data(for: hash) == bytes)
+    }
+}

--- a/bitchatTests/Services/StickerPackFetchTests.swift
+++ b/bitchatTests/Services/StickerPackFetchTests.swift
@@ -1,0 +1,111 @@
+//
+// StickerPackFetchTests.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+/// Fetch-path tests for `StickerPackService` with injected relay query,
+/// downloader, and clock — no relay, Tor, or network access.
+@Suite("Sticker Pack Fetch Tests")
+struct StickerPackFetchTests {
+
+    private final class Counter: @unchecked Sendable { var value = 0 }
+    private final class MutableClock: @unchecked Sendable {
+        var current = Date(timeIntervalSince1970: 1_700_000_000)
+        func now() -> Date { current }
+    }
+
+    private let pubkey = String(repeating: "a", count: 64)
+
+    @MainActor
+    private func makeService(
+        clock: MutableClock,
+        relayQuery: @escaping StickerPackService.RelayQuery
+    ) -> StickerPackService {
+        StickerPackService(
+            cache: StickerCache(
+                baseDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("sticker-pack-fetch-tests-\(UUID().uuidString)", isDirectory: true)
+            ),
+            relayQuery: relayQuery,
+            downloader: { _ in throw URLError(.notConnectedToInternet) },
+            networkActivationAllowed: { true },
+            metadataURL: nil,
+            now: clock.now
+        )
+    }
+
+    @MainActor
+    @Test("missing pack is negative-cached: repeats back off instead of re-querying relays")
+    func missingPackIsNegativeCached() async {
+        let clock = MutableClock()
+        let calls = Counter()
+        let service = makeService(clock: clock) { _ in
+            calls.value += 1
+            return []
+        }
+
+        await #expect(throws: StickerPackService.StickerPackError.packNotFound) {
+            try await service.fetchPack(authorPubkeyHex: pubkey, identifier: "nope")
+        }
+        #expect(calls.value == 1)
+
+        // Immediate retry short-circuits into backoff — no second relay query.
+        // (Every retry would be a repeat read beacon to the relay set.)
+        do {
+            _ = try await service.fetchPack(authorPubkeyHex: pubkey, identifier: "nope")
+            Issue.record("expected packFetchBackoff")
+        } catch let StickerPackService.StickerPackError.packFetchBackoff(retryAfter) {
+            #expect(retryAfter > clock.current)
+        } catch {
+            Issue.record("expected packFetchBackoff, got \(error)")
+        }
+        #expect(calls.value == 1)
+
+        // After the initial 30s backoff elapses the relay is queried again,
+        // and the repeated miss backs off further.
+        clock.current = clock.current.addingTimeInterval(31)
+        await #expect(throws: StickerPackService.StickerPackError.packNotFound) {
+            try await service.fetchPack(authorPubkeyHex: pubkey, identifier: "nope")
+        }
+        #expect(calls.value == 2)
+
+        // Third failure doubled the backoff: +45s is still inside the 60s window.
+        clock.current = clock.current.addingTimeInterval(45)
+        do {
+            _ = try await service.fetchPack(authorPubkeyHex: pubkey, identifier: "nope")
+            Issue.record("expected packFetchBackoff")
+        } catch let StickerPackService.StickerPackError.packFetchBackoff(retryAfter) {
+            #expect(retryAfter > clock.current)
+        } catch {
+            Issue.record("expected packFetchBackoff, got \(error)")
+        }
+        #expect(calls.value == 2)
+    }
+
+    @MainActor
+    @Test("invalid coordinates are rejected before any relay query")
+    func invalidCoordinateRejectedBeforeQuery() async {
+        let clock = MutableClock()
+        let calls = Counter()
+        let service = makeService(clock: clock) { _ in
+            calls.value += 1
+            return []
+        }
+
+        await #expect(throws: StickerPackService.StickerPackError.invalidCoordinate) {
+            try await service.fetchPack(authorPubkeyHex: "not-hex", identifier: "nope")
+        }
+        // A coordinate the wire codec could never express is refused up front.
+        await #expect(throws: StickerPackService.StickerPackError.invalidCoordinate) {
+            try await service.fetchPack(authorPubkeyHex: pubkey, identifier: "has spaces")
+        }
+        #expect(calls.value == 0)
+    }
+}

--- a/bitchatTests/Services/StickerPackValidationTests.swift
+++ b/bitchatTests/Services/StickerPackValidationTests.swift
@@ -1,0 +1,309 @@
+//
+// StickerPackValidationTests.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+/// Pure validation tests for `StickerPackService.parsePackEvent` — no relay,
+/// Tor, or network access; `NostrEvent` fixtures are built in code.
+@Suite("Sticker Pack Validation Tests")
+struct StickerPackValidationTests {
+
+    private let pubkey = String(repeating: "a", count: 64)
+    private let hash1 = String(repeating: "1", count: 64)
+    private let hash2 = String(repeating: "2", count: 64)
+
+    // MARK: - Fixture builders
+
+    private func makeEvent(
+        kind: Int = 30031,
+        pubkey: String? = nil,
+        createdAt: Int = 1_700_000_000,
+        tags: [[String]]
+    ) -> NostrEvent {
+        // Raw-kind init (internal, @testable): bypasses the inbound relay
+        // tag-count cap so >64-tag packs can be exercised for unit tests.
+        NostrEvent(
+            pubkey: pubkey ?? self.pubkey,
+            createdAt: createdAt,
+            kind: kind,
+            tags: tags,
+            content: ""
+        )
+    }
+
+    private func stickerTag(
+        shortcode: String = "party_blob",
+        hash: String? = nil,
+        mime: String = "image/webp",
+        dim: String? = "128x128",
+        url: String? = nil
+    ) -> [String] {
+        let h = hash ?? hash1
+        var tag = ["sticker", shortcode, url ?? "https://cdn.example.com/stickers/\(h).webp", h, mime]
+        if let dim { tag.append(dim) }
+        return tag
+    }
+
+    private func validTags(stickers: [[String]]? = nil) -> [[String]] {
+        [
+            ["d", "cool-pack"],
+            ["title", "Cool Pack"],
+            ["pack_format", "sonar-sticker-pack-v1"]
+        ] + (stickers ?? [stickerTag()])
+    }
+
+    // MARK: - Valid pack
+
+    @Test("spec-compliant pack event parses with all fields")
+    func validPackParses() {
+        let event = makeEvent(tags: [
+            ["d", "cool-pack"],
+            ["title", "Cool Pack"],
+            ["description", "A very cool pack"],
+            ["image", "https://cdn.example.com/cover.png"],
+            ["pack_format", "sonar-sticker-pack-v1"],
+            ["sticker", "party_blob", "https://cdn.example.com/stickers/\(hash1).webp",
+             hash1, "image/webp", "128x128", "Party blob", "🎉"]
+        ])
+
+        let pack = StickerPackService.parsePackEvent(event)
+        #expect(pack != nil)
+        #expect(pack?.coordinate == "30031:\(pubkey):cool-pack")
+        #expect(pack?.authorPubkey == pubkey)
+        #expect(pack?.identifier == "cool-pack")
+        #expect(pack?.title == "Cool Pack")
+        #expect(pack?.description == "A very cool pack")
+        #expect(pack?.coverURL?.absoluteString == "https://cdn.example.com/cover.png")
+        #expect(pack?.stickers.count == 1)
+        let sticker = pack?.stickers.first
+        #expect(sticker?.shortcode == "party_blob")
+        #expect(sticker?.sha256 == hash1)
+        #expect(sticker?.mime == "image/webp")
+        #expect(sticker?.dim == StickerDimensions(width: 128, height: 128))
+        #expect(sticker?.alt == "Party blob")
+        #expect(sticker?.emoji == "🎉")
+        #expect(pack?.createdAt == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test("optional dim/alt/emoji may be absent")
+    func optionalFieldsMayBeAbsent() {
+        let event = makeEvent(tags: validTags(stickers: [
+            ["sticker", "blob", "https://cdn.example.com/\(hash1).png", hash1, "image/png"]
+        ]))
+        let pack = StickerPackService.parsePackEvent(event)
+        #expect(pack?.stickers.first?.dim == nil)
+        #expect(pack?.stickers.first?.alt == nil)
+        #expect(pack?.stickers.first?.emoji == nil)
+    }
+
+    // MARK: - Envelope rules
+
+    @Test("wrong kind is rejected", arguments: [30032, 1, 10031, 30311])
+    func wrongKindRejected(kind: Int) {
+        #expect(StickerPackService.parsePackEvent(makeEvent(kind: kind, tags: validTags())) == nil)
+    }
+
+    @Test("missing pack_format tag is rejected")
+    func missingPackFormatRejected() {
+        let tags = validTags().filter { $0.first != "pack_format" }
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("wrong pack_format value is rejected")
+    func wrongPackFormatRejected() {
+        let tags = validTags().map { $0.first == "pack_format" ? ["pack_format", "other-v1"] : $0 }
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("missing or invalid d tag is rejected", arguments: [nil, "", "has spaces", String(repeating: "x", count: 300)])
+    func invalidDTagRejected(identifier: String?) {
+        var tags = validTags().filter { $0.first != "d" }
+        if let identifier { tags.append(["d", identifier]) }
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("missing or blank title is rejected", arguments: [nil, "", "   "])
+    func invalidTitleRejected(title: String?) {
+        var tags = validTags().filter { $0.first != "title" }
+        if let title { tags.append(["title", title]) }
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("malformed pubkey is rejected")
+    func invalidPubkeyRejected() {
+        #expect(StickerPackService.parsePackEvent(makeEvent(pubkey: "nothex", tags: validTags())) == nil)
+        #expect(StickerPackService.parsePackEvent(
+            makeEvent(pubkey: String(repeating: "A", count: 64), tags: validTags())
+        ) == nil)
+    }
+
+    // MARK: - Sticker tag rules
+
+    @Test("pack with zero stickers is rejected")
+    func noStickersRejected() {
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: validTags(stickers: []))) == nil)
+    }
+
+    @Test("non-HTTPS sticker URL is rejected", arguments: [
+        "http://cdn.example.com/x.webp",
+        "ftp://cdn.example.com/x.webp",
+        "not-a-url",
+        "https://user:pass@cdn.example.com/x.webp"
+    ])
+    func nonHTTPSRejected(url: String) {
+        let tags = validTags(stickers: [stickerTag(url: url)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("sticker URL whose path lacks the sha256 is rejected")
+    func urlMissingHashRejected() {
+        let tags = validTags(stickers: [
+            stickerTag(url: "https://cdn.example.com/stickers/other.webp")
+        ])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("disallowed MIME is rejected", arguments: ["image/jpeg", "image/svg+xml", "video/mp4", "application/octet-stream"])
+    func badMimeRejected(mime: String) {
+        let tags = validTags(stickers: [stickerTag(mime: mime)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("all allowed MIMEs parse", arguments: ["image/webp", "image/png", "image/apng", "image/gif"])
+    func allowedMimesParse(mime: String) {
+        let tags = validTags(stickers: [stickerTag(mime: mime)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags))?.stickers.first?.mime == mime)
+    }
+
+    @Test("malformed sha256 is rejected", arguments: [
+        "xyz", String(repeating: "1", count: 63), String(repeating: "F", count: 64)
+    ])
+    func badSHA256Rejected(hash: String) {
+        let tags = validTags(stickers: [
+            ["sticker", "blob", "https://cdn.example.com/\(hash).webp", hash, "image/webp", "10x10"]
+        ])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("invalid shortcode is rejected", arguments: ["", "UPPER", "has space", "emoji🎉", String(repeating: "a", count: 65)])
+    func badShortcodeRejected(shortcode: String) {
+        let tags = validTags(stickers: [stickerTag(shortcode: shortcode)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("duplicate shortcodes are rejected")
+    func duplicateShortcodeRejected() {
+        let tags = validTags(stickers: [
+            stickerTag(shortcode: "dup", hash: hash1),
+            stickerTag(shortcode: "dup", hash: hash2)
+        ])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("duplicate hashes are rejected")
+    func duplicateHashRejected() {
+        let tags = validTags(stickers: [
+            stickerTag(shortcode: "one", hash: hash1),
+            stickerTag(shortcode: "two", hash: hash1)
+        ])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("packs with more than 200 stickers are rejected")
+    func tooManyStickersRejected() {
+        let stickers = (0..<201).map { i -> [String] in
+            let hash = String(format: "%064d", i + 1) // decimal digits are valid lowercase hex
+            return ["sticker", "s\(i)", "https://cdn.example.com/\(hash).webp", hash, "image/webp", "10x10"]
+        }
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: validTags(stickers: stickers))) == nil)
+    }
+
+    @Test("200 stickers exactly parses")
+    func exactlyMaxStickersParses() {
+        let stickers = (0..<200).map { i -> [String] in
+            let hash = String(format: "%064d", i + 1)
+            return ["sticker", "s\(i)", "https://cdn.example.com/\(hash).webp", hash, "image/webp", "10x10"]
+        }
+        let pack = StickerPackService.parsePackEvent(makeEvent(tags: validTags(stickers: stickers)))
+        #expect(pack?.stickers.count == 200)
+    }
+
+    @Test("invalid dim is rejected", arguments: ["0x10", "10x0", "5000x10", "10x5000", "abc", "10x20x30", "-5x10", "10X20", "10 x20"])
+    func badDimRejected(dim: String) {
+        let tags = validTags(stickers: [stickerTag(dim: dim)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("boundary dims parse", arguments: ["1x1", "4096x4096", "1x4096"])
+    func boundaryDimsParse(dim: String) {
+        let tags = validTags(stickers: [stickerTag(dim: dim)])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags))?.stickers.first?.dim != nil)
+    }
+
+    @Test("truncated sticker tag is rejected")
+    func truncatedStickerTagRejected() {
+        let tags = validTags(stickers: [
+            ["sticker", "blob", "https://cdn.example.com/\(hash1).webp", hash1] // missing mime
+        ])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    // MARK: - Cover image
+
+    @Test("non-HTTPS cover image is rejected")
+    func nonHTTPSCoverRejected() {
+        var tags = validTags()
+        tags.append(["image", "http://cdn.example.com/cover.png"])
+        #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    // MARK: - Ref validation (pack-edit attack)
+
+    @Test("validateStickerRef requires both shortcode and pinned hash in the current pack")
+    @MainActor
+    func validateStickerRefAgainstPack() {
+        let event = makeEvent(tags: validTags(stickers: [
+            stickerTag(shortcode: "party_blob", hash: hash1)
+        ]))
+        guard let pack = StickerPackService.parsePackEvent(event) else {
+            Issue.record("fixture pack failed to parse")
+            return
+        }
+        let service = StickerPackService(
+            cache: StickerCache(baseDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("sticker-svc-tests-\(UUID().uuidString)", isDirectory: true)),
+            relayQuery: { _ in [] },
+            downloader: { _ in throw URLError(.networkConnectionLost) },
+            networkActivationAllowed: { false },
+            metadataURL: nil
+        )
+
+        // Happy path: coordinate + shortcode + pinned hash all match.
+        #expect(service.validateStickerRef(
+            packCoordinate: pack.coordinate, shortcode: "party_blob",
+            plaintextSha256: hash1, against: pack
+        ))
+        // Pack edited: shortcode still present but hash changed → untrusted.
+        #expect(!service.validateStickerRef(
+            packCoordinate: pack.coordinate, shortcode: "party_blob",
+            plaintextSha256: hash2, against: pack
+        ))
+        // Shortcode removed from the pack → untrusted.
+        #expect(!service.validateStickerRef(
+            packCoordinate: pack.coordinate, shortcode: "gone",
+            plaintextSha256: hash1, against: pack
+        ))
+        // Different pack entirely → untrusted.
+        #expect(!service.validateStickerRef(
+            packCoordinate: "30031:\(String(repeating: "b", count: 64)):cool-pack",
+            shortcode: "party_blob", plaintextSha256: hash1, against: pack
+        ))
+    }
+}

--- a/bitchatTests/Services/StickerPackValidationTests.swift
+++ b/bitchatTests/Services/StickerPackValidationTests.swift
@@ -192,10 +192,21 @@ struct StickerPackValidationTests {
         #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
     }
 
-    @Test("invalid shortcode is rejected", arguments: ["", "UPPER", "has space", "emoji🎉", String(repeating: "a", count: 65)])
+    // Shortcode rules come from the wire codec (`StickerRef.isValidShortcode`):
+    // `[A-Za-z0-9_]{1,64}` — uppercase is valid, dash is not.
+    @Test("invalid shortcode is rejected", arguments: ["", "has space", "emoji🎉", "so-wave", String(repeating: "a", count: 65)])
     func badShortcodeRejected(shortcode: String) {
         let tags = validTags(stickers: [stickerTag(shortcode: shortcode)])
         #expect(StickerPackService.parsePackEvent(makeEvent(tags: tags)) == nil)
+    }
+
+    @Test("codec-valid shortcode parses (pack and wire rules cannot drift)")
+    func codecValidShortcodeParses() {
+        let tags = validTags(stickers: [stickerTag(shortcode: "Wave_09")])
+        let pack = StickerPackService.parsePackEvent(makeEvent(tags: tags))
+        #expect(pack?.stickers.first?.shortcode == "Wave_09")
+        // …and the same shortcode is encodable into a wire reference.
+        #expect(StickerRef.isValidShortcode("Wave_09"))
     }
 
     @Test("duplicate shortcodes are rejected")

--- a/docs/SONAR-STICKERS.md
+++ b/docs/SONAR-STICKERS.md
@@ -72,21 +72,23 @@ Sticker references are always carried as **ordinary message content**:
   event (kind 20000), inside the existing encryption for that channel.
 
 No new message type, TLV, or Nostr kind is introduced for sending stickers.
-Clients SHOULD gate sending on the peer's advertised capabilities (below);
-receiving clients MUST accept sticker content regardless.
+v1 does not gate sending on capabilities; receiving clients MUST accept
+sticker content regardless (old clients render harmless literal text — see
+"Old-Client Behavior" below).
 
 ## Capability Bit
 
-Support is advertised via the `PeerCapabilities` bitfield in announce
-packets (see `localPackages/BitFoundation/.../PeerCapabilities.swift`):
-
-- **`.stickers` = bit 11** (`1 << 11`)
+- **`.stickers` = bit 13** (`1 << 13`) — **reserved, NOT advertised in v1.**
 
 Bit 10 remains reserved (`nonDestructiveNoiseReplacement`, decodable but
-unused) and MUST NOT be reused. A peer that advertises `.stickers`
-understands the `␟sticker␟` content prefix and can render refs to images.
-Senders SHOULD prefer sending a ref only to peers advertising the bit, and
-MAY fall back to a short textual description (`:shortcode:`) otherwise.
+unused), bit 11 is claimed by #1107 (double ratchet), and bit 12 by #1438
+(spray recovery); none of these MUST be reused. The stickers bit is
+reserved for a future inline-BLE byte delivery mode and is NOT set in v1
+announce packets: references ride as ordinary message content, so there is
+nothing to negotiate. When a peer capability becomes meaningful (e.g.
+inline delivery), senders SHOULD prefer sending a ref only to peers
+advertising the bit and MAY fall back to a short textual description
+(`:shortcode:`) otherwise.
 
 ## Pack Resolution
 
@@ -107,6 +109,15 @@ Resolution is a client-side cache/fetch concern and never touches the mesh:
    published as a replaceable kind-`10031` event whose `a` tags are
    `30031:<pubkey>:<identifier>` pointers, deduplicated in first-seen
    order. Clients SHOULD merge relays' versions keeping the newest event.
+5. **Fetch consent (privacy).** Resolving an uninstalled pack on behalf of
+   an inbound message MUST NOT happen automatically at render time: an
+   on-render fetch is a read beacon — a per-recipient pack URL tells the
+   sender exactly when the message was viewed, and DM sticker fetches leak
+   conversation metadata to relays/Blossom hosts. Uninstalled packs render
+   a placeholder and fetch only on explicit user consent (e.g. a tap).
+   Packs the user installed resolve automatically. Failed pack lookups
+   SHOULD be negative-cached with exponential backoff so a missing/dead
+   pack is not re-fetched on every render (a repeat beacon).
 
 See https://sonarprivacy.xyz/docs#SONAR-STICKERS for the full pack and
 publication spec.

--- a/docs/SONAR-STICKERS.md
+++ b/docs/SONAR-STICKERS.md
@@ -1,0 +1,136 @@
+# Sonar Stickers Specification
+
+## Overview
+
+Sonar stickers let peers send image stickers from shared, content-addressed
+sticker packs over bitchat. A sticker is **not** sent as image bytes on the
+mesh; instead the sender emits a small *sticker reference* as ordinary
+message content, and receiving clients resolve the reference to an image via
+Nostr + Blossom. This keeps the BLE mesh payload tiny while allowing
+arbitrarily large sticker art.
+
+The upstream pack specification (pack format, Blossom publication, signing)
+lives at **https://sonarprivacy.xyz/docs#SONAR-STICKERS**. This document
+specifies only the bitchat wire format and client behavior. The reference
+implementation is byte-identical to sonar-ffi's `mesh_sticker_content` /
+`mesh_parse_sticker_content`.
+
+## Wire Format
+
+### Content Prefix
+
+A sticker reference is encoded as message **content** (UTF-8 text) with the
+following exact layout:
+
+```
+␟sticker␟<pack-coordinate>␟<shortcode>␟<plaintext-sha256>
+```
+
+where `␟` is ASCII **Unit Separator (0x1F)**. In Swift:
+
+```swift
+"\u{1F}sticker\u{1F}\(coordinate)\u{1F}\(shortcode)\u{1F}\(sha256)"
+```
+
+Field order and count are fixed:
+
+| # | Field              | Validation |
+|---|--------------------|------------|
+| 0 | *(empty sentinel)* | MUST be empty (leading `0x1F`) |
+| 1 | tag                | MUST be the literal ASCII string `sticker` |
+| 2 | pack-coordinate    | `30031:<64 lowercase hex>:<identifier>`; identifier is 1–80 chars of `[A-Za-z0-9._-]` |
+| 3 | shortcode          | 1–64 chars of `[A-Za-z0-9_]` |
+| 4 | plaintext-sha256   | exactly 64 lowercase hex chars (SHA-256 of the decrypted sticker plaintext) |
+
+### Parsing Rules
+
+Parsers MUST:
+
+1. Split the content on `0x1F` with **at most 4 splits**, preserving empty
+   subsequences.
+2. Accept only if the split yields **exactly 5 parts**, `parts[0]` is empty,
+   and `parts[1] == "sticker"`.
+3. Validate fields 2–4 against the table above; any violation MUST cause the
+   whole parse to fail.
+4. Treat a failed parse as ordinary text (see *Old-Client Behavior*).
+5. Never crash on malformed input: this content is attacker-controlled on
+   public channels.
+
+Senders MUST NOT emit a reference whose fields fail validation. The pack
+service SHOULD reuse the same validators (`StickerRef.isValidCoordinate`,
+`isValidShortcode`, `isValidSha256`) rather than re-implementing them.
+
+## Where References May Appear
+
+Sticker references are always carried as **ordinary message content**:
+
+- **Private DMs** — inside the existing encrypted Noise envelope, exactly
+  like a text message. The reference (and thus sticker choice) is never
+  visible to relays or passive observers.
+- **Public mesh channel** — as ordinary broadcast message content.
+- **Geohash / Nostr channels** — as the content of the usual geohash chat
+  event (kind 20000), inside the existing encryption for that channel.
+
+No new message type, TLV, or Nostr kind is introduced for sending stickers.
+Clients SHOULD gate sending on the peer's advertised capabilities (below);
+receiving clients MUST accept sticker content regardless.
+
+## Capability Bit
+
+Support is advertised via the `PeerCapabilities` bitfield in announce
+packets (see `localPackages/BitFoundation/.../PeerCapabilities.swift`):
+
+- **`.stickers` = bit 11** (`1 << 11`)
+
+Bit 10 remains reserved (`nonDestructiveNoiseReplacement`, decodable but
+unused) and MUST NOT be reused. A peer that advertises `.stickers`
+understands the `␟sticker␟` content prefix and can render refs to images.
+Senders SHOULD prefer sending a ref only to peers advertising the bit, and
+MAY fall back to a short textual description (`:shortcode:`) otherwise.
+
+## Pack Resolution
+
+Resolution is a client-side cache/fetch concern and never touches the mesh:
+
+1. **Pack lookup (Nostr, kind 30031).** The pack-coordinate is an
+   addressable Nostr pointer: kind `30031`, author = the 64-hex pubkey,
+   `d` tag = the identifier. Clients fetch the pack definition event from
+   relays and extract the sticker list.
+2. **Image fetch (Blossom).** Sticker image bytes are fetched over
+   **HTTPS only** from Blossom servers, **pinned by SHA-256**: the
+   downloaded bytes MUST hash to the `plaintext-sha256` from the reference
+   (and to the hash in the pack entry) before caching or rendering.
+3. **Media constraints.** Decoders MUST enforce the MIME allowlist
+   (`image/webp`, `image/png`, `image/apng`, `image/gif`) and dimensions
+   ≤ 4096×4096. Packs contain ≤ 200 stickers.
+4. **Install list (Nostr, kind 10031).** A user's installed packs are
+   published as a replaceable kind-`10031` event whose `a` tags are
+   `30031:<pubkey>:<identifier>` pointers, deduplicated in first-seen
+   order. Clients SHOULD merge relays' versions keeping the newest event.
+
+See https://sonarprivacy.xyz/docs#SONAR-STICKERS for the full pack and
+publication spec.
+
+## Old-Client Behavior
+
+Clients that predate this spec (or do not advertise `.stickers`) see the
+reference as a plain UTF-8 string. Because Unit Separator is a non-printing
+control character, the content renders as roughly
+`sticker 30031:…:my-pack wave deadbeef…` — ugly but harmless. Old clients
+MUST NOT crash on this content, and this spec adds no bytes outside the
+existing content field, so no migration is required.
+
+## Security Rules
+
+Receivers and pack services MUST:
+
+- **Verify before caching.** Never cache or render image bytes whose
+  SHA-256 does not match the expected `plaintext-sha256`.
+- **Untrusted-state rendering.** If the currently resolved pack does not
+  contain the `(shortcode, hash)` pair from a reference, render an
+  "untrusted / unknown sticker" placeholder — not whatever image the pack
+  currently has under that shortcode.
+- **HTTPS only.** Never fetch or render non-HTTPS URLs, regardless of what
+  a pack event claims.
+- **Never crash on input.** All parsing of references, pack events, and
+  image metadata is attacker-controlled; treat every field as hostile.

--- a/docs/brainstorms/2026-07-27-sonar-stickers-bitchat.md
+++ b/docs/brainstorms/2026-07-27-sonar-stickers-bitchat.md
@@ -1,0 +1,66 @@
+## Clarified Problem Statement
+
+**Goal:** Add Sonar sticker support (sonar-sticker-pack-v1) to bitchat iOS: send/receive sticker references in BLE mesh chat, resolve packs from Nostr (kind 30031), download sticker bytes from Blossom HTTPS, and cache them in-app like Sonar does — adapted to bitchat's BLE-only mesh constraints.
+
+**Context (grounded):**
+- Spec: sonarprivacy.xyz/docs#SONAR-STICKERS == bitchat-to-sonar `docs/SONAR-STICKERS.md` (kind 30031 packs, kind 10031 installed list, Blossom assets, plaintext sha256 pinning).
+- Sonar impl: `core/sonar-ffi/src/lib.rs` `mesh_sticker_content`/`mesh_parse_sticker_content` — encodes refs as `\x1Fsticker\x1F<pack-coordinate>\x1F<shortcode>\x1F<sha256>` inside a normal mesh message content string (Unit-Separator delimited, no new packet type). Sent refs pin the plaintext hash so pack edits can't rewrite history.
+- Sonar caching: `MarmotService.fetchStickerPack` / `fetchStickerImage` (Rust core, relay + HTTPS fetch) + in-memory LRU (500 entries) keyed by sha256 in `MarmotChatView`/`SonarAppStore.stickerImageData`.
+- bitchat: message content is a String (media already uses content prefixes, see `BitchatMessage+Media.swift` + `MimeType.Category.messagePrefix`). BLE fragmentation at 512-byte MTU, Noise-padded frames. No SonarCore FFI in this repo — encoding must be re-implemented in pure Swift (trivial, ~20 lines).
+- bitchat has internet paths despite BLE-only chat: `Nostr/NostrRelayManager.swift`, geohash channels, `ChatViewModel+Tor.swift`. Private media already has an encrypted BLE path (`NoisePayloadType.privateFile 0x20`, `BitchatFilePacket` TLV, docs/PRIVATE-MEDIA-MIGRATION.md).
+
+**Constraints:**
+- BLE-only mesh: peers may have no internet. A sticker ref must degrade to a placeholder, never block or corrupt chat.
+- No new BLE MessageType needed if content-prefix encoding is used (refs are ~120-160 bytes ASCII — fits easily in one fragmented message).
+- Fetch of packs/images is the only internet-dependent step; must match bitchat privacy posture (Tor when enabled).
+- Wire compat: reusing sonar's `\x1Fsticker\x1F` encoding keeps interop with Sonar mesh clients; old bitchat clients render it as (odd) text, not a crash.
+- Must validate like the spec: HTTPS-only URLs, sha256-in-URL + verify hash before caching, MIME allowlist (webp/png/apng/gif), dim <= 4096.
+
+**Non-goals (to confirm):**
+- Publishing/importing packs (Signal import, sonar-cli flow) — out of scope for the app.
+- Android implementation (separate repo; wire format must just be documented for it).
+- Marmot/MLS group stickers (bitchat has no Marmot).
+
+**Success criteria:**
+- User can install/browse a sticker pack and send a sticker in a BLE private chat (and/or public channel per scope answer).
+- Recipient with internet renders the sticker; recipient offline sees a clean placeholder, renders later once fetched.
+- Sticker bytes are cached on disk keyed by sha256 (content-addressed); reopening chat doesn't re-download.
+- Edited-pack attack: ref hash mismatch renders "untrusted sticker", never a substituted image.
+
+## Approaches Considered
+
+### Approach A: Reference-only + lazy fetch + disk cache (port of Sonar mesh encoding)
+- Sketch: Pure-Swift port of `mesh_sticker_content` parse/format. Sending = content string in normal private message. Receiving = parse prefix, resolve pack via NostrRelayManager (kind 30031 by author+d), download image via URLSession (Tor-aware), verify sha256, cache in Application Support/stickers/<sha256>. Render via new StickerMessageView; placeholder state when unfetchable.
+- Affected files: `Models/BitchatMessage+Media.swift` (new .sticker case), new `Services/StickerPackService.swift` + `Services/StickerCache.swift`, `Views/Media/` new StickerMessageView, `ViewModels/Extensions/ChatViewModel+PrivateChat.swift` (send path), `Nostr/NostrRelayManager.swift` (pack query), picker UI in `Views/`.
+- Tradeoffs: smallest BLE footprint, zero protocol risk, wire-compatible with Sonar. Offline peers see placeholders until online. No picker pack-install UX unless added (needs kind 10031 handling or local-only list).
+- Effort: M
+
+### Approach B: A + inline BLE delivery of sticker bytes
+- Sketch: Same reference encoding, but sender optionally pushes the sticker image over the existing encrypted privateFile (0x20) BitchatFilePacket path so fully-offline BLE peers render immediately; receiver caches by sha256 and skips the HTTPS fetch entirely.
+- Affected files: all of A + `Services/BLE/BLEFileTransferHandler.swift`, `BLEIncomingFileStore.swift`, `Models/BitchatFilePacket.swift` (sticker MIME/category), capability bit in `Protocols/PeerCapabilities+Local.swift`.
+- Tradeoffs: true BLE-only experience, no internet ever needed between two peers. Costs BLE bandwidth (stickers ~50-300 KB over a 512-byte-MTU fragmented link is slow), more protocol surface (capability negotiation like privateMedia bit 8/9), sender must have the bytes cached. Still needs A's fetch path for pack browsing.
+- Effort: L
+
+### Approach C: Full Sonar feature port (install lists, picker, kind 10031 sync)
+- Sketch: A + pack install/uninstall synced via kind 10031, full sticker picker sheet (like `SonarEmojiPickerView`), pack discovery via `t=sonar-sticker-pack-v1` relay queries.
+- Affected files: all of A + new picker views, `Nostr/NostrIdentity.swift` signing of 10031, pack-management UI.
+- Tradeoffs: complete UX parity with Sonar, but pulls Nostr identity publishing into bitchat (which today only reads/geohash-publishes) — bigger privacy and scope footprint. Can be layered on A later.
+- Effort: L
+
+## Recommendation
+
+**Approach A first**, designed so B and C layer on without rework: isolate the wire codec (`StickerRef` format/parse, unit-tested against sonar-ffi vectors), the cache (content-addressed by sha256), and the fetch service behind one `StickerPackService`. A matches "download and cache like sonar" exactly, touches no BLE protocol code, and the only real design decisions are fetch privacy (Tor) and offline placeholder UX.
+
+## Decisions (2026-07-27)
+1. Transport scope: all text channels — refs are content strings, so rendering works everywhere for free; send UI enabled in DMs + public mesh + geohash channels. (default, user may override)
+2. Fetch privacy: follow bitchat's existing Tor setting — relay queries via NostrRelayManager, Blossom HTTPS fetches Tor-routed when Tor is on. (default)
+3. Wire: reuse sonar `\x1Fsticker\x1F<coord>\x1F<shortcode>\x1F<sha256>` prefix for interop with Sonar mesh clients. (confirmed lean)
+4. Offline peers: placeholder-only in v1 (Approach A); BLE inline-byte delivery (Approach B) deferred. (default)
+5. Pack sources: **full kind-10031 install sync like Sonar** (user choice, option C) — scope grows to include Approach C's install-list handling: local install/uninstall, kind 10031 publish/fetch via Nostr identity, pack picker UI, pack discovery optional.
+
+## Scope impact of decision 5
+v1 = Approach A + the kind-10031 layer of Approach C:
+- `StickerPackService` gains install/uninstall + installed-list sync (fetch 10031 on launch, publish on change, dedupe preserving first-seen order per spec).
+- Signing: kind 10031 events signed with the bitchat Nostr identity (`Nostr/NostrIdentity.swift`); confirm which identity is canonical before publishing.
+- Picker UI: port the shape of Sonar's `SonarEmojiPickerView` (pack tabs + sticker grid + install from coordinate), reusing `StickerCache` for thumbnails.
+- Still out: Signal import/publishing packs (stays in sonar-cli), Android impl, Approach B inline BLE bytes.


### PR DESCRIPTION
## What is Sonar, and why interoperable stickers?

[Sonar](https://sonarprivacy.xyz/) is an open, privacy-preserving messaging ecosystem built as a bitchat fork — it extends bitchat's Bluetooth-mesh chat with Nostr-based features (presence, store-and-forward, sticker packs) and a Tor-routed, fail-closed networking posture. It shares bitchat's goal: communication that works peer-to-peer over BLE and degrades gracefully when the internet is absent or hostile.

Stickers are one of the most-loved features in any chat app, but historically they've been a walled garden — packs locked to a single client, with no portability and no integrity guarantees. Sonar defined an open, Nostr-native format for them, [sonar-sticker-pack-v1](https://sonarprivacy.xyz/docs/#SONAR-STICKERS), so that:

- Pack metadata lives as **signed, addressable Nostr events** (kind `30031`) — any client can discover, verify authorship of, and render a pack without app-specific secrets.
- Sticker bytes live on **Blossom-compatible HTTPS storage**, content-addressed by the plaintext **sha256**, so a sticker reference is stable, verifiable, and tamper-evident — even if a pack author later edits it.
- The on-the-wire reference carried inside a chat message is a tiny `\u{1F}`-delimited string (pack coordinate + shortcode + pinned hash), small enough to ride bitchat's BLE mesh unchanged.

Bringing this to bitchat means **bitchat and Sonar users share the same sticker packs** — no proprietary lock-in, no re-encoding, full cross-client interop. A pack published once renders identically in both apps; an Android client implementing the same spec (documented in this PR's `docs/SONAR-STICKERS.md`) joins the same ecosystem for free.

- Project home: https://sonarprivacy.xyz/
- Sticker spec: https://sonarprivacy.xyz/docs/#SONAR-STICKERS

---

## Summary

Implements `sonar-sticker-pack-v1` in bitchat: send/receive stickers in any chat channel as ordinary content messages using the sonar-interop Unit-Separator-delimited wire format, resolve packs from Nostr kind 30031, download bytes over TorURLSession (fail-closed), and cache on disk keyed by sha256.

- Wire codec — pure-Swift StickerRefCodec, byte-identical to sonar-ffi mesh_sticker_content for mesh interop. No new BLE packet type; refs ride the existing encrypted envelopes.
- Resolution + cache — StickerPackService/StickerCache: HTTPS-only URLs, sha256 verify-before-write, MIME allowlist, <=4 MiB / <=4096px validation, content-addressed disk cache under files/stickers/ (covered by the existing panic wipe), negative-cache backoff, in-flight fetch coalescing.
- Pack-edit defense — sent refs pin the plaintext sha256; if the current pack no longer contains the shortcode+hash, the row renders an untrusted state instead of substituting a different image.
- Install list — StickerInstallStore (kind 10031) sync is opt-in, default OFF: publishing links the user's sticker tastes to their persistent Nostr identity, so fetch-only is the safe default.
- UI — StickerMessageView (placeholder while offline, taps to retry), picker sheet (install-by-coordinate, sync toggle with a privacy warning), composer button.
- Safety hardening — sticker content is routed to its own row so the Cashu/link scan never runs on it; sticker refs map to a clean notification body (ticket emoji + 'Sticker') so the raw ref never reaches the lock screen.
- NostrProtocol — kind-aware inbound tag cap (30031/10031 -> 220) so real 200-sticker packs actually parse; PeerCapabilities.stickers bit (bit 11) reserved for a future inline-BLE delivery path.
- Wire spec — docs/SONAR-STICKERS.md for Android/third-party interop.

Decisions, scope, and the full approach comparison are in docs/brainstorms/2026-07-27-sonar-stickers-bitchat.md.

Note on Localizable.xcstrings: the catalog was re-serialized by a tool, so the diff looks large. The only semantic change is +13 sticker keys (0 removed, all existing translations byte-identical); it will re-normalize on the next Xcode export.

## Non-goals (follow-ups)
- Signal-pack import/publishing (stays in sonar-cli).
- Animated sticker playback (renders the static first frame in v1; an ImageIO frame-iterator animator is the natural follow-up).
- Inline BLE delivery of sticker bytes for fully-offline peers (Approach B) — the .stickers capability bit is reserved for it.

## Test plan
- [x] StickerRefCodec — round-trip + sonar-ffi parity vectors, never-crash pathological inputs
- [x] StickerPackService.parsePackEvent — full spec-validation matrix (non-HTTPS, URL-without-sha256, bad MIME, dup shortcodes/hashes, >200 stickers, boundary dims, wrong kind, missing pack_format, malformed pubkey/d-tag)
- [x] StickerCache — hash-mismatch reject, path-traversal reject, 4 MiB cap, LRU eviction, negative-cache backoff, concurrent-fetch coalescing, removeAll
- [x] LocalizationCoverageTests green (main app + share extension)
- [x] swift build clean; 46 sticker/localization tests pass
- [ ] Runtime smoke on device/simulator (sticker render + picker) — not run in CI; recommend a manual check before merge
