### PR TITLE
docs: BitFoundation golden-vector guide for SDK consumers (#1073)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This project is released into the public domain. See the [LICENSE](LICENSE) file
 
 ## [Technical Architecture](https://deepwiki.com/permissionlesstech/bitchat)
 
+For cross-platform crypto digests and wire vectors (Android / future SDKs), see [BitFoundation golden vectors](docs/BITFOUNDATION-GOLDEN-VECTORS.md).
+
 BitChat uses a **hybrid messaging architecture** with two complementary transport layers:
 
 ### Bluetooth Mesh Network (Offline)

--- a/docs/BITFOUNDATION-GOLDEN-VECTORS.md
+++ b/docs/BITFOUNDATION-GOLDEN-VECTORS.md
@@ -1,0 +1,48 @@
+# BitFoundation golden vectors
+
+BitChat’s shared crypto and wire types live in `localPackages/BitFoundation`. Executable **golden vectors** in that package are how independent clients (Android today, future SDKs under [#1073](https://github.com/permissionlesstech/bitchat/issues/1073)) prove they speak the same bytes without copying Swift source.
+
+This note documents the pattern already used for peer-ID rotation so new protocol surfaces can follow it.
+
+## Where the pattern lives today
+
+| Piece | Path |
+|---|---|
+| Spec text | [`docs/PEER-ID-ROTATION.md`](PEER-ID-ROTATION.md) |
+| Implementation | `localPackages/BitFoundation/Sources/BitFoundation/PeerIDRotation.swift` |
+| Golden vectors | `localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDRotationTests.swift` |
+| Wire-format tests | `localPackages/BitFoundation/Tests/BitFoundationTests/AnnounceV2PacketTests.swift` |
+
+Comments in `PeerIDRotationTests` mark fixed hex digests with `VECTOR:` and explain the two rules that keep them useful.
+
+## Rules
+
+1. **Reproduce from the spec, not from the other platform’s code.**  
+   Derive expected digests from `docs/PEER-ID-ROTATION.md` (or the relevant protocol doc) using an independent HKDF/HMAC implementation. Matching Swift by reading Swift only proves both sides share a bug.
+
+2. **When the derivation changes, the hex changes deliberately.**  
+   Never “fix” a vector to match new behavior in place without updating the spec and calling out the break. A vector that silently tracks the implementation has stopped being a vector.
+
+3. **Keep inputs obviously fake and stable.**  
+   Use fixed key material (for example `01..20`) and fixed epochs so CI failure is about crypto, not flaky clocks.
+
+4. **Ship vectors next to the type they constrain.**  
+   Prefer `BitFoundationTests` over app-target tests so an SDK or Android checkout that vendors only BitFoundation still runs them.
+
+## How to add vectors for a new surface
+
+1. Write or update the human spec under `docs/`.
+2. Implement the pure functions in BitFoundation (no UI, no BLE).
+3. Add `@Test` cases that assert full hex digests (or fixed byte arrays) with a `VECTOR:` comment naming the construction.
+4. Cross-check once with an independent tool (Python `hmac`/`hashlib`, Go, etc.) and note that in the test file header.
+5. Link the new doc from this file’s table when the surface is meant for interop.
+
+## What this is not
+
+- Not a substitute for a versioned, standalone protocol repository (the longer-term ask in #1073 / #1448).
+- Not permission to paste production key material into tests.
+- Not a requirement that every unit test become a golden vector — reserve digests for cross-platform consensus surfaces.
+
+## Quick check
+
+From the repo root, BitFoundation’s suite (including vectors) runs as part of the normal SwiftPM / `just test` path used by CI.

--- a/docs/BITFOUNDATION-GOLDEN-VECTORS.md
+++ b/docs/BITFOUNDATION-GOLDEN-VECTORS.md
@@ -45,4 +45,14 @@ Comments in `PeerIDRotationTests` mark fixed hex digests with `VECTOR:` and expl
 
 ## Quick check
 
-From the repo root, BitFoundation’s suite (including vectors) runs as part of the normal SwiftPM / `just test` path used by CI.
+BitFoundation’s suite (including golden vectors) is a nested package. From the
+repo root run:
+
+```sh
+swift test --package-path localPackages/BitFoundation
+```
+
+(or `cd localPackages/BitFoundation && swift test`). Root `just test` /
+`swift test` only builds the app target and does **not** execute
+`BitFoundationTests` — CI runs the package path separately
+(`.github/workflows/swift-tests.yml`).

--- a/docs/PEER-ID-ROTATION.md
+++ b/docs/PEER-ID-ROTATION.md
@@ -11,6 +11,7 @@
 | Epochs, ID derivation, recognition tags, tag block, binding message | `localPackages/BitFoundation/Sources/BitFoundation/PeerIDRotation.swift` |
 | `announceV2 = 0x2C` wire format | `localPackages/BitFoundation/Sources/BitFoundation/AnnounceV2Packet.swift` |
 | Executable test vectors | `localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDRotationTests.swift` |
+| How to author golden vectors | [`docs/BITFOUNDATION-GOLDEN-VECTORS.md`](BITFOUNDATION-GOLDEN-VECTORS.md) |
 | Wire-format tests | `localPackages/BitFoundation/Tests/BitFoundationTests/AnnounceV2PacketTests.swift` |
 
 The code is deliberately an **opinionated working base, not a finished feature**. Every number and context string in it is a concrete proposal you can disagree with by changing one function and watching a test vector move. What is *not* implemented is the part that carries risk: nothing emits a v2 announce, and `BLEService` parses the type and explicitly ignores it, because consuming it needs both the replacement identity binding (§4.5) and a decision on how unverified presence appears in the peer list (O4).

--- a/localPackages/BitFoundation/README.md
+++ b/localPackages/BitFoundation/README.md
@@ -1,0 +1,5 @@
+# BitFoundation
+
+Shared BitChat protocol primitives (peer IDs, binary codec helpers, rotation proposals) used by the iOS/macOS app and intended for other clients.
+
+Golden-vector conventions for cross-platform digests: [`docs/BITFOUNDATION-GOLDEN-VECTORS.md`](../../docs/BITFOUNDATION-GOLDEN-VECTORS.md).

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDRotationTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDRotationTests.swift
@@ -5,6 +5,9 @@ import CryptoKit
 
 /// Executable test vectors for peer ID rotation.
 ///
+/// Authoring rules for this pattern (and future BitFoundation surfaces) live in
+/// `docs/BITFOUNDATION-GOLDEN-VECTORS.md`.
+///
 /// These are the numbers the Android implementation must reproduce. Two rules
 /// for keeping them useful:
 ///


### PR DESCRIPTION
## Summary
- New `docs/BITFOUNDATION-GOLDEN-VECTORS.md` documents the `VECTOR:` pattern from `PeerIDRotationTests`.
- Cross-links from PEER-ID-ROTATION, README, BitFoundation package README, and the test header.

Closes nothing by itself; supports #1073 / cross-platform interop.

## Test plan
- [ ] Links resolve in GitHub UI
- [ ] No code/behavior changes