### PR TITLE
Deflake VoiceRecorderTests: replace timed semaphores with async events

### DIFF
--- a/bitchatTests/VoiceRecorderTests.swift
+++ b/bitchatTests/VoiceRecorderTests.swift
@@ -10,10 +10,41 @@ import Foundation
 import Testing
 @testable import bitchat
 
+/// One-shot event that bridges synchronous production seams to async tests
+/// without blocking a shared dispatch worker while waiting for the seam.
+private final class VoiceRecorderAsyncEvent: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock { () -> Bool in
+                guard !isSignaled else { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+    }
+
+    func signal() {
+        let continuations = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+            guard !isSignaled else { return [] }
+            isSignaled = true
+            defer { waiters.removeAll() }
+            return waiters
+        }
+        continuations.forEach { $0.resume() }
+    }
+}
+
 private final class VoiceRecorderTestSession: SessionApplying, @unchecked Sendable {
     private let lock = NSLock()
     private let activationGate = DispatchSemaphore(value: 0)
-    private let activationBeganGate = DispatchSemaphore(value: 0)
+    private let activationBegan = VoiceRecorderAsyncEvent()
     private let shouldGateFirstActivation: Bool
     private var gatedFirstActivation = false
     private var _activationCalls: [Bool] = []
@@ -34,23 +65,13 @@ private final class VoiceRecorderTestSession: SessionApplying, @unchecked Sendab
             return true
         }
         if shouldWait {
-            activationBeganGate.signal()
+            activationBegan.signal()
             activationGate.wait()
         }
     }
 
-    func waitUntilActivationBegan(
-        timeout: DispatchTimeInterval = .seconds(5)
-    ) async -> Bool {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                continuation.resume(
-                    returning: self.activationBeganGate.wait(
-                        timeout: DispatchTime.now() + timeout
-                    ) == .success
-                )
-            }
-        }
+    func waitUntilActivationBegan() async {
+        await activationBegan.wait()
     }
 
     func resumeActivation() {
@@ -155,7 +176,7 @@ private final class TestVoiceAudioRecorderFactory: VoiceAudioRecorderCreating {
 /// this remains deterministic when the full test suite saturates the executor.
 private final class VoiceRecorderPaddingGate: @unchecked Sendable {
     private let lock = NSLock()
-    private let enteredGate = DispatchSemaphore(value: 0)
+    private let entered = VoiceRecorderAsyncEvent()
     private var isOpen = false
     private var openWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -166,25 +187,15 @@ private final class VoiceRecorderPaddingGate: @unchecked Sendable {
                 openWaiters.append(continuation)
                 return false
             }
-            enteredGate.signal()
+            entered.signal()
             if resumeImmediately {
                 continuation.resume()
             }
         }
     }
 
-    func waitUntilEntered(
-        timeout: DispatchTimeInterval = .seconds(5)
-    ) async -> Bool {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                continuation.resume(
-                    returning: self.enteredGate.wait(
-                        timeout: DispatchTime.now() + timeout
-                    ) == .success
-                )
-            }
-        }
+    func waitUntilEntered() async {
+        await entered.wait()
     }
 
     func open() {
@@ -223,7 +234,7 @@ struct VoiceRecorderTests {
         let owner = VoiceRecorder.RecordingOwner()
 
         let startTask = Task { try await voiceRecorder.startRecording(owner: owner) }
-        #expect(await session.waitUntilActivationBegan())
+        await session.waitUntilActivationBegan()
 
         await voiceRecorder.cancelRecording(owner: owner)
         session.resumeActivation()
@@ -321,7 +332,7 @@ struct VoiceRecorderTests {
         try await finishingHold.start()
         let firstURL = try #require(factory.urls.first)
         let finishTask = Task { await finishingHold.finish() }
-        #expect(await paddingGate.waitUntilEntered())
+        await paddingGate.waitUntilEntered()
 
         await #expect(throws: VoiceRecorder.RecorderError.recordingInProgress) {
             try await rejectedHold.start()


### PR DESCRIPTION
## Problem

`VoiceRecorderTests.cancelWhileSessionAcquireIsInFlightNeverCreatesARecorder` is the last of the three recurring CI flakes — 7 sightings, three in the last two days alone (the #1506 and #1528 merge runs, and #1550's PR run this morning).

Root cause: `waitUntilActivationBegan` hardcodes a **5-second `DispatchSemaphore` timeout** — below the 10s house floor from #1491, and invisible to `TestTimingHygieneTests` because it's a raw semaphore wait rather than a helper-timeout parameter (this exact site was flagged in the July 26 triage as a starvation site the guard can't see). On a starved runner, the window expires before the recorder's session-acquire task gets scheduled.

## Fix — extracted verbatim from #1107

@mmalmi already fixed this inside #1107, but that PR is blocked on a BLE-V3 rebase and shouldn't hold CI stability hostage. This extracts just the `VoiceRecorderTests.swift` change: both test gates (activation and padding) drop their `DispatchSemaphore` + timeout for an untimed async-event wait (`VoiceRecorderAsyncEvent`, private to the file), so **no timing constant remains to starve** — the test framework's own timeout is the backstop. Same "make the flake class unrepeatable" standard as #1491/#1563/#1564.

When #1107 rebases, this file will already match its branch — no conflict, no divergence.

## Verification (count-checked via xcresulttool)

- 7/7 `VoiceRecorderTests` green on the iOS simulator.
- **7/7 × 5 consecutive runs under 16× CPU oversubscription.**

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)