### PR TITLE
Don't suggest blocked people in @-mentions

### DIFF
--- a/bitchat/ViewModels/ChatComposerCoordinator.swift
+++ b/bitchat/ViewModels/ChatComposerCoordinator.swift
@@ -31,6 +31,10 @@ protocol ChatComposerContext: AnyObject {
     /// The transport's own nickname (excluded from autocomplete candidates).
     var meshNickname: String { get }
     func meshPeerNicknames() -> [PeerID: String]
+    /// True when this mesh nickname belongs to a blocked peer.
+    func isMeshNicknameBlocked(_ nickname: String) -> Bool
+    /// True when this geohash pubkey is blocked for location chats.
+    func isNostrBlocked(pubkeyHexLowercased: String) -> Bool
 
     // MARK: Geohash identity (shared with the other contexts)
     var geoNicknames: [String: String] { get }
@@ -40,8 +44,8 @@ protocol ChatComposerContext: AnyObject {
 extension ChatViewModel: ChatComposerContext {
     // `autocompleteSuggestions`, `autocompleteRange`, `showAutocomplete`,
     // `selectedAutocompleteIndex`, `nickname`, `myPeerID`, `activeChannel`,
-    // `geoNicknames`, `meshPeerNicknames()`, and
-    // `deriveNostrIdentity(forGeohash:)` are shared requirements with the
+    // `geoNicknames`, `meshPeerNicknames()`, `isNostrBlocked(pubkeyHexLowercased:)`,
+    // and `deriveNostrIdentity(forGeohash:)` are shared requirements with the
     // other contexts or satisfied by existing `ChatViewModel` members. The
     // members below flatten nested service accesses into intent-named calls.
 
@@ -59,6 +63,13 @@ extension ChatViewModel: ChatComposerContext {
 
     var meshNickname: String {
         meshService.myNickname
+    }
+
+    func isMeshNicknameBlocked(_ nickname: String) -> Bool {
+        for (peerID, nick) in meshService.getPeerNicknames() where nick == nickname {
+            if isPeerBlocked(peerID) { return true }
+        }
+        return false
     }
 }
 
@@ -136,11 +147,14 @@ private extension ChatComposerCoordinator {
         switch context.activeChannel {
         case .mesh:
             let values = context.meshPeerNicknames().values
-            return Array(values.filter { $0 != context.meshNickname })
+            return Array(values.filter { nick in
+                nick != context.meshNickname && !context.isMeshNicknameBlocked(nick)
+            })
 
         case .location(let channel):
             var tokens = Set<String>()
             for (pubkey, nick) in context.geoNicknames {
+                guard !context.isNostrBlocked(pubkeyHexLowercased: pubkey) else { continue }
                 tokens.insert("\(nick)#\(pubkey.suffix(4))")
             }
             if let identity = try? context.deriveNostrIdentity(forGeohash: channel.geohash) {

--- a/bitchatTests/ChatComposerCoordinatorContextTests.swift
+++ b/bitchatTests/ChatComposerCoordinatorContextTests.swift
@@ -52,8 +52,18 @@ private final class MockChatComposerContext: ChatComposerContext {
     var activeChannel: ChannelID = .mesh
     var meshNickname = "me"
     var meshNicknamesByPeerID: [PeerID: String] = [:]
+    var blockedMeshNicknames: Set<String> = []
+    var blockedNostrPubkeys: Set<String> = []
 
     func meshPeerNicknames() -> [PeerID: String] { meshNicknamesByPeerID }
+
+    func isMeshNicknameBlocked(_ nickname: String) -> Bool {
+        blockedMeshNicknames.contains(nickname)
+    }
+
+    func isNostrBlocked(pubkeyHexLowercased: String) -> Bool {
+        blockedNostrPubkeys.contains(pubkeyHexLowercased.lowercased())
+    }
 
     // Geohash identity
     var geoNicknames: [String: String] = [:]
@@ -117,6 +127,33 @@ struct ChatComposerCoordinatorContextTests {
         ]
 
         coordinator.updateAutocomplete(for: "@ca", cursorPosition: 3)
+        #expect(context.queriedPeerCandidates == [["carol#dddd"]])
+    }
+
+    @Test @MainActor
+    func updateAutocomplete_excludesBlockedMeshAndGeohashPeers() {
+        let context = MockChatComposerContext()
+        let coordinator = ChatComposerCoordinator(context: context)
+        context.meshNicknamesByPeerID = [
+            PeerID(str: "1111111111111111"): "alice",
+            PeerID(str: "2222222222222222"): "eve",
+            PeerID(str: "3333333333333333"): "me"
+        ]
+        context.blockedMeshNicknames = ["eve"]
+        context.queryResult = (["@alice"], NSRange(location: 0, length: 3))
+
+        coordinator.updateAutocomplete(for: "@a", cursorPosition: 2)
+        #expect(context.queriedPeerCandidates == [["alice"]])
+
+        context.activeChannel = .location(GeohashChannel(level: .city, geohash: "u4pruydq"))
+        context.geoNicknames = [
+            "aaaabbbbccccdddd": "carol",
+            "bbbbccccddddeeee": "blocked"
+        ]
+        context.blockedNostrPubkeys = ["bbbbccccddddeeee"]
+        context.queriedPeerCandidates = []
+
+        coordinator.updateAutocomplete(for: "@", cursorPosition: 1)
         #expect(context.queriedPeerCandidates == [["carol#dddd"]])
     }
 

--- a/bitchatTests/ChatComposerCoordinatorContextTests.swift
+++ b/bitchatTests/ChatComposerCoordinatorContextTests.swift
@@ -145,16 +145,17 @@ struct ChatComposerCoordinatorContextTests {
         coordinator.updateAutocomplete(for: "@a", cursorPosition: 2)
         #expect(context.queriedPeerCandidates == [["alice"]])
 
-        context.activeChannel = .location(GeohashChannel(level: .city, geohash: "u4pruydq"))
-        context.geoNicknames = [
+        let geoContext = MockChatComposerContext()
+        let geoCoordinator = ChatComposerCoordinator(context: geoContext)
+        geoContext.activeChannel = .location(GeohashChannel(level: .city, geohash: "u4pruydq"))
+        geoContext.geoNicknames = [
             "aaaabbbbccccdddd": "carol",
             "bbbbccccddddeeee": "blocked"
         ]
-        context.blockedNostrPubkeys = ["bbbbccccddddeeee"]
-        context.queriedPeerCandidates = []
+        geoContext.blockedNostrPubkeys = ["bbbbccccddddeeee"]
 
-        coordinator.updateAutocomplete(for: "@", cursorPosition: 1)
-        #expect(context.queriedPeerCandidates == [["carol#dddd"]])
+        geoCoordinator.updateAutocomplete(for: "@", cursorPosition: 1)
+        #expect(geoContext.queriedPeerCandidates == [["carol#dddd"]])
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- mesh autocomplete skips nicknames that belong to a blocked peer
- geohash autocomplete skips blocked Nostr pubkeys the same way

Small privacy/UX gap — blocking someone and still seeing them in the mention list felt wrong.

## Test plan
- [ ] block a mesh peer, type `@` + their prefix — they shouldn't appear
- [ ] unblock them — they show up again
- [ ] same for a blocked geohash person in a location channel

Made with [Cursor](https://cursor.com)