### PR TITLE
Fix EnvironmentObject crash inside NavigationStack sheet

### DIFF
--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -27,6 +27,10 @@ struct ContentPeopleSheetView: View {
     @EnvironmentObject private var privateConversationModel: PrivateConversationModel
     @EnvironmentObject private var verificationModel: VerificationModel
     @EnvironmentObject private var conversationUIModel: ConversationUIModel
+    @EnvironmentObject private var locationChannelsModel: LocationChannelsModel
+    @EnvironmentObject private var peerListModel: PeerListModel
+    @EnvironmentObject private var publicChatModel: PublicChatModel
+    @EnvironmentObject private var privateInboxModel: PrivateInboxModel
     @Environment(\.scenePhase) private var scenePhase
 
     @Binding var showSidebar: Bool
@@ -184,6 +188,14 @@ struct ContentPeopleSheetView: View {
                 }
             }
         }
+        .environmentObject(appChromeModel)
+        .environmentObject(privateConversationModel)
+        .environmentObject(verificationModel)
+        .environmentObject(conversationUIModel)
+        .environmentObject(locationChannelsModel)
+        .environmentObject(peerListModel)
+        .environmentObject(publicChatModel)
+        .environmentObject(privateInboxModel)
         .themedSheetBackground()
         .foregroundColor(palette.primary)
         .confirmationDialog(


### PR DESCRIPTION
ContentPeopleSheetView was missing @EnvironmentObject declarations for locationChannelsModel, peerListModel, publicChatModel, and privateInboxModel. Its child views inside the NavigationStack (ContentPeopleListView, MessageListView) require these objects, but SwiftUI's sheet presentation context can lose inherited environment objects during the view graph update cycle, causing EnvironmentObject.error() to fatal-error.

Re-inject all eight environment objects on the NavigationStack so child views can always resolve them regardless of environment propagation issues.