### PR TITLE
docs: prefer "people" over "users" in house copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ BitChat uses a **hybrid messaging architecture** with two complementary transpor
 
 ### Nostr Protocol (Internet)
 
-- **Global Reach**: Connect with users worldwide via internet relays
+- **Global Reach**: Connect with people worldwide via internet relays
 - **Location Channels**: Geographic chat rooms using geohash coordinates
 - **440+ Relay Network**: Distributed across the globe for reliability
 - **BitChat Private Envelopes**: App-specific encrypted private messages over Nostr relays

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project is released into the public domain. See the [LICENSE](LICENSE) file
 - **Privacy First**: No accounts, no phone numbers, no servers. Note that the mesh does use a persistent per-device identifier derived from your identity key — see [the whitepaper](WHITEPAPER.md) on identity and metadata for what a nearby radio can observe
 - **Private Message End-to-End Encryption**: [Noise Protocol](https://noiseprotocol.org) for mesh, BitChat private envelopes for Nostr fallback
 - **IRC-Style Commands**: Familiar `/slap`, `/msg`, `/who` style interface
+- **People Sheet**: Nearby mesh peers, location-channel presence, and private groups in one place
 - **Universal App**: Native support for iOS and macOS
 - **Emergency Wipe**: Triple-tap to instantly clear all data
 - **Performance Optimizations**: LZ4 message compression, adaptive battery modes, and optimized networking

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -2470,7 +2470,7 @@
       "shouldTranslate" : false
     },
     "%@ active" : {
-      "comment" : "A label at the bottom of the people list sheet showing the number of active users.",
+      "comment" : "A label at the bottom of the people list sheet showing the number of active people.",
       "extractionState" : "stale",
       "localizations" : {
         "ar" : {

--- a/bitchat/Views/GeohashPeopleList.swift
+++ b/bitchat/Views/GeohashPeopleList.swift
@@ -10,7 +10,7 @@ struct GeohashPeopleList: View {
     private enum Strings {
         static let noneNearby: LocalizedStringKey = "geohash_people.none_nearby"
         static let youSuffix: LocalizedStringKey = "geohash_people.you_suffix"
-        static let blockedTooltip = String(localized: "geohash_people.tooltip.blocked", comment: "Tooltip shown next to users blocked in geohash channels")
+        static let blockedTooltip = String(localized: "geohash_people.tooltip.blocked", comment: "Tooltip shown next to people blocked in geohash channels")
         static let unblock: LocalizedStringKey = "geohash_people.action.unblock"
         static let block: LocalizedStringKey = "geohash_people.action.block"
         static let unblockText = String(localized: "geohash_people.action.unblock", comment: "Context menu action to unblock a person")


### PR DESCRIPTION
## Summary
- README global-reach bullet and people-sheet feature mention use **people**.
- Catalog comment + geohash blocked-tooltip source comment aligned.

## Test plan
- [ ] Skim README / comments — no user-visible string churn beyond intended English README bullet