### PR TITLE
docs: Android↔iOS media interop + iOS 1.7.0 private-media skew (#1518)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
-Cross-platform image and voice note issues (especially Android → iOS): see [Media interop](docs/MEDIA-INTEROP.md).
-
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 
 ## License
@@ -30,6 +28,7 @@ This project is released into the public domain. See the [LICENSE](LICENSE) file
 - **Decentralized Mesh Network**: Automatic peer discovery and multi-hop message relay over Bluetooth LE
 - **Privacy First**: No accounts, no phone numbers, no servers. Note that the mesh does use a persistent per-device identifier derived from your identity key — see [the whitepaper](WHITEPAPER.md) on identity and metadata for what a nearby radio can observe
 - **Private Message End-to-End Encryption**: [Noise Protocol](https://noiseprotocol.org) for mesh, BitChat private envelopes for Nostr fallback
+- **Cross-platform media troubleshooting**: Android ↔ iOS image/voice note drops — see [Media interop](docs/MEDIA-INTEROP.md)
 - **IRC-Style Commands**: Familiar `/slap`, `/msg`, `/who` style interface
 - **Universal App**: Native support for iOS and macOS
 - **Emergency Wipe**: Triple-tap to instantly clear all data

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
+Cross-platform image and voice note issues (especially Android → iOS): see [Media interop](docs/MEDIA-INTEROP.md).
+
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 
 ## License

--- a/bitchat/Services/BLE/MimeType.swift
+++ b/bitchat/Services/BLE/MimeType.swift
@@ -18,6 +18,11 @@ extension UTType {
 }
 
 // MARK: - MimeType Enum
+//
+// Android send paths use `image/jpeg` and `audio/mp4` (see bitchat-android
+// docs/file_transfer.md). Keep those strings in `allowed` and document
+// changes in docs/MEDIA-INTEROP.md — silent MIME REJECT drops are a common
+// false lead for Android → iOS reports (#1518).
 
 enum MimeType: CaseIterable, Hashable {
     case jpeg

--- a/bitchatTests/MimeTypeTests.swift
+++ b/bitchatTests/MimeTypeTests.swift
@@ -87,4 +87,12 @@ struct MimeTypeTests {
         #expect(MimeType.octetStream.matches(data: randomData),
                 "application/octet-stream should always be considered valid")
     }
+
+    /// Android MediaSendingManager emits these exact strings today.
+    @Test func androidCanonicalSendMimesAreAccepted() {
+        #expect(MimeType("image/jpeg") == .jpeg)
+        #expect(MimeType("audio/mp4") == .mp4Audio)
+        #expect(MimeType("image/jpeg")?.isAllowed == true)
+        #expect(MimeType("audio/mp4")?.isAllowed == true)
+    }
 }

--- a/docs/MEDIA-INTEROP.md
+++ b/docs/MEDIA-INTEROP.md
@@ -1,0 +1,75 @@
+# Cross-platform media interop (iOS ↔ Android)
+
+Text messages mesh fine across clients. **Images and voice notes** use the
+file-transfer packet (`MessageType.fileTransfer`) plus, for DMs, Noise-sealed
+private-media delivery. Failures are usually silent on the receiver: the
+sender shows "sent," the receiver never grows a bubble.
+
+This note is for debugging reports like
+[#1518](https://github.com/permissionlesstech/bitchat/issues/1518)
+(Android → iOS media missing; iOS → Android OK).
+
+## Wire shape both sides agree on
+
+Android documents the TLV file packet in
+[`bitchat-android` `docs/file_transfer.md`](https://github.com/permissionlesstech/bitchat-android/blob/main/docs/file_transfer.md).
+Canonical MIME strings from Android send paths today:
+
+| Kind | MIME |
+|------|------|
+| Photo | `image/jpeg` |
+| Voice | `audio/mp4` |
+
+iOS accepts those via `MimeType` / `BLEIncomingFileValidator`. A MIME reject
+or magic-byte mismatch is logged (`MIME REJECT` / `MAGIC REJECT`) and the
+payload is dropped — there is no in-chat error bubble yet.
+
+## Version skew (the #1518 smoking gun)
+
+Reporter stack in #1518:
+
+- Android **1.7.4**
+- iOS App Store **1.7.0** (tag `v1.7.0`, 2026-07-08)
+
+After `v1.7.0`, main gained several **private-media** fixes that App Store
+1.7.0 does not include, including (non-exhaustive):
+
+- Encrypt private media before BLE fragmentation
+- Persist authenticated private-media delivery receipts
+- Retry confirmed private media after reconnect
+- Earlier: stamp incoming DM images delivered (#1402)
+
+Public / mesh file transfer and private Noise media do not share the same
+code path. A skew where Android has newer private-media behavior than iOS
+1.7.0 matches "private chat photos die Android→iOS, text is fine."
+
+**First remediation for reporters:** install an iOS build from current
+`main` (TestFlight / Xcode) or wait for the next App Store cut that includes
+the July private-media stack — do not assume MIME incompatibility until that
+is ruled out.
+
+## What to collect if it still fails on matched builds
+
+On the **iOS** device, with verbose logging / Console:
+
+1. `MIME REJECT` / `MAGIC REJECT` / `Failed to decode file transfer`
+2. Whether the chat is **mesh/public** vs **private DM**
+3. Exact app versions on both ends (build number, not just marketing version)
+4. Whether Tor / Nostr relay delivery is involved (geohash) vs BLE-only
+
+On Android, confirm `MediaSendingManager` still emits `image/jpeg` /
+`audio/mp4` for the failing send.
+
+## Maintainer release gate
+
+Before cutting an App Store build that claims Android media parity, run the
+device matrix in [#1580](https://github.com/permissionlesstech/bitchat/issues/1580)
+**plus**:
+
+- [ ] Android → iOS private DM image
+- [ ] Android → iOS private DM voice note
+- [ ] iOS → Android private DM image (control)
+- [ ] Android → iOS public/mesh image (control)
+
+See also Tor / distribution notes in `docs/VERIFYING-A-BUILD.md` when the
+store build itself is unreachable.

--- a/docs/MEDIA-INTEROP.md
+++ b/docs/MEDIA-INTEROP.md
@@ -24,6 +24,9 @@ iOS accepts those via `MimeType` / `BLEIncomingFileValidator`. A MIME reject
 or magic-byte mismatch is logged (`MIME REJECT` / `MAGIC REJECT`) and the
 payload is dropped — there is no in-chat error bubble yet.
 
+When a local wire-shape / file-transfer spec lands under `/spec` (see #1519),
+prefer that over the Android doc link above.
+
 ## Version skew (the #1518 smoking gun)
 
 Reporter stack in #1518:
@@ -32,21 +35,23 @@ Reporter stack in #1518:
 - iOS App Store **1.7.0** (tag `v1.7.0`, 2026-07-08)
 
 After `v1.7.0`, main gained several **private-media** fixes that App Store
-1.7.0 does not include, including (non-exhaustive):
+1.7.0 did not include. Those shipped in App Store **1.7.1** (`v1.7.1`),
+including:
 
-- Encrypt private media before BLE fragmentation
-- Persist authenticated private-media delivery receipts
-- Retry confirmed private media after reconnect
-- Earlier: stamp incoming DM images delivered (#1402)
+- Encrypt private media before BLE fragmentation (#1434)
+- Persist authenticated private-media delivery receipts (#1466)
+- Retry confirmed private media after reconnect (#1467)
+
+Note: stamp incoming DM images delivered (#1402 / `35fb9fdd`) **is already in
+v1.7.0** — do not treat it as missing on store 1.7.0.
 
 Public / mesh file transfer and private Noise media do not share the same
 code path. A skew where Android has newer private-media behavior than iOS
 1.7.0 matches "private chat photos die Android→iOS, text is fine."
 
-**First remediation for reporters:** install an iOS build from current
-`main` (TestFlight / Xcode) or wait for the next App Store cut that includes
-the July private-media stack — do not assume MIME incompatibility until that
-is ruled out.
+**First remediation for reporters:** update iOS to App Store **1.7.1** (or
+newer / a current `main` build). Do not assume MIME incompatibility until
+matched versions are ruled out.
 
 ## What to collect if it still fails on matched builds
 
@@ -60,16 +65,17 @@ On the **iOS** device, with verbose logging / Console:
 On Android, confirm `MediaSendingManager` still emits `image/jpeg` /
 `audio/mp4` for the failing send.
 
-## Maintainer release gate
+## Maintainer release gate (media parity)
 
-Before cutting an App Store build that claims Android media parity, run the
-device matrix in [#1580](https://github.com/permissionlesstech/bitchat/issues/1580)
-**plus**:
+Before cutting an App Store build that claims Android media parity, run at
+least:
 
+- [ ] Upgrade-in-place from the previous store build (identity / favorites / DM history intact)
 - [ ] Android → iOS private DM image
 - [ ] Android → iOS private DM voice note
 - [ ] iOS → Android private DM image (control)
 - [ ] Android → iOS public/mesh image (control)
+- [ ] Locked-device background receive of an image over mesh
 
 See also Tor / distribution notes in `docs/VERIFYING-A-BUILD.md` when the
 store build itself is unreachable.

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -91,5 +91,6 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
-- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.- **App Store iOS builds can lag Android private-media fixes.** See docs/MEDIA-INTEROP.md and #1518 before treating silent Android→iOS image drops as MIME bugs.
+- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.
+- **App Store iOS builds can lag Android private-media fixes.** See [docs/MEDIA-INTEROP.md](MEDIA-INTEROP.md) and [#1518](https://github.com/permissionlesstech/bitchat/issues/1518) before treating silent Android→iOS image drops as MIME bugs. App Store **1.7.1** includes the July private-media stack (#1434/#1466/#1467); **1.7.0** already included #1402.
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -91,4 +91,5 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
-- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.
+- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.- **App Store iOS builds can lag Android private-media fixes.** See docs/MEDIA-INTEROP.md and #1518 before treating silent Android→iOS image drops as MIME bugs.
+

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -119,3 +119,7 @@ The panic action clears identity/session state, preferences, location state, gro
 - Treat geohash precision, bridge-cell changes, new relay tags, and announce fields as privacy-surface changes.
 - Re-run real-device Bluetooth, background/locked-device recovery, location revocation, and audio-route checks; simulators cannot validate the physical side of those behaviors.
 - Check what a new notification discloses on a locked screen, and that the app-switcher snapshot is covered, whenever notification or scene-lifecycle code changes.
+
+## Cross-platform media
+
+Silent Android ↔ iOS image/voice drops are documented in [MEDIA-INTEROP.md](MEDIA-INTEROP.md).


### PR DESCRIPTION
## Summary
- Document silent Android → iOS image/voice drops: MIME allow-list, private-media path, and the **iOS App Store 1.7.0 vs Android 1.7.4** skew (post-`v1.7.0` private-media fixes on main).
- Link from README, privacy notes, verifying gaps; annotate `MimeType` and lock Android's `image/jpeg` / `audio/mp4` in tests.
- Release-gate checklist for Android↔iOS DM media before claiming parity.

## Test plan
- [ ] Read `docs/MEDIA-INTEROP.md` against #1518 reporter versions
- [x] MimeTypeTests include `androidCanonicalSendMimesAreAccepted`
- [ ] Maintainers: confirm next App Store cut includes July private-media stack before closing #1518 as "user error"

Does not close #1518 until a matched-build repro is ruled in/out — this unblocks triage.


Made with [Cursor](https://cursor.com)