### PR TITLE
Fix $$ escaping that broke every Xcode just recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,7 @@ check-clean-safety:
 check: check-clean-safety
     @echo "Checking prerequisites..."
     @command -v xcodebuild >/dev/null 2>&1 || (echo "❌ xcodebuild not found. Install full Xcode." && exit 1)
-    @developer_dir="$$(xcode-select -p 2>/dev/null)"; case "$$developer_dir" in *.app/Contents/Developer) ;; *) echo "❌ Full Xcode is not selected. Run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"; exit 1;; esac
+    @developer_dir="$(xcode-select -p 2>/dev/null)"; case "$developer_dir" in *.app/Contents/Developer) ;; *) echo "❌ Full Xcode is not selected. Run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"; exit 1;; esac
     @xcodebuild -version
     @echo "✅ Development environment ready (a signing identity is not required for just build)"
 
@@ -35,7 +35,7 @@ build: check
     @xcodebuild -project "{{project}}" -scheme "{{macos_scheme}}" -configuration Debug -derivedDataPath "{{derived_data}}" CODE_SIGNING_ALLOWED=NO build
 
 run: build
-    @app="{{derived_data}}/Build/Products/Debug/bitchat.app"; test -d "$$app" || (echo "❌ Built app not found at $$app" && exit 1); open "$$app"
+    @app="{{derived_data}}/Build/Products/Debug/bitchat.app"; test -d "$app" || (echo "❌ Built app not found at $app" && exit 1); open "$app"
 
 # Backward-compatible alias for the old quick-run recipe.
 dev-run: run


### PR DESCRIPTION
`just` has no Make-style `$$` escaping — recipe lines go to `sh` verbatim, so `$$` expands to the shell's PID. In `check`, `$$(xcode-select -p)` became `<pid>(xcode-select -p)` (never executed) and the `case` compared `<pid>developer_dir` against `*.app/Contents/Developer`, which can't match. It always took the failure branch, telling you to run an `xcode-select` command that had already succeeded.

`check` gates `build`, `run`, and `test-ios`, so every Xcode-backed recipe was unreachable. `run` had the same bug on its own line — `test -d "$$app"` tests `<pid>app` — and reported "Built app not found" after a successful build, so both lines are fixed here.

No workflow invokes `just`, which is why CI stayed green. Introduced in #1433.

Verified on Xcode 26.6 / just 1.57.0: `check` passes, `build` succeeds, `run` launches.
