### PR TITLE
docs: track notarized macOS .dmg sideload gap (#1097)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the notarized `.dmg` ask in #1097) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the [notarized `.dmg` ask](https://github.com/permissionlesstech/bitchat/issues/1097)) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the notarized `.dmg` ask in #1097) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -103,6 +103,7 @@ Cutting a release:
 - Push the tag. `source-manifest.yml` runs and attaches `SOURCE-MANIFEST.txt` to the release; if the release does not exist yet, collect the manifest from the workflow artifact and attach it when you publish.
 - Sign the tag (`git tag -s`). A signed tag lets anyone verify the release came from a key you control, independent of GitHub. This needs a published key fingerprint to be useful — see the gap below.
 - Note the commit hash somewhere outside this repository. If the repository is taken down, a hash recorded elsewhere is what lets people verify a mirror.
+- If/when notarized Developer ID `.dmg` artifacts exist, attach them to the same release as `SOURCE-MANIFEST.txt` and link them from the "macOS Developer ID" section above.
 
 Known gaps, so nobody assumes more protection than exists:
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -108,4 +108,5 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
+- **No notarized Developer ID `.dmg` on Releases yet.** [#1097](https://github.com/permissionlesstech/bitchat/issues/1097) tracks that ask; see "macOS Developer ID / notarized `.dmg`" above.
 - **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -79,6 +79,23 @@ What to do instead, in order of preference: install from the App Store; build fr
 
 Do not rely on the app looking right. A modified build has no reason to look different.
 
+
+## macOS Developer ID / notarized `.dmg` (#1097)
+
+A notarized Developer ID `.dmg` attached to GitHub Releases would give macOS
+users a sideload path that still carries Apple's signature chain — stronger
+than an unsigned forum binary, weaker than the App Store for verification
+storytelling, and useful when the store is unreachable.
+
+Status on main today:
+
+- Tagged releases already ship an **attested source manifest** (build from
+  verified source remains the supported non–App Store path).
+- There is **no** published notarized `.dmg` yet — that needs release-signing
+  infrastructure and a maintainer decision on key custody.
+- Until that lands, treat any third-party `.dmg` / `.app` the same as other
+  unverifiable compiled builds above.
+
 ## For maintainers
 
 Cutting a release:

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -83,7 +83,7 @@ Do not rely on the app looking right. A modified build has no reason to look dif
 ## macOS Developer ID / notarized `.dmg` (#1097)
 
 A notarized Developer ID `.dmg` attached to GitHub Releases would give macOS
-users a sideload path that still carries Apple's signature chain — stronger
+people a sideload path that still carries Apple's signature chain — stronger
 than an unsigned forum binary, weaker than the App Store for verification
 storytelling, and useful when the store is unreachable.
 

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -8,6 +8,7 @@ Last reviewed: July 2026
 - Nostr private fallback, bridge courier drops, mesh bridging, geohash channels, and notices
 - CoreLocation and reverse geocoding
 - Local persistence, panic wipe, logging, and App Store privacy manifests
+- Distribution trust (App Store vs unverifiable sideloads, including the #1097 `.dmg` ask) — see docs/VERIFYING-A-BUILD.md
 
 The user-facing contract is `PRIVACY_POLICY.md`. This document records implementation-level behavior and residual risks that should be re-audited when storage or transport semantics change.
 


### PR DESCRIPTION
## Summary
- Document the #1097 ask (notarized Developer ID `.dmg`) in VERIFYING-A-BUILD without promising an artifact that does not exist yet.
- List it under known gaps + maintainer release checklist; link from README and privacy distribution notes.
- Keeps the project stance: App Store / attested source first; unsigned forum binaries stay unverifiable.

## Test plan
- [ ] Read the new "macOS Developer ID" section — status matches jack’s #1097 comment
- [ ] Known-gaps checklist can absorb a download URL when maintainers ship one

Tracks #1097 (issue stays open until a notarized artifact ships).

Made with [Cursor](https://cursor.com)
