### PR TITLE
Chore: consolidate NostrEmbeddedBitChat base64url onto shared utility

### DIFF
--- a/bitchat/Nostr/NostrEmbeddedBitChat.swift
+++ b/bitchat/Nostr/NostrEmbeddedBitChat.swift
@@ -28,7 +28,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` base64url-encoded BitChat packet carrying a delivery/read ack for Nostr DMs.
@@ -51,7 +51,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` ACK (delivered/read) without an embedded recipient peer ID (geohash DMs).
@@ -72,7 +72,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` payload without an embedded recipient peer ID (used for geohash DMs).
@@ -94,7 +94,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     private static func normalizeRecipientPeerID(_ recipientPeerID: PeerID) -> PeerID {
@@ -109,14 +109,5 @@ struct NostrEmbeddedBitChat {
         }
         // Fallback: return as-is (expecting 16 hex chars) – caller should pass a valid peer ID
         return recipientPeerID
-    }
-
-    /// Base64url encode without padding
-    private static func base64URLEncode(_ data: Data) -> String {
-        let b64 = data.base64EncodedString()
-        return b64
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
     }
 }


### PR DESCRIPTION
## What

Removes the last duplicated base64url *encoder* in the Nostr path. `NostrEmbeddedBitChat` carried a private `base64URLEncode` that was character-for-character identical to the shared `Base64URLCoding.encode`. Its four call sites now use the shared utility and the duplicate helper is deleted.

## Why

Part of #642 (consolidate base64url helpers into a single utility). After this, the `bitchat1:` encoder has one auditable base64url implementation. `NostrProtocol` already uses `Base64URLCoding`.

## Scope note

`CashuTokenDecoder.base64URLDecode` is intentionally left as-is. It normalizes padding differently (strips existing `=` then re-pads, and rejects a length remainder of 1) and sits on the strict `/pay` send path, so it is not a drop-in equivalent of `Base64URLCoding.decode`. Folding it in would be a behavior change rather than a pure refactor, so it is out of scope here.

## Testing

- macOS Debug build succeeds (`xcodebuild ... CODE_SIGNING_ALLOWED=NO build`).
- `swift test --filter Base64URLCodingTests --filter NostrProtocolTests` passes (24 tests). The ack round-trip tests exercise `NostrEmbeddedBitChat`'s encoder directly.

No behavior change: the substituted implementation is byte-identical to the removed one.