### PR TITLE
fix(ble): don't spend the fragment scheduler's slot budget on blocked requests

### DIFF
--- a/bitchat/Services/BLE/BLEOutboundFragmentTransferScheduler.swift
+++ b/bitchat/Services/BLE/BLEOutboundFragmentTransferScheduler.swift
@@ -261,8 +261,6 @@ struct BLEOutboundFragmentTransferScheduler {
                 continue
             }
 
-            availableSlots -= 1
-
             guard activeTransfers.count < maxConcurrentTransfers else {
                 pendingTransfers.insert(request, at: 0)
                 results.append(.queued(request: request, transferId: transferId, position: .front))
@@ -270,11 +268,17 @@ struct BLEOutboundFragmentTransferScheduler {
             }
 
             guard activeTransfers[transferId] == nil else {
+                // Blocked on an already-active copy of this content: leave
+                // the slot budget untouched so a later, unrelated pending
+                // transfer can still start in this same pass instead of
+                // being starved until some other transfer happens to
+                // complete.
                 blockedFront.append(request)
                 results.append(.queued(request: request, transferId: transferId, position: .front))
                 continue
             }
 
+            availableSlots -= 1
             activeTransfers[transferId] = ActiveTransferState(
                 totalFragments: 0,
                 sentFragments: 0,

--- a/bitchatTests/Services/BLEOutboundFragmentTransferSchedulerTests.swift
+++ b/bitchatTests/Services/BLEOutboundFragmentTransferSchedulerTests.swift
@@ -261,6 +261,48 @@ struct BLEOutboundFragmentTransferSchedulerTests {
     }
 
     @Test
+    func blockedDuplicateAtFrontOfQueueDoesNotStarveALaterUnrelatedPendingTransfer() {
+        // Bug: reservePendingStarts spent the slot budget on a pending
+        // request the moment it was dequeued, before checking whether that
+        // request would actually be admitted. A resend of still-active
+        // content sitting at the front of the queue therefore consumed a
+        // slot even though it was deferred back to the queue rather than
+        // started -- starving an unrelated, genuinely startable transfer
+        // right behind it until some other transfer happened to complete.
+        var scheduler = BLEOutboundFragmentTransferScheduler()
+        let t1 = makeRequest(type: MessageType.fileTransfer.rawValue, transferId: "t1", payload: "file-a")
+        let t2 = makeRequest(type: MessageType.fileTransfer.rawValue, transferId: "t2", payload: "file-b")
+        let dupT1 = makeRequest(type: MessageType.fileTransfer.rawValue, transferId: "t1", payload: "file-a")
+        let unrelated = makeRequest(type: MessageType.fileTransfer.rawValue, transferId: "t3", payload: "file-c")
+
+        _ = scheduler.submit(t1, maxConcurrentTransfers: 2)
+        _ = scheduler.submit(t2, maxConcurrentTransfers: 2)
+        #expect(scheduler.activeCount == 2)
+
+        // Both slots are full, so a resend of "t1" (still active) and an
+        // unrelated transfer both land in the pending queue, in that order.
+        _ = scheduler.submit(dupT1, maxConcurrentTransfers: 2)
+        _ = scheduler.submit(unrelated, maxConcurrentTransfers: 2)
+        #expect(scheduler.pendingCount == 2)
+
+        // "t2" finishes; "t1" stays active, so the queued "t1" resend at the
+        // front of the queue is still blocked when we reserve pending starts.
+        let didActivate = scheduler.activateReservedTransfer(id: "t2", totalFragments: 1, workItems: [])
+        #expect(didActivate)
+        #expect(scheduler.markFragmentSent(transferId: "t2") == .complete(sentFragments: 1, totalFragments: 1))
+
+        let starts = scheduler.reservePendingStarts(maxConcurrentTransfers: 2)
+
+        let startedTransferIds: [String] = starts.compactMap {
+            if case let .start(_, reservedTransferId) = $0 { return reservedTransferId }
+            return nil
+        }
+        #expect(startedTransferIds == ["t3"], "the unrelated pending transfer must start in the same pass despite the blocked front item")
+        #expect(scheduler.activeCount == 2, "t1 (still running) and the newly-started t3")
+        #expect(scheduler.pendingCount == 1, "only the blocked t1 resend remains queued")
+    }
+
+    @Test
     func removeAllReturnsActiveWorkItemsAndDropsPendingTransfers() {
         var scheduler = BLEOutboundFragmentTransferScheduler()
         let active = makeRequest(type: MessageType.fileTransfer.rawValue, transferId: "active")


### PR DESCRIPTION
## Problem

`BLEOutboundFragmentTransferScheduler.reservePendingStarts(maxConcurrentTransfers:)` walks the pending queue and starts as many transfers as there are free slots. For each dequeued request it decremented `availableSlots` **before** checking whether the request would actually be admitted.

A request is *blocked* (deferred back into the queue instead of started) when its `transferId` already has an active copy in flight — e.g. a resend of content that's still being sent, sitting at the front of the pending queue after `submit()` inserted it there. That blocked request still consumed a slot from the budget even though nothing actually started. With the concurrency cap this repo ships (`TransportConfig.bleMaxConcurrentTransfers = 2`), a single blocked item at the front of the queue can zero out `availableSlots` and end the `while` loop before it ever reaches a later, unrelated, genuinely startable pending transfer — which then sits starved until some *other*, unrelated transfer happens to complete and trigger another pass, instead of starting immediately when real capacity (`activeTransfers.count < maxConcurrentTransfers`) was already available.

This is a real, reachable path: `submit()` already anticipates "resubmit the same transferId while it's still active" (see the existing `submitQueuesDuplicateActiveTransferAtFront` test), and `reservePendingStarts` is invoked from `BLEService.startNextPendingTransferIfNeeded()` every time any transfer completes — an ordinary sequence of concurrent file/voice/image transfers at the shipped cap of 2 can trigger it.

## Fix

Move `availableSlots -= 1` to the point where a transfer is actually admitted into `activeTransfers` (right before the `.start` result), instead of unconditionally at the top of each loop iteration. A blocked request no longer touches the budget, so the loop keeps checking the rest of the queue in the same pass.

## Test plan

- [x] Added `blockedDuplicateAtFrontOfQueueDoesNotStarveALaterUnrelatedPendingTransfer` to `BLEOutboundFragmentTransferSchedulerTests.swift`: fills both slots (`t1`, `t2`), queues a resend of `t1` (still active) followed by an unrelated `t3`, completes `t2` (leaving `t1` active so the `t1` resend stays blocked), then asserts `t3` starts in the same `reservePendingStarts` pass and only the blocked `t1` resend remains queued.
- [x] Manually traced the test against the pre-fix code path by hand (no Swift toolchain available in my environment to run `swift test` — see note below): the old code decrements the budget to 0 while processing the blocked `t1` resend and exits the loop immediately, so `t3` is never dequeued this pass at all — `startedTransferIds` comes back empty and the assertions fail. With the fix, the blocked item leaves the budget untouched, `t3` is dequeued next and starts, and the assertions pass.
- [x] Manually re-verified every other existing test in the file against the new code path (order of operations for the two other branches — the unconditional-start no-transferId case, and the duplicate-content-drop case — is unchanged; only the transfer-blocked-on-active-id branch's slot bookkeeping moved).

**Disclosure:** I don't have Xcode/a Swift toolchain in my environment, so I could not run `swift test` directly — I verified this change by careful manual trace of both the old and new code against the new test's exact inputs (documented above), but please treat CI / a maintainer's local run as the authoritative check before merging.
