### PR TITLE
Fix built-in relay actor isolation

### DIFF
--- a/bitchat/Nostr/NostrRelayManager.swift
+++ b/bitchat/Nostr/NostrRelayManager.swift
@@ -153,14 +153,18 @@ final class NostrRelayManager: ObservableObject {
     
     // Built-in relays carry private-message envelopes, so avoid relays known to
     // reject the kinds they use.
-    private static let builtInRelays = [
+    nonisolated private static let builtInRelays = [
         "wss://relay.damus.io",
         "wss://nos.lol",
         "wss://relay.primal.net",
         "wss://offchain.pub"
         // For local testing, you can add: "ws://localhost:8080"
     ]
-    private static let builtInRelaySet = Set(builtInRelays.compactMap { NostrRelayURL.normalized($0) })
+    /// Exposed so the relay settings UI can reject re-adding a built-in.
+    /// `nonisolated` because it is an immutable constant with no actor state.
+    nonisolated static let builtInRelayURLs = Set(
+        builtInRelays.compactMap { NostrRelayURL.normalized($0) }
+    )
 
     /// The relays private messages target: the built-in set plus any added by
     /// hand. Four hardcoded hostnames are four names for a censor to block, so
@@ -182,10 +186,6 @@ final class NostrRelayManager: ObservableObject {
         defaultRelaySet = Set(defaultRelays)
     }
 
-    /// Exposed so the relay settings UI can reject re-adding a built-in.
-    /// `nonisolated` because it is an immutable constant with no actor state.
-    nonisolated static var builtInRelayURLs: Set<String> { builtInRelaySet }
-    
     @Published private(set) var relays: [Relay] = []
     @Published private(set) var isConnected = false
     /// Whether a relay that carries private messages is connected. DMs


### PR DESCRIPTION
## Summary

- Mark the built-in relay list and its normalized URL set as immutable `nonisolated` constants.
- Replace the nonisolated computed proxy with the stored normalized set.

## Why

`NostrRelayManager` is main-actor isolated, but `builtInRelayURLs` is intentionally available outside the actor because it contains immutable relay strings used by the settings UI. Its computed accessor still read a main-actor-isolated backing property, producing a concurrency warning that becomes an error in Swift 6 language mode.

The backing constants now share the accessor's nonisolated boundary. Relay contents and runtime behavior are unchanged.

## Impact

Callers can continue reading the normalized built-in relay set without an actor hop, while the relay manager compiles without the Swift 6 isolation warning.

## Validation

- `swift test --filter NostrRelaySettingsTests` — 10 tests passed
- `swift test --parallel` — 1,949 tests in 208 suites passed
- `xcodebuild -quiet -project bitchat.xcodeproj -scheme 'bitchat (macOS)' -configuration Debug -derivedDataPath .DerivedData-agent CODE_SIGNING_ALLOWED=NO build` — succeeded
- `git diff --check` — passed

## Assistance disclosure

This contribution was prepared with OpenAI Codex assistance. The final diff and validation results were reviewed before submission.
