### PR TITLE
fix: stop EnvironmentObject crash in the people sheet

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -92,6 +92,9 @@ struct ContentView: View {
     @EnvironmentObject private var conversationUIModel: ConversationUIModel
     @EnvironmentObject private var locationChannelsModel: LocationChannelsModel
     @EnvironmentObject private var sharedContentImportModel: SharedContentImportModel
+    @EnvironmentObject private var peerListModel: PeerListModel
+    @EnvironmentObject private var publicChatModel: PublicChatModel
+    @EnvironmentObject private var privateInboxModel: PrivateInboxModel
 
     @StateObject private var voiceRecordingVM = VoiceRecordingViewModel()
     @State private var messageText = ""
@@ -297,6 +300,17 @@ struct ContentView: View {
                 showImagePicker: $showImagePicker,
                 imagePickerSourceType: $imagePickerSourceType
             )
+            // Sheets + NavigationStack can drop inherited EnvironmentObjects on
+            // some iOS versions (#1558). Re-inject every model the sheet tree
+            // reads so ContentPeopleListView / MessageListView never crash.
+            .environmentObject(appChromeModel)
+            .environmentObject(privateConversationModel)
+            .environmentObject(verificationModel)
+            .environmentObject(conversationUIModel)
+            .environmentObject(locationChannelsModel)
+            .environmentObject(peerListModel)
+            .environmentObject(publicChatModel)
+            .environmentObject(privateInboxModel)
             #else
             ContentPeopleSheetView(
                 showSidebar: $showSidebar,
@@ -314,6 +328,14 @@ struct ContentView: View {
                 onSendMessage: sendMessage,
                 showMacImagePicker: $showMacImagePicker
             )
+            .environmentObject(appChromeModel)
+            .environmentObject(privateConversationModel)
+            .environmentObject(verificationModel)
+            .environmentObject(conversationUIModel)
+            .environmentObject(locationChannelsModel)
+            .environmentObject(peerListModel)
+            .environmentObject(publicChatModel)
+            .environmentObject(privateInboxModel)
             #endif
         }
         .sheet(isPresented: $appChromeModel.isAppInfoPresented) {

--- a/bitchatTests/ViewSmokeTests.swift
+++ b/bitchatTests/ViewSmokeTests.swift
@@ -542,6 +542,9 @@ struct ViewSmokeTests {
         ])
         try? await Task.sleep(nanoseconds: 50_000_000)
 
+        // ContentView + people sheet must mount with the full feature-model
+        // set (peerList / publicChat / privateInbox included). Missing any of
+        // those crashes the NavigationStack sheet on some iOS versions (#1558).
         _ = mount(installSmokeEnvironment(ContentView(), featureModels: featureModels))
         _ = mount(installSmokeEnvironment(ContentPeopleSheetHarness(), featureModels: featureModels))
 


### PR DESCRIPTION
## Summary
- Re-inject every environment object the people-sheet tree needs (`peerListModel`, `publicChatModel`, `privateInboxModel`, plus the ones ContentView already held) when presenting the sheet.
- NavigationStack-hosted sheets can drop inherited EnvironmentObjects on some iOS versions, which crashes `ContentPeopleListView` / `MessageListView`.

Fixes #1558

## Test plan
- [x] `just test` (SwiftPM suite)
- [ ] On device/simulator: open the people sheet from mesh and from a DM — no crash
- [ ] Open fingerprint / verification from inside the sheet — still works


Made with [Cursor](https://cursor.com)