### PR TITLE
chore: use Base64URLCoding in NostrEmbeddedBitChat (#642)

### DIFF
--- a/bitchat/Nostr/Base64URLCoding.swift
+++ b/bitchat/Nostr/Base64URLCoding.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Shared unpadded base64url codec for Nostr / BitChat embed payloads.
+/// `NostrEmbeddedBitChat` and `NostrProtocol` both encode through this type (#642).
 enum Base64URLCoding {
     static func encode(_ data: Data) -> String {
         data.base64EncodedString()

--- a/bitchat/Nostr/NostrEmbeddedBitChat.swift
+++ b/bitchat/Nostr/NostrEmbeddedBitChat.swift
@@ -3,6 +3,8 @@ import BitFoundation
 
 // MARK: - BitChat-over-Nostr Adapter
 
+/// Embeds BitChat packets in Nostr DM/geohash envelopes as `bitchat1:` payloads.
+/// Binary framing stays in BitFoundation; base64url uses `Base64URLCoding` (#642).
 struct NostrEmbeddedBitChat {
     /// Build a `bitchat1:` base64url-encoded BitChat packet carrying a private message for Nostr DMs.
     static func encodePMForNostr(content: String, messageID: String, recipientPeerID: PeerID, senderPeerID: PeerID) -> String? {

--- a/bitchat/Nostr/NostrEmbeddedBitChat.swift
+++ b/bitchat/Nostr/NostrEmbeddedBitChat.swift
@@ -110,13 +110,4 @@ struct NostrEmbeddedBitChat {
         // Fallback: return as-is (expecting 16 hex chars) – caller should pass a valid peer ID
         return recipientPeerID
     }
-
-    /// Base64url encode without padding
-    private static func base64URLEncode(_ data: Data) -> String {
-        let b64 = data.base64EncodedString()
-        return b64
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
 }

--- a/bitchat/Nostr/NostrEmbeddedBitChat.swift
+++ b/bitchat/Nostr/NostrEmbeddedBitChat.swift
@@ -28,7 +28,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` base64url-encoded BitChat packet carrying a delivery/read ack for Nostr DMs.
@@ -51,7 +51,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` ACK (delivered/read) without an embedded recipient peer ID (geohash DMs).
@@ -72,7 +72,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` payload without an embedded recipient peer ID (used for geohash DMs).
@@ -94,7 +94,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     private static func normalizeRecipientPeerID(_ recipientPeerID: PeerID) -> PeerID {

--- a/bitchatTests/Nostr/Base64URLCodingTests.swift
+++ b/bitchatTests/Nostr/Base64URLCodingTests.swift
@@ -28,3 +28,16 @@ struct Base64URLCodingTests {
         #expect(decoded == original)
     }
 }
+
+    @Test
+    func matchesLegacyNostrEmbeddedBitChatEncoder() {
+        // Character-identical to the deleted private helper in NostrEmbeddedBitChat.
+        let data = Data([0x00, 0x01, 0x02, 0xfd, 0xfe, 0xff])
+        let legacy = data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        #expect(Base64URLCoding.encode(data) == legacy)
+    }
+


### PR DESCRIPTION
## Summary
- Completes jack’s rescoped #642 ask: `NostrEmbeddedBitChat` now encodes through the shared `Base64URLCoding` helper and drops its private copy.
- Leaves `Base64URLCoding` in the app target (no BitFoundation move) so this stays reviewable beside #1500 rather than competing with it.
- Pins the alphabet with a regression test matching the deleted helper.

## Test plan
- [ ] `Base64URLCodingTests` including `matchesLegacyNostrEmbeddedBitChatEncoder`
- [ ] Smoke: send a Nostr DM / geohash DM and confirm `bitchat1:` payloads still decode on the peer
- [ ] No overlap with #1500’s file move — that PR can delete the app-local type later if desired

Closes #642


Made with [Cursor](https://cursor.com)