### PR TITLE
Defer alert-binding dismissal writes out of the view update

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -182,7 +182,13 @@ struct ContentView: View {
                       !hasRootModalPresentation else {
                     return
                 }
-                appChromeModel.showBluetoothAlert = false
+                // SwiftUI can invoke this setter inside a view update (the
+                // alert dismisses when a scenePhase change re-evaluates the
+                // `get`); publishing synchronously there is undefined
+                // behavior, so defer the write one hop.
+                Task { @MainActor in
+                    appChromeModel.showBluetoothAlert = false
+                }
             }
         )
     }
@@ -205,7 +211,11 @@ struct ContentView: View {
                       !hasRootModalPresentationBesidesVoiceAlert else {
                     return
                 }
-                voiceRecordingVM.showAlert = false
+                // Same deferral as the Bluetooth alert above: the setter can
+                // run inside a view update when the sheet state changes.
+                Task { @MainActor in
+                    voiceRecordingVM.showAlert = false
+                }
             }
         )
     }


### PR DESCRIPTION
Fixes the \`Publishing changes from within view updates is not allowed\` runtime warning at \`ContentView.swift:185\`, reproduced on device by launching with Bluetooth off (alert up) and changing scene phase: SwiftUI invokes the alert binding's setter inside the view update when the \`get\` re-evaluates to false, and both root alert bindings (Bluetooth + voice, introduced with #1460) wrote their \`@Published\` backing state synchronously from that setter. The write now defers one main-actor hop.

Found during #1498 device validation; independent of that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)