### PR TITLE
feat: minimal nix develop shell (Xcode still required) (#1556)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ build.log
 # Local configs
 Local.xcconfig
 *.profraw
+# Nix
+result
+.direnv

--- a/README.md
+++ b/README.md
@@ -166,3 +166,5 @@ SwiftPM suite and `just test-ios` runs the iPhone 17 simulator suite.
 - Share extension strings are separate in `bitchatShareExtension/Localization/Localizable.xcstrings`.
 - Prefer keys that describe intent (`app_info.features.offline.title`) and reuse existing ones where possible.
 - Run `xcodebuild -project bitchat.xcodeproj -scheme "bitchat (macOS)" -configuration Debug CODE_SIGNING_ALLOWED=NO build` to compile-check any localization updates.
+
+Nix users: see [docs/NIX.md](docs/NIX.md) for a minimal `nix develop` shell (Xcode still required).

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -34,3 +34,8 @@ explicitly in a follow-up rather than expanding this flake by default.
 If you have Nix installed, run `nix flake lock` and commit `flake.lock` so the
 nixpkgs input is pinned for everyone.
 
+## CI
+
+GitHub Actions continues to use macOS runners with Xcode. This flake is for
+local contributor convenience only and is not wired into CI yet.
+

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -28,3 +28,9 @@ boundary (#1556) over a brittle xcframework rebuild inside Nix.
 
 If you need reproducible **Rust** pieces (e.g. Arti tooling), add those packages
 explicitly in a follow-up rather than expanding this flake by default.
+
+## Lockfile
+
+If you have Nix installed, run `nix flake lock` and commit `flake.lock` so the
+nixpkgs input is pinned for everyone.
+

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -1,0 +1,30 @@
+# Nix development shell (#1556)
+
+BitChat’s iOS/macOS targets are built with **Xcode**. A Nix flake cannot replace
+the Apple toolchain, but it can pin ordinary CLI helpers for contributors who
+already use `nix develop`.
+
+## What the flake provides
+
+```bash
+nix develop
+```
+
+Currently: `git`, `jq`, `python3`, plus a shell hook that checks `xcode-select`.
+
+It does **not** vend `xcodebuild`, simulators, or signing identities.
+
+## What you still need
+
+1. Xcode from the Mac App Store (version matching `Configs/` / CI).
+2. Accept the Xcode license: `sudo xcodebuild -license`
+3. Open `bitchat.xcodeproj` / use the project’s documented test commands.
+
+## Why this is intentionally small
+
+Shipping a “full” Swift/Nix app shell that pretends to compile BitChat without
+Xcode would rot against Apple’s SDK and confuse CI. Prefer documenting the
+boundary (#1556) over a brittle xcframework rebuild inside Nix.
+
+If you need reproducible **Rust** pieces (e.g. Arti tooling), add those packages
+explicitly in a follow-up rather than expanding this flake by default.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "bitchat development shell helpers (Xcode still required to build the app)";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs; [
+              git
+              jq
+              python3
+              # Swift/Xcode come from Apple; nix does not replace Xcode.app.
+            ];
+            shellHook = ''
+              echo "bitchat nix shell: tooling only."
+              echo "Build/test still need a full Xcode install (xcode-select -p)."
+              if ! xcode-select -p >/dev/null 2>&1; then
+                echo "WARNING: xcode-select cannot find Xcode developer tools." >&2
+              fi
+            '';
+          };
+        });
+    };
+}

--- a/scripts/check-nix-flake.sh
+++ b/scripts/check-nix-flake.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Non-Nix hosts: just verify flake.nix is parseable JSON-ish via nix if present.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if ! command -v nix >/dev/null 2>&1; then
+  echo "nix not installed; skipping flake evaluation"
+  # Still require the files to exist
+  test -f "$ROOT/flake.nix"
+  test -f "$ROOT/docs/NIX.md"
+  exit 0
+fi
+nix flake check "$ROOT" --no-build 2>/dev/null || nix eval "$ROOT#devShells.$(nix eval --impure --raw --expr 'builtins.currentSystem')"#default.name


### PR DESCRIPTION
## Summary
- Add a small `flake.nix` with `git` / `jq` / `python3` and an Xcode presence check.
- Document the hard boundary in `docs/NIX.md`: Nix does **not** replace Xcode for building BitChat.
- README link, gitignore for `result`/`.direnv`, optional `scripts/check-nix-flake.sh`.

## Test plan
- [ ] `nix develop` on a Mac with Xcode — shellHook prints cleanly
- [ ] Without Nix: `scripts/check-nix-flake.sh` still exits 0 after file checks
- [ ] Confirm we do **not** claim App Store / `xcodebuild` via Nix

Closes #1556


Made with [Cursor](https://cursor.com)