### PR TITLE
Silence the four release-build warnings

### DIFF
--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -663,7 +663,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     
     func removeEphemeralSession(peerID: PeerID) {
         queue.sync(flags: .barrier) {
-            self.ephemeralSessions.removeValue(forKey: peerID)
+            _ = self.ephemeralSessions.removeValue(forKey: peerID)
         }
     }
     

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -2943,7 +2943,7 @@ extension BLEService: GossipSyncManager.Delegate {
 
     func sendPacket(to peerID: PeerID, packet: BitchatPacket) {
         onEngine {
-            sendPacketDirected(packet, to: peerID)
+            _ = sendPacketDirected(packet, to: peerID)
         }
     }
 
@@ -3336,9 +3336,12 @@ extension BLEService {
     }
 
     func _test_drainPrivateMediaSendPipeline() async {
+        // Capture only the (Sendable) queue, not self, so the @Sendable
+        // dispatch closures carry no non-Sendable state.
+        let queue = messageQueue
         await withCheckedContinuation { continuation in
-            self.messageQueue.async { [weak self] in
-                self?.messageQueue.async {
+            queue.async {
+                queue.async {
                     continuation.resume()
                 }
             }
@@ -3357,9 +3360,10 @@ extension BLEService {
     }
 
     func _test_drainNoiseMessagePipeline() async {
+        let queue = messageQueue
         await withCheckedContinuation { continuation in
-            self.messageQueue.async {
-                self.messageQueue.async {
+            queue.async {
+                queue.async {
                     continuation.resume()
                 }
             }


### PR DESCRIPTION
Four compiler warnings surfaced while building the 1.7.1 RC — all introduced in this release window, all behavior-neutral:

- `BLEService.sendPacket(to:)` discarded `sendPacketDirected`'s `Bool` through generic `onEngine` → unused-result (from #1547).
- Both `_test_drain*Pipeline` helpers captured non-Sendable `self` in `@Sendable` dispatch closures (from #1498/#1434); they only need the queue, which is Sendable — capture that instead.
- `SecureIdentityStateManager.removeEphemeralSession` returned `removeValue`'s result out of the barrier closure → unused-result on `sync(flags:execute:)` (from #1349).

Two `_ =` discards and two capture-list changes; no behavior change. Local iOS build confirmed warning-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)