### PR TITLE
Fix the SimulatedMesh announce-loss flake

### DIFF
--- a/bitchatTests/Simulation/SimulatedMesh.swift
+++ b/bitchatTests/Simulation/SimulatedMesh.swift
@@ -58,10 +58,19 @@ final class SimulatedMesh {
         )
         let index = nodes.count
         let node = Node(service: service, scheduler: scheduler)
+        // An earlier node's engine can fire its tap (which reads `emitted`
+        // under the lock) while this append reallocates the array.
+        lock.lock()
         nodes.append(node)
         neighbors.append([])
         emitted.append([])
-        service.setNickname(nickname)
+        lock.unlock()
+        // The tap must be live before `setNickname` below: setNickname
+        // force-announces asynchronously on the engine, and if that slot
+        // ran in the gap before a later tap install, the announce was
+        // emitted invisibly while still stamping the wall-clock announce
+        // throttle — swallowing `announceAll`'s forced announce on a
+        // starved runner (the CI flake this ordering fixes).
         service._test_onOutboundPacket = { [weak self] packet in
             // Runs on the sender's engine; only buffer here — delivering
             // inline would nest one engine inside another.
@@ -71,6 +80,7 @@ final class SimulatedMesh {
             self.emitted[index].append(packet)
             self.lock.unlock()
         }
+        service.setNickname(nickname)
         return node
     }
 
@@ -175,8 +185,16 @@ final class SimulatedMesh {
     }
 
     /// Full discovery round: every node announces, traffic settles.
+    ///
+    /// Resets each node's announce throttle first: the throttle window is
+    /// wall-clock, so any announce that already ran (setNickname's, in
+    /// `addNode`) would otherwise swallow this forced one whenever the two
+    /// land within the forced minimum interval — which is always, on any
+    /// runner. `forceAnnounce(from:)` deliberately does NOT reset — the
+    /// panic-rotation tests pin the production reset behavior through it.
     func announceAll() {
         for node in nodes {
+            node.service._test_resetAnnounceThrottle()
             node.service._test_forceAnnounce()
         }
         pump()


### PR DESCRIPTION
## Problem

`SimulatedMeshTests.announceExchangeBindsLinksAndConnectsPeers` failed four runs on July 30 (three on main — including merges that touch no BLE code — and one PR run), always with the same 4-issue signature: both central bindings nil, both peer lists empty.

Root cause is a startup race in the `SimulatedMesh` harness, not in the engine:

1. `addNode` calls `setNickname`, which **force-announces asynchronously on the engine** — one statement *before* the outbound tap is installed.
2. When a starved runner lets that engine slot run inside the gap, the announce is emitted invisibly (no tap) while still stamping the wall-clock announce throttle.
3. `announceAll`'s forced announce then arrives well inside the **0.15s forced minimum interval** (`bleForceAnnounceMinIntervalSeconds`) and is swallowed.
4. No discovery traffic ever reaches the mesh → bindings nil, peer lists empty.

On fast machines the tap install wins the two-statement race, which is why this only fires on the loaded CI runner — and per-test, which is why the sibling tests passed in the same red runs.

**Reproduced deterministically**: forcing the ordering with a 5ms sleep after `setNickname` makes **all 8 SimulatedMesh tests fail** on the old harness with exactly the CI signature — and pass on the fixed one.

## Fix (harness-only)

- Install the outbound tap **before** `setNickname`, so an early nickname announce is captured instead of silently lost.
- `announceAll` resets each node's announce throttle before forcing: the throttle window is wall-clock, so prior announce debt could otherwise always swallow the discovery round. `forceAnnounce(from:)` deliberately keeps no-reset — the panic-rotation tests pin the production throttle-reset behavior through it.
- Take the harness lock around `addNode`'s array appends, which could race an earlier node's engine firing the tap (which reads `emitted` under the same lock) while the append reallocates.

## Verification (count-checked via xcresulttool)

- Suite green normally: 8/8.
- **8/8 × 6 runs under 16× CPU oversubscription.**
- **8/8 under the adversarial forced ordering** (5ms sleep) that fails 8/8 without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)