### PR TITLE
Fix Android-to-iOS media transfers

### DIFF
--- a/bitchat/Protocols/BitchatFilePacket.swift
+++ b/bitchat/Protocols/BitchatFilePacket.swift
@@ -192,17 +192,22 @@ enum PrivateMediaMessageIdentity {
         let path = leafName as NSString
         let stem = path.deletingPathExtension
         let fileExtension = path.pathExtension.lowercased()
+        let lowerStem = stem.lowercased()
+        
+        let isImage = lowerStem.hasPrefix("img_")
+        let isVoice = lowerStem.hasPrefix("voice_")
+        
         switch true {
-        case stem.hasPrefix("img_"):
+        case isImage:
             guard fileExtension == "jpg" || fileExtension == "jpeg" else { return nil }
-        case stem.hasPrefix("voice_"):
-            guard fileExtension == "m4a" else { return nil }
+        case isVoice:
+            guard fileExtension == "m4a" || fileExtension == "ogg" else { return nil }
         default:
             return nil
         }
         let entropyToken = stem.split(separator: "_").last.map(String.init)
         let hasUUIDEntropy = entropyToken.flatMap(UUID.init(uuidString:)) != nil
-        let voiceBurstID = stem.hasPrefix("voice_")
+        let voiceBurstID = isVoice
             ? String(stem.dropFirst("voice_".count))
             : ""
         let hasBurstEntropy = voiceBurstID.count == 16

--- a/bitchat/Services/BLE/BLEFileTransferHandler.swift
+++ b/bitchat/Services/BLE/BLEFileTransferHandler.swift
@@ -177,6 +177,10 @@ final class BLEFileTransferHandler {
     /// quota, persistence, and UI-delivery behavior as public files.
     @discardableResult
     func handlePrivatePayload(_ payload: Data, from peerID: PeerID, timestamp: Date) -> Bool {
+        SecureLogger.debug(
+            "📁 handlePrivatePayload: received \(payload.count) bytes from \(peerID.id.prefix(8))…, prefix=[\(payload.prefix(8).map { String(format: "%02x", $0) }.joined(separator: " "))]",
+            category: .session
+        )
         let env = environment
         let peers = env.peersSnapshot()
         let senderNickname = BLEPeerSenderDisplayName.resolveKnownPeer(

--- a/bitchat/Services/BLE/BLEFileTransferPolicy.swift
+++ b/bitchat/Services/BLE/BLEFileTransferPolicy.swift
@@ -44,14 +44,17 @@ enum BLEIncomingFileRejection: Error, Equatable {
 enum BLEIncomingFileValidator {
     static func validate(payload: Data) -> Result<BLEIncomingFileAcceptance, BLEIncomingFileRejection> {
         guard let filePacket = BitchatFilePacket.decode(payload) else {
+            SecureLogger.error("❌ BLEIncomingFileValidator: BitchatFilePacket.decode returned nil", category: .session)
             return .failure(.malformedPayload)
         }
 
         guard FileTransferLimits.isValidPayload(filePacket.content.count) else {
+            SecureLogger.warning("🚫 BLEIncomingFileValidator: payloadTooLarge (\(filePacket.content.count) bytes)", category: .security)
             return .failure(.payloadTooLarge(bytes: filePacket.content.count))
         }
 
         guard let mime = MimeType(filePacket.mimeType), mime.isAllowed else {
+            SecureLogger.warning("🚫 BLEIncomingFileValidator: unsupportedMime '\(filePacket.mimeType ?? "nil")'", category: .security)
             return .failure(.unsupportedMime(
                 mimeType: filePacket.mimeType,
                 bytes: filePacket.content.count
@@ -59,10 +62,12 @@ enum BLEIncomingFileValidator {
         }
 
         guard mime.matches(data: filePacket.content) else {
+            let prefix = filePacket.content.prefix(20).map { String(format: "%02x", $0) }.joined(separator: " ")
+            SecureLogger.warning("🚫 BLEIncomingFileValidator: magicMismatch for \(mime) (prefix: \(prefix))", category: .security)
             return .failure(.magicMismatch(
                 mime: mime,
                 bytes: filePacket.content.count,
-                prefixHex: filePacket.content.prefix(20).map { String(format: "%02x", $0) }.joined(separator: " ")
+                prefixHex: prefix
             ))
         }
 

--- a/bitchat/Services/BLE/MimeType.swift
+++ b/bitchat/Services/BLE/MimeType.swift
@@ -169,7 +169,8 @@ enum MimeType: CaseIterable, Hashable {
     init?(_ mimeString: String?) {
         guard let mimeString else { return nil }
         
-        let normalized = mimeString.lowercased()
+        let cleaned = mimeString.split(separator: ";").first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? mimeString
+        let normalized = cleaned.lowercased()
 
         // Direct match with our canonical list
         if let match = MimeType.allCases.first(where: { $0.mimeString == normalized }) {

--- a/bitchatTests/MimeTypeTests.swift
+++ b/bitchatTests/MimeTypeTests.swift
@@ -87,4 +87,13 @@ struct MimeTypeTests {
         #expect(MimeType.octetStream.matches(data: randomData),
                 "application/octet-stream should always be considered valid")
     }
+
+    // MARK: - MIME Parsing with Parameters
+    @Test func mimeParsingWithParameters() throws {
+        let mime = MimeType("audio/ogg; codecs=opus")
+        #expect(mime == .ogg)
+
+        let mimeImage = MimeType("image/jpeg; charset=utf-8")
+        #expect(mimeImage == .jpeg)
+    }
 }

--- a/bitchatTests/Protocols/BitchatFilePacketTests.swift
+++ b/bitchatTests/Protocols/BitchatFilePacketTests.swift
@@ -155,4 +155,33 @@ final class BitchatFilePacketTests: XCTestCase {
             "media-910bd42c65060ab76bb6406f220c4516"
         )
     }
+
+    func testPrivateMediaMessageIdentityHandlesAndroidFilenameVariants() throws {
+        let alice = PeerID(str: "0011223344556677")
+        let bob = PeerID(str: "8899aabbccddeeff")
+
+        // Test uppercase prefix IMG_
+        let imgID = try XCTUnwrap(PrivateMediaMessageIdentity.stableID(
+            senderPeerID: alice,
+            recipientPeerID: bob,
+            fileName: "IMG_20260725_105708_1CC2760D-76AA-40C3-8013-C7FAA6C2EF99.jpg"
+        ))
+        XCTAssertTrue(PrivateMediaMessageIdentity.isStableID(imgID))
+
+        // Test uppercase prefix VOICE_ and extension .ogg for Android voice notes
+        let voiceID = try XCTUnwrap(PrivateMediaMessageIdentity.stableID(
+            senderPeerID: alice,
+            recipientPeerID: bob,
+            fileName: "VOICE_20260725_105708_0123456789abcdef.ogg"
+        ))
+        XCTAssertTrue(PrivateMediaMessageIdentity.isStableID(voiceID))
+
+        // Test standard lowercase voice_ note with .ogg extension
+        let lowerVoiceID = try XCTUnwrap(PrivateMediaMessageIdentity.stableID(
+            senderPeerID: alice,
+            recipientPeerID: bob,
+            fileName: "voice_20260725_105708_0123456789abcdef.ogg"
+        ))
+        XCTAssertTrue(PrivateMediaMessageIdentity.isStableID(lowerVoiceID))
+    }
 }

--- a/bitchatTests/Services/AndroidInteropTests.swift
+++ b/bitchatTests/Services/AndroidInteropTests.swift
@@ -1,0 +1,107 @@
+import BitFoundation
+import XCTest
+@testable import bitchat
+
+final class AndroidInteropTests: XCTestCase {
+
+    func testAndroidJPEGPayloadPassesValidation() throws {
+        // Construct an Android-shaped JPEG packet:
+        // fileName: "IMG_20260727_221600_12345678-1234-1234-1234-1234567890ab.jpg"
+        // mimeType: "image/jpeg; charset=utf-8"
+        // content: JPEG magic bytes + dummy data
+        var content = Data([0xFF, 0xD8, 0xFF])
+        content.append(contentsOf: Array(repeating: UInt8(0x00), count: 100))
+
+        let filePacket = BitchatFilePacket(
+            fileName: "IMG_20260727_221600_12345678-1234-1234-1234-1234567890ab.jpg",
+            fileSize: UInt64(content.count),
+            mimeType: "image/jpeg; charset=utf-8",
+            content: content
+        )
+
+        guard let encoded = filePacket.encode() else {
+            return XCTFail("Failed to encode JPEG file packet")
+        }
+
+        let result = BLEIncomingFileValidator.validate(payload: encoded)
+        switch result {
+        case .success(let acceptance):
+            XCTAssertEqual(acceptance.mime, .jpeg)
+            // Verify stableID resolves successfully
+            let localPeer = PeerID(str: "8899aabbccddeeff")
+            let senderPeer = PeerID(str: "0011223344556677")
+            let stableID = PrivateMediaMessageIdentity.stableID(
+                for: acceptance.filePacket,
+                senderPeerID: senderPeer,
+                recipientPeerID: localPeer
+            )
+            XCTAssertNotNil(stableID)
+        case .failure(let error):
+            XCTFail("Android JPEG validation failed: \(error)")
+        }
+    }
+
+    func testAndroidOGGVoiceNotePayloadPassesValidation() throws {
+        // Construct an Android-shaped OGG voice note packet:
+        // fileName: "VOICE_20260727_221600_0123456789abcdef.ogg"
+        // mimeType: "audio/ogg; codecs=opus"
+        // content: OGG magic bytes + dummy data
+        var content = Data([0x4F, 0x67, 0x67, 0x53])
+        content.append(contentsOf: Array(repeating: UInt8(0x00), count: 200)) // Must be > 100 bytes for leniency check? Wait, ogg doesn't need > 100 bytes but we append just in case
+
+        let filePacket = BitchatFilePacket(
+            fileName: "VOICE_20260727_221600_0123456789abcdef.ogg",
+            fileSize: UInt64(content.count),
+            mimeType: "audio/ogg; codecs=opus",
+            content: content
+        )
+
+        guard let encoded = filePacket.encode() else {
+            return XCTFail("Failed to encode OGG voice note packet")
+        }
+
+        let result = BLEIncomingFileValidator.validate(payload: encoded)
+        switch result {
+        case .success(let acceptance):
+            XCTAssertEqual(acceptance.mime, .ogg)
+            // Verify stableID resolves successfully
+            let localPeer = PeerID(str: "8899aabbccddeeff")
+            let senderPeer = PeerID(str: "0011223344556677")
+            let stableID = PrivateMediaMessageIdentity.stableID(
+                for: acceptance.filePacket,
+                senderPeerID: senderPeer,
+                recipientPeerID: localPeer
+            )
+            XCTAssertNotNil(stableID)
+        case .failure(let error):
+            XCTFail("Android OGG validation failed: \(error)")
+        }
+    }
+
+    func testAndroidOctetStreamFallbackPassesValidation() throws {
+        // Construct fallback application/octet-stream packet:
+        // fileName: "file_20260727_221600_12345678-1234-1234-1234-1234567890ab.bin"
+        // mimeType: "application/octet-stream"
+        // content: random bytes
+        let content = Data([0x01, 0x02, 0x03, 0x04, 0x05])
+
+        let filePacket = BitchatFilePacket(
+            fileName: "file_20260727_221600_12345678-1234-1234-1234-1234567890ab.bin",
+            fileSize: UInt64(content.count),
+            mimeType: "application/octet-stream",
+            content: content
+        )
+
+        guard let encoded = filePacket.encode() else {
+            return XCTFail("Failed to encode binary packet")
+        }
+
+        let result = BLEIncomingFileValidator.validate(payload: encoded)
+        switch result {
+        case .success(let acceptance):
+            XCTAssertEqual(acceptance.mime, .octetStream)
+        case .failure(let error):
+            XCTFail("Android binary fallback validation failed: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Changes Made
1. Robust MIME Type Parameter Stripping
.File modified: MimeType.swift
.Detail: Android sends MIME headers that include parameter directives (e.g., audio/ogg; codecs=opus, image/jpeg; charset=utf-8). The iOS parser was attempting exact matching on these strings, causing it to reject common media MIME types as .unsupportedMime. We updated the initializer to sanitize and strip trailing parameters before matching.

2. Case-Insensitivity & Android .ogg Voice Note Interoperability
.File modified: BitchatFilePacket.swift
.Detail: Android filename prefixes vary in casing (e.g., IMG_ or VOICE_). The stable ID calculation under PrivateMediaMessageIdentity.stableID was case-sensitive and failed for Android-cased filenames, preventing stable deduplication. We refactored it to be case-insensitive. We also enabled support for the .ogg file extension in the stable ID validation, as Android uses OGG container formats for voice bursts.

3. Comprehensive Payload Validation & Logging
.Files modified: 
  .BLEFileTransferHandler.swift
  .BLEFileTransferPolicy.swift
.Detail: Added explicit warning/error logging inside handlePrivatePayload and BLEIncomingFileValidator.validate to trace file validation failures, including MIME discrepancies and magic bytes, ensuring future protocol deviations are clear in debug sessions.\

Verifications & Testing:-

We created new unit and interop tests to verify the fixes:

MIME Parser Parameters: Added mimeParsingWithParameters() to MimeTypeTests.swift to ensure parameters are correctly stripped and parsed.
Case-Insensitive stableIDs: Added testPrivateMediaMessageIdentityHandlesAndroidFilenameVariants() to 
BitchatFilePacketTests.swift to verify IMG_ and .ogg formats resolve correctly.
Android Interop Suite: Added a new test file 
AndroidInteropTests.swift
 with:
testAndroidJPEGPayloadPassesValidation()
testAndroidOGGVoiceNotePayloadPassesValidation()
testAndroidOctetStreamFallbackPassesValidation()