### PR TITLE
Make the completion-grace restart test deterministic

### DIFF
--- a/bitchat/Noise/NoiseSessionManager.swift
+++ b/bitchat/Noise/NoiseSessionManager.swift
@@ -1028,6 +1028,27 @@ final class NoiseSessionManager {
             .cancel()
     }
 
+    #if DEBUG
+    /// Fires a pending suppressed-initiation recovery immediately instead of
+    /// waiting out the completion-grace timer, so tests can inject a grace
+    /// period too large to lose against a starved runner and still exercise
+    /// the recovery path deterministically.
+    func _test_fireSuppressedInitiationRecovery(for peerID: PeerID) {
+        managerQueue.sync(flags: .barrier) {
+            guard let pending = suppressedInitiationRecoveryTimeouts
+                .removeValue(forKey: peerID) else {
+                return
+            }
+            pending.cancel()
+            guard let current = sessions[peerID],
+                  current.isEstablished() else {
+                return
+            }
+            requestHandshakeRecovery(for: peerID)
+        }
+    }
+    #endif
+
     private func requestHandshakeRecovery(
         for peerID: PeerID,
         after delay: TimeInterval = 0

--- a/bitchat/Services/NoiseEncryptionService.swift
+++ b/bitchat/Services/NoiseEncryptionService.swift
@@ -1089,6 +1089,10 @@ final class NoiseEncryptionService {
     func _test_initiateAutomaticRekey(for peerID: PeerID) throws {
         try initiateAutomaticRekey(for: peerID)
     }
+
+    func _test_fireSuppressedInitiationRecovery(for peerID: PeerID) {
+        sessionManager._test_fireSuppressedInitiationRecovery(for: peerID)
+    }
     #endif
     
     deinit {

--- a/bitchatTests/Services/NoiseEncryptionServiceTests.swift
+++ b/bitchatTests/Services/NoiseEncryptionServiceTests.swift
@@ -962,15 +962,20 @@ struct NoiseEncryptionServiceTests {
 
     @Test("Immediate legacy restart during completion grace converges once")
     func immediateLegacyRestartDuringCompletionGrace() async throws {
+        // The grace period must still be open when the restart initiation
+        // arrives below. A small value races the wall clock on a starved
+        // runner, so inject one no test run can outlive; the recovery half
+        // is then fired explicitly instead of waiting out the timer.
+        let unlosableGracePeriod: TimeInterval = 600
         let firstKeychain = MockKeychain()
         let secondKeychain = MockKeychain()
         let first = NoiseEncryptionService(
             keychain: firstKeychain,
-            recentInitiatorCompletionGracePeriod: 0.03
+            recentInitiatorCompletionGracePeriod: unlosableGracePeriod
         )
         let second = NoiseEncryptionService(
             keychain: secondKeychain,
-            recentInitiatorCompletionGracePeriod: 0.03
+            recentInitiatorCompletionGracePeriod: unlosableGracePeriod
         )
         let firstPeerID = PeerID(publicKey: first.getStaticPublicKeyData())
         let secondPeerID = PeerID(publicKey: second.getStaticPublicKeyData())
@@ -1035,6 +1040,7 @@ struct NoiseEncryptionServiceTests {
         )
         #expect(lower.hasEstablishedSession(with: higherPeerID))
 
+        lower._test_fireSuppressedInitiationRecovery(for: higherPeerID)
         let requested = await TestHelpers.waitUntil(
             { recovery.messages.count == 1 },
             timeout: TestConstants.longTimeout


### PR DESCRIPTION
## Problem

`immediateLegacyRestartDuringCompletionGrace` is the most-sighted flake in CI — seven red runs across #1502 (twice in a row), #1477, #883, #1364, and main itself, each with the same 5-issue signature.

The test injects a **0.03s** `recentInitiatorCompletionGracePeriod` and its premise is that the restart initiation arrives *inside* that window. But between starting the grace clock (handshake completion) and processing the restart message, the test constructs a whole new `NoiseEncryptionService` — keypair generation and keychain work. On the loaded 2-core CI runner that alone can exceed 30ms, the window expires, the lower peer processes the initiation as a legitimate fresh handshake instead of suppressing it, and the `== nil` expectations cascade.

Same starvation class #1491 was built to kill — a tiny injected timing constant racing real work — but it slipped the guard because it's an injected grace period, not a wait.

## Fix

- The test injects a grace period no test run can outlive (600s), so both timing-dependent decisions — in-grace suppression of the first initiation and pending-recovery coalescing of the duplicate — are decided deterministically rather than against the wall clock.
- The deferred recovery is then fired explicitly through a new DEBUG-only hook (`NoiseSessionManager._test_fireSuppressedInitiationRecovery(for:)`, passed through `NoiseEncryptionService` in the existing `_test_` style) instead of waiting out the real timer. The hook cancels the scheduled work item before requesting recovery, so the converged-exactly-once assertion can't double-fire.

No production behavior changes — the hook is `#if DEBUG` and only cancels-then-fires the already-scheduled recovery under the manager queue barrier.

## Verification

All results below are count-checked against `xcresulttool` totals (an earlier verification pass used a single-test `-only-testing` filter that silently matched **zero** tests; everything was re-run with suite-level filters and verified to have actually executed 30 tests).

- Full `NoiseEncryptionServiceTests` suite (30 tests) green on the iOS simulator.
- Fixed suite: **30/30 × 5 consecutive runs under 16× CPU oversubscription** (a 6th run was lost to a simulator app-launch refusal under load — no tests executed, infrastructure not test failure).
- Honest caveat: the *old* test did not reproduce locally in 2 suite runs under the same load — the starvation needs the slow 2-core CI runner. The diagnosis rests on the mechanism plus the identical assertion signature in all seven CI sightings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)