### PR TITLE
add flake.nix for reproducible Nix dev shell

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,7 @@ default:
     @echo "  just build              Build the macOS app without signing"
     @echo "  just test               Run the SwiftPM test suite"
     @echo "  just test-ios           Run tests on the iPhone 17 simulator"
+    @echo "  just develop            Enter the Nix dev shell (swiftlint, xcbeautify, jq)"
     @echo "  just clean              Remove repo-local build artifacts only"
     @echo "  just nuke               Also remove nested package build caches"
     @echo "  just check              Validate the development environment"
@@ -59,6 +60,11 @@ nuke: clean
     @find localPackages -type d -name .build -prune -exec rm -rf -- {} +
     @rm -rf -- ".cache"
     @echo "✅ Removed repository build caches; tracked files were untouched"
+
+# Enter a Nix dev shell with project tooling (swiftlint, xcbeautify, jq).
+# Requires Nix with flakes enabled. See flake.nix for the package list.
+develop:
+    @nix develop --command $SHELL
 
 info:
     @echo "BitChat - decentralized mesh messaging"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "BitChat — decentralized peer-to-peer mesh messaging";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            jq
+            swiftlint
+            xcbeautify
+          ];
+
+          shellHook = ''
+            unset DEVELOPER_DIR SDKROOT
+            unset NIX_CFLAGS_COMPILE NIX_LDFLAGS
+            unset NIX_APPLE_SDK_VERSION NIX_BINTOOLS
+
+            # Strip SDK-related Nix compiler wrapper vars (arch-dependent names)
+            for var in $(env | grep -E '^NIX_(CC|BINTOOLS)_WRAPPER_' | cut -d= -f1); do
+              unset "$var"
+            done
+
+            # System /usr/bin must come first so xcrun detects Xcode/CLT, not
+            # the incompatible Nix SDK.
+            export PATH="/usr/bin:/usr/sbin:$PATH"
+          '';
+        };
+      });
+    };
+}


### PR DESCRIPTION
Provides a nix develop shell with swiftlint, xcbeautify, and jq for local development. Includes shellHook to strip Nix stdenv vars (DEVELOPER_DIR, SDKROOT, etc.) that otherwise break Xcode/Swift SDK detection on macOS.

Also adds 'just develop' recipe as a convenience alias.