### PR TITLE
Mark a DM unread when sent while the app was closed

### DIFF
--- a/bitchat/ViewModels/ChatPrivateConversationCoordinator.swift
+++ b/bitchat/ViewModels/ChatPrivateConversationCoordinator.swift
@@ -548,8 +548,14 @@ final class ChatPrivateConversationCoordinator {
 
         let isViewing = context.selectedPrivateChatPeer == conversationPeerID
         let wasReadBefore = context.sentReadReceipts.contains(messageId)
+        // Recency gates only the notification. A DM sent while the app was
+        // closed reaches this path through the gift-wrap lookback long after
+        // it was sent, so gating the badge on recency left the conversation
+        // looking read and the message findable only by opening that chat.
+        // The mesh overload below marks unread whenever the chat is not on
+        // screen, with no recency test at all.
         let isRecentMessage = Date().timeIntervalSince(messageTimestamp) < 30
-        let shouldMarkUnread = !wasReadBefore && !isViewing && isRecentMessage
+        let shouldMarkUnread = !wasReadBefore && !isViewing
         if shouldMarkUnread {
             context.markPrivateChatUnread(conversationPeerID)
         }
@@ -558,7 +564,7 @@ final class ChatPrivateConversationCoordinator {
             sendReadReceiptIfNeeded(to: messageId, senderPubKey: senderPubkey, from: id)
         }
 
-        if !isViewing && shouldMarkUnread {
+        if shouldMarkUnread && isRecentMessage {
             context.notifyPrivateMessage(from: senderName, message: pm.content, peerID: conversationPeerID)
         }
 

--- a/bitchatTests/ChatPrivateConversationCoordinatorContextTests.swift
+++ b/bitchatTests/ChatPrivateConversationCoordinatorContextTests.swift
@@ -460,7 +460,8 @@ struct ChatPrivateConversationCoordinatorContextTests {
         context.displayNamesByPubkey[senderPubkey] = "bob#5678"
         let payloadData = PrivateMessagePacket(messageID: "geo-1", content: "hi there").encode()!
         let payload = NoisePayload(type: .privateMessage, data: payloadData)
-        // Old timestamp: not "recent", so no unread marking (and no notification).
+        // An old timestamp suppresses the notification but not the unread
+        // badge: recency gates only the alert.
         let oldTimestamp = Date().addingTimeInterval(-120)
 
         coordinator.handlePrivateMessage(
@@ -476,7 +477,7 @@ struct ChatPrivateConversationCoordinatorContextTests {
         #expect(context.sentGeoDeliveryAcks == ["geo-1"])
         #expect(context.privateChats[convKey]?.map(\.id) == ["geo-1"])
         #expect(context.privateChats[convKey]?.first?.sender == "bob#5678")
-        #expect(context.unreadPrivateMessages.isEmpty)
+        #expect(context.unreadPrivateMessages == [convKey])
         #expect(context.notifyUIChangedCount == 1)
 
         // Redelivery: ack is deduplicated and the message is not appended twice.
@@ -489,6 +490,91 @@ struct ChatPrivateConversationCoordinatorContextTests {
         )
         #expect(context.geoDeliveryAcks.count == 1)
         #expect(context.privateChats[convKey]?.count == 1)
+    }
+
+    /// A DM sent while the app was closed reaches this path through the
+    /// gift-wrap lookback, so it is minutes or hours old by the time it is
+    /// handled. The conversation still has to show as unread or the message
+    /// is unfindable; only the notification is gated on recency.
+    @Test @MainActor
+    func geoPrivateMessage_marksUnreadForAnOldMessageWithoutNotifying() async {
+        let context = MockChatPrivateConversationContext()
+        let coordinator = ChatPrivateConversationCoordinator(context: context)
+        let convKey = PeerID(str: "nostr_abcdef12")
+        let senderPubkey = "feedface00112233"
+        context.displayNamesByPubkey[senderPubkey] = "bob#5678"
+        let payloadData = PrivateMessagePacket(
+            messageID: "offline-1",
+            content: "sent while you were away"
+        ).encode()!
+        let payload = NoisePayload(type: .privateMessage, data: payloadData)
+
+        coordinator.handlePrivateMessage(
+            payload,
+            senderPubkey: senderPubkey,
+            convKey: convKey,
+            id: MockChatPrivateConversationContext.dummyIdentity,
+            messageTimestamp: Date().addingTimeInterval(-3600)
+        )
+
+        #expect(context.privateChats[convKey]?.map(\.id) == ["offline-1"])
+        #expect(context.unreadPrivateMessages == [convKey])
+        #expect(context.privateMessageNotifications.isEmpty)
+    }
+
+    /// The recency window still does its job: a message that arrives while
+    /// the person is elsewhere in the app both badges and notifies.
+    @Test @MainActor
+    func geoPrivateMessage_notifiesForARecentMessage() async {
+        let context = MockChatPrivateConversationContext()
+        let coordinator = ChatPrivateConversationCoordinator(context: context)
+        let convKey = PeerID(str: "nostr_abcdef12")
+        let senderPubkey = "feedface00112233"
+        context.displayNamesByPubkey[senderPubkey] = "bob#5678"
+        let payloadData = PrivateMessagePacket(
+            messageID: "fresh-1",
+            content: "just sent"
+        ).encode()!
+        let payload = NoisePayload(type: .privateMessage, data: payloadData)
+
+        coordinator.handlePrivateMessage(
+            payload,
+            senderPubkey: senderPubkey,
+            convKey: convKey,
+            id: MockChatPrivateConversationContext.dummyIdentity,
+            messageTimestamp: Date()
+        )
+
+        #expect(context.unreadPrivateMessages == [convKey])
+        #expect(context.privateMessageNotifications.map(\.peerID) == [convKey])
+    }
+
+    /// Opening the conversation is what clears it: a message that arrives
+    /// while the chat is on screen is neither badged nor notified.
+    @Test @MainActor
+    func geoPrivateMessage_doesNotMarkUnreadWhileTheChatIsOpen() async {
+        let context = MockChatPrivateConversationContext()
+        let coordinator = ChatPrivateConversationCoordinator(context: context)
+        let convKey = PeerID(str: "nostr_abcdef12")
+        let senderPubkey = "feedface00112233"
+        context.displayNamesByPubkey[senderPubkey] = "bob#5678"
+        context.selectedPrivateChatPeer = convKey
+        let payloadData = PrivateMessagePacket(
+            messageID: "viewing-1",
+            content: "you are looking at this"
+        ).encode()!
+        let payload = NoisePayload(type: .privateMessage, data: payloadData)
+
+        coordinator.handlePrivateMessage(
+            payload,
+            senderPubkey: senderPubkey,
+            convKey: convKey,
+            id: MockChatPrivateConversationContext.dummyIdentity,
+            messageTimestamp: Date()
+        )
+
+        #expect(context.unreadPrivateMessages.isEmpty)
+        #expect(context.privateMessageNotifications.isEmpty)
     }
 
     @Test @MainActor


### PR DESCRIPTION
A DM sent while the app is closed reaches `handlePrivateMessage` through the gift-wrap lookback, so it is minutes or hours old by the time it is handled. The unread decision gated on that age:

```swift
let isRecentMessage = Date().timeIntervalSince(messageTimestamp) < 30
let shouldMarkUnread = !wasReadBefore && !isViewing && isRecentMessage
```

So the message is appended to the conversation but the conversation is not marked unread. Nothing in the UI shows it arrived, and the person finds it only if they happen to open that chat.

The mesh overload of `handlePrivateMessage` in the same file has no recency test at all: if the chat is not on screen, the conversation is marked unread.

```swift
} else {
    context.markPrivateChatUnread(peerID)
    context.notifyPrivateMessage(from: message.sender, message: message.content, peerID: peerID)
}
```

The same message therefore badges when it arrives over the mesh and does not when it arrives over Nostr.

The gate made sense when it was written: it predates the persistent gift-wrap dedup from #1398, and before that store existed, every relaunch replayed the lookback and re-processed old DMs, so recency kept replayed DMs from re-badging and re-alerting on every launch. #1398 now drops replayed events before they reach this code, which leaves the gate suppressing only first-time deliveries.

This change moves the recency test off the badge and onto the notification. Recency still gates the alert, so a reconnect that pulls a batch of old DMs does not fire a burst of them, and nothing new reaches the lock screen. Only the in-app unread state changes.

## Changes

In the Nostr overload of `ChatPrivateConversationCoordinator.handlePrivateMessage`, `isRecentMessage` moves off `shouldMarkUnread` and onto the notification.

## Tests

Three added, one existing assertion changed.

- An old message marks the conversation unread and sends no notification.
- A recent message does both, which keeps the notification path covered.
- A message arriving while that chat is on screen does neither.
- `geoPrivateMessage_sendsDeliveryAckOnceAndDeduplicates` asserted `unreadPrivateMessages.isEmpty`, with a comment explaining that an old timestamp means no unread marking. That assertion depended on the recency gate this change removes, so it now expects the conversation to be unread. Flagging it because it is an existing assertion, not a new one, and the comment above it changed with it.

## Validation

- Full iOS test suite green on the iPhone 17 Pro simulator (Xcode 26.6).
- `swiftlint` adds no violations on the two touched files.

## What this does not change

Notification behavior is untouched: a message older than the 30 second window still does not notify. Read receipts, delivery acks, and dedup are all unchanged.
