### PR TITLE
Add a recent-chats section so DM conversations can't become unreachable

### DIFF
--- a/bitchat/App/PeerListModel.swift
+++ b/bitchat/App/PeerListModel.swift
@@ -39,12 +39,27 @@ struct GroupChatRow: Identifiable, Equatable {
     var id: String { peerID.id }
 }
 
+/// A direct conversation whose person is NOT in any roster above it. Without
+/// this section, a DM from a passerby became unreachable the moment they went
+/// offline: the roster filters to connected/reachable/mutual-favorite, the
+/// header envelope only exists while unread, and /msg can't resolve offline
+/// strangers — the thread was still in memory with no row anywhere in the UI.
+struct RecentChatRow: Identifiable, Equatable {
+    let peerID: PeerID
+    let displayName: String
+    let hasUnread: Bool
+    let lastActivity: Date
+
+    var id: String { peerID.id }
+}
+
 @MainActor
 final class PeerListModel: ObservableObject {
     @Published private(set) var allPeers: [BitchatPeer] = []
     @Published private(set) var meshRows: [MeshPeerRow] = []
     @Published private(set) var geohashPeople: [GeohashPersonRow] = []
     @Published private(set) var groupRows: [GroupChatRow] = []
+    @Published private(set) var recentChatRows: [RecentChatRow] = []
     @Published private(set) var reachableMeshPeerCount = 0
     @Published private(set) var connectedMeshPeerCount = 0
     @Published private(set) var visibleGeohashPeerCount = 0
@@ -139,6 +154,17 @@ final class PeerListModel: ObservableObject {
         conversations.$unreadConversations
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+
+        // Direct-conversation changes reorder or create recent-chat rows.
+        // Filtered to `.direct` so public-timeline traffic (every mesh or
+        // geohash message emits a change) doesn't rebuild the sheet.
+        conversations.changes
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] change in
+                guard case .direct = Self.changedConversationID(change) else { return }
                 self?.refresh()
             }
             .store(in: &cancellables)
@@ -239,6 +265,7 @@ final class PeerListModel: ObservableObject {
 
         let geohashPeople = buildGeohashPeople()
         let groupRows = buildGroupRows()
+        let recentChatRows = buildRecentChatRows(meshRows: meshRows)
 
         self.meshRows = meshRows
         reachableMeshPeerCount = meshCounts.reachable
@@ -246,6 +273,7 @@ final class PeerListModel: ObservableObject {
         self.geohashPeople = geohashPeople
         visibleGeohashPeerCount = geohashPeople.count
         self.groupRows = groupRows
+        self.recentChatRows = recentChatRows
         renderID = (
             meshRows.map {
                 "\($0.id)-\($0.displayName)-\($0.isConnected)-\($0.isReachable)-\($0.hasUnread)-\($0.isFavorite)-\($0.isBlocked)"
@@ -255,8 +283,80 @@ final class PeerListModel: ObservableObject {
             } +
             groupRows.map {
                 "group:\($0.id)-\($0.name)-\($0.memberCount)-\($0.hasUnread)"
+            } +
+            recentChatRows.map {
+                "chat:\($0.id)-\($0.displayName)-\($0.hasUnread)"
             }
         ).joined(separator: "|")
+    }
+
+    /// Direct conversations with people absent from the rosters above:
+    /// the offline passerby DM, the geoDM from a channel since left. Rows
+    /// mirrored under both an ephemeral and a stable peer ID collapse to
+    /// one row per identity (newest activity wins), matching how the
+    /// private-chat coordinators consolidate on open.
+    private func buildRecentChatRows(meshRows: [MeshPeerRow]) -> [RecentChatRow] {
+        // A conversation can be keyed by the stable Noise peer ID while the
+        // roster lists the ephemeral one — compare fingerprints too.
+        var visibleIdentities = Set<String>()
+        for row in meshRows {
+            visibleIdentities.insert(row.peerID.id)
+            if let fingerprint = chatViewModel.getFingerprint(for: row.peerID) {
+                visibleIdentities.insert(fingerprint)
+            }
+        }
+
+        struct Candidate {
+            let peerID: PeerID
+            let lastActivity: Date
+        }
+        var bestByIdentity: [String: Candidate] = [:]
+
+        for (id, conversation) in conversations.conversationsByID {
+            guard case .direct(let handle) = id else { continue }
+            let peerID = handle.routingPeerID
+            // Groups have their own section; blocked people get no row.
+            guard !peerID.isGroup else { continue }
+            guard let lastMessage = conversation.messages.last else { continue }
+            guard !chatViewModel.isPeerBlocked(peerID) else { continue }
+
+            let fingerprint = chatViewModel.getFingerprint(for: peerID)
+            if visibleIdentities.contains(peerID.id) { continue }
+            if let fingerprint, visibleIdentities.contains(fingerprint) { continue }
+
+            let identityKey = fingerprint ?? peerID.id
+            if let existing = bestByIdentity[identityKey],
+               existing.lastActivity >= lastMessage.timestamp {
+                continue
+            }
+            bestByIdentity[identityKey] = Candidate(peerID: peerID, lastActivity: lastMessage.timestamp)
+        }
+
+        return bestByIdentity.values
+            .sorted { $0.lastActivity > $1.lastActivity }
+            .map { candidate in
+                RecentChatRow(
+                    peerID: candidate.peerID,
+                    displayName: chatViewModel.resolveNickname(for: candidate.peerID),
+                    hasUnread: chatViewModel.hasUnreadMessages(for: candidate.peerID),
+                    lastActivity: candidate.lastActivity
+                )
+            }
+    }
+
+    private static func changedConversationID(_ change: ConversationChange) -> ConversationID {
+        switch change {
+        case .appended(let id, _),
+             .updated(let id, _),
+             .statusChanged(let id, _, _),
+             .messageRemoved(let id, _),
+             .cleared(let id),
+             .removed(let id),
+             .unreadChanged(let id, _):
+            return id
+        case .migrated(_, let to):
+            return to
+        }
     }
 
     private func buildGroupRows() -> [GroupChatRow] {

--- a/bitchat/App/PeerListModel.swift
+++ b/bitchat/App/PeerListModel.swift
@@ -265,7 +265,7 @@ final class PeerListModel: ObservableObject {
 
         let geohashPeople = buildGeohashPeople()
         let groupRows = buildGroupRows()
-        let recentChatRows = buildRecentChatRows(meshRows: meshRows)
+        let recentChatRows = buildRecentChatRows(meshRows: meshRows, geohashPeople: geohashPeople)
 
         self.meshRows = meshRows
         reachableMeshPeerCount = meshCounts.reachable
@@ -295,7 +295,10 @@ final class PeerListModel: ObservableObject {
     /// mirrored under both an ephemeral and a stable peer ID collapse to
     /// one row per identity (newest activity wins), matching how the
     /// private-chat coordinators consolidate on open.
-    private func buildRecentChatRows(meshRows: [MeshPeerRow]) -> [RecentChatRow] {
+    private func buildRecentChatRows(
+        meshRows: [MeshPeerRow],
+        geohashPeople: [GeohashPersonRow]
+    ) -> [RecentChatRow] {
         // A conversation can be keyed by the stable Noise peer ID while the
         // roster lists the ephemeral one — compare fingerprints too.
         var visibleIdentities = Set<String>()
@@ -304,6 +307,12 @@ final class PeerListModel: ObservableObject {
             if let fingerprint = chatViewModel.getFingerprint(for: row.peerID) {
                 visibleIdentities.insert(fingerprint)
             }
+        }
+        // Someone visible in the geohash section must not also get a chat
+        // row: their GeoDM conversation is keyed by the nostr_ form of the
+        // same pubkey the roster lists.
+        for person in geohashPeople {
+            visibleIdentities.insert(PeerID(nostr_: person.id).id)
         }
 
         struct Candidate {
@@ -337,11 +346,21 @@ final class PeerListModel: ObservableObject {
             .map { candidate in
                 RecentChatRow(
                     peerID: candidate.peerID,
-                    displayName: chatViewModel.resolveNickname(for: candidate.peerID),
+                    displayName: displayName(for: candidate.peerID),
                     hasUnread: chatViewModel.hasUnreadMessages(for: candidate.peerID),
                     lastActivity: candidate.lastActivity
                 )
             }
+    }
+
+    /// GeoDM conversations resolve through the Nostr mapping —
+    /// `resolveNickname` only consults mesh identity sources and would
+    /// render a `nostr_…` key as an opaque `anonnost` fallback.
+    private func displayName(for peerID: PeerID) -> String {
+        if peerID.isGeoDM {
+            return chatViewModel.geohashDisplayName(for: peerID)
+        }
+        return chatViewModel.resolveNickname(for: peerID)
     }
 
     private static func changedConversationID(_ change: ConversationChange) -> ConversationID {

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -2047,6 +2047,378 @@
         }
       }
     },
+    "chats.accessibility.open_hint" : {
+      "comment" : "Accessibility hint on a recent chat row explaining activation opens the direct conversation",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يفتح هذه المحادثة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই কথোপকথন খোলে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "öffnet diese unterhaltung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "opens this conversation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "abre esta conversación"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "این گفتگو را باز می‌کند"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "binubuksan ang usapang ito"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ouvre cette conversation"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "פותח את השיחה הזו"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यह वार्तालाप खोलता है"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "membuka percakapan ini"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "apre questa conversazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この会話を開きます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 대화를 엽니다"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "membuka perbualan ini"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "यो वार्तालाप खोल्छ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "opent dit gesprek"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "otwiera tę rozmowę"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "abre esta conversa"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "abre esta conversa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "открывает этот разговор"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "öppnar den här konversationen"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இந்த உரையாடலைத் திறக்கும்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เปิดการสนทนานี้"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu konuşmayı açar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "відкриває цю розмову"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ گفتگو کھولتا ہے"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mở cuộc trò chuyện này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开此对话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟此對話"
+          }
+        }
+      }
+    },
+    "chats.section.header" : {
+      "comment" : "Section header above recent direct conversations in the people sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الدردشات"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "চ্যাট"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chats"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chats"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chats"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گفتگوها"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mga chat"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "discussions"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "צ'אטים"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "चैट"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "obrolan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chat"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채팅"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sembang"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "च्याटहरू"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chats"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "czaty"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "conversas"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "conversas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "чаты"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chattar"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "அரட்டைகள்"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "แชท"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sohbetler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "чати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "چیٹس"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "trò chuyện"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聊天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聊天"
+          }
+        }
+      }
+    },
     "content.system.media_delete_refused" : {
       "comment" : "System message shown in the affected chat when an explicit media delete or /clear was refused and bubbles/files were kept",
       "extractionState" : "manual",

--- a/bitchat/Views/ContentSheetViews.swift
+++ b/bitchat/Views/ContentSheetViews.swift
@@ -365,6 +365,16 @@ private struct ContentPeopleListView: View {
                                 showSidebar = true
                             }
                         )
+                        // Direct conversations survive channel switches; the
+                        // geoDM someone opened from another cell must stay
+                        // reachable here too.
+                        RecentChatList(
+                            chats: peerListModel.recentChatRows,
+                            onTapChat: { peerID in
+                                peerListModel.startConversation(with: peerID)
+                                showSidebar = true
+                            }
+                        )
                     } else {
                         PeopleSectionHeader(
                             icon: "antenna.radiowaves.left.and.right",
@@ -396,6 +406,16 @@ private struct ContentPeopleListView: View {
                         GroupChatList(
                             groups: peerListModel.groupRows,
                             onTapGroup: { peerID in
+                                peerListModel.startConversation(with: peerID)
+                                showSidebar = true
+                            }
+                        )
+                        // Conversations with people no roster above lists
+                        // anymore — without this, a read DM from an offline
+                        // non-favorite had no row anywhere in the UI.
+                        RecentChatList(
+                            chats: peerListModel.recentChatRows,
+                            onTapChat: { peerID in
                                 peerListModel.startConversation(with: peerID)
                                 showSidebar = true
                             }

--- a/bitchat/Views/RecentChatList.swift
+++ b/bitchat/Views/RecentChatList.swift
@@ -1,0 +1,89 @@
+//
+// RecentChatList.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import BitFoundation
+import SwiftUI
+
+/// "chats" section for the people sheet: direct conversations with people
+/// who are not in any roster above it (offline passersby, geoDMs from a
+/// channel since left). Before this section existed, those threads were
+/// unreachable the moment the unread envelope cleared — still in memory,
+/// no row anywhere in the UI. Renders nothing when there are none.
+struct RecentChatList: View {
+    @ThemedPalette private var palette
+
+    let chats: [RecentChatRow]
+    let onTapChat: (PeerID) -> Void
+
+    private enum Strings {
+        static let header = String(localized: "chats.section.header", defaultValue: "chats", comment: "Section header above recent direct conversations in the people sheet")
+        static let unread = String(localized: "mesh_peers.state.unread", comment: "State label for a peer with unread private messages")
+        static let newMessagesTooltip = String(localized: "mesh_peers.tooltip.new_messages", comment: "Tooltip for the unread messages indicator")
+        static let openChatHint = String(localized: "chats.accessibility.open_hint", defaultValue: "opens this conversation", comment: "Accessibility hint on a recent chat row explaining activation opens the direct conversation")
+    }
+
+    /// Relative "5 min ago" stamps; the formatter is locale-aware.
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        if !chats.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                // Same glyph+label header shape as #mesh / groups.
+                PeopleSectionHeader(
+                    icon: "bubble.left.and.bubble.right",
+                    iconColor: palette.secondary,
+                    title: Strings.header
+                )
+
+                ForEach(chats) { chat in
+                    HStack(spacing: 4) {
+                        Text(verbatim: chat.displayName)
+                            .bitchatFont(size: 14)
+                            .foregroundColor(palette.primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        Text(verbatim: Self.relativeFormatter.localizedString(for: chat.lastActivity, relativeTo: Date()))
+                            .bitchatFont(size: 11)
+                            .foregroundColor(palette.secondary.opacity(0.8))
+
+                        Spacer()
+
+                        if chat.hasUnread {
+                            Image(systemName: "envelope.fill")
+                                .font(.bitchatSystem(size: 10))
+                                .foregroundColor(.orange)
+                                .help(Strings.newMessagesTooltip)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onTapChat(chat.peerID) }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(accessibilityDescription(for: chat))
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityHint(Strings.openChatHint)
+                }
+            }
+        }
+    }
+
+    private func accessibilityDescription(for chat: RecentChatRow) -> String {
+        var parts: [String] = [
+            chat.displayName,
+            Self.relativeFormatter.localizedString(for: chat.lastActivity, relativeTo: Date())
+        ]
+        if chat.hasUnread { parts.append(Strings.unread) }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/bitchatTests/AppArchitectureTests.swift
+++ b/bitchatTests/AppArchitectureTests.swift
@@ -506,6 +506,40 @@ struct AppArchitectureTests {
         #expect(peerListModel.recentChatRows.first?.lastActivity == Date(timeIntervalSince1970: 100))
         // The roster doesn't list this peer — that's exactly why the row exists.
         #expect(!peerListModel.meshRows.contains { $0.peerID == offlinePeerID })
+
+        // A geoDM thread resolves through the Nostr mapping (bare-key
+        // fallback here), never resolveNickname's mesh-only anon fallback.
+        let pubkeyHex = String(repeating: "ab", count: 32)
+        let geoDMPeer = PeerID(nostr_: pubkeyHex)
+        viewModel.seedPrivateChat([
+            BitchatMessage(
+                id: "geo-1",
+                sender: "stranger",
+                content: "hello from another cell",
+                timestamp: Date(timeIntervalSince1970: 300),
+                isRelay: false,
+                isPrivate: true,
+                recipientNickname: "me",
+                senderPeerID: geoDMPeer
+            )
+        ], for: geoDMPeer)
+
+        await waitUntil {
+            peerListModel.recentChatRows.contains { $0.peerID == geoDMPeer }
+        }
+        let geoRow = peerListModel.recentChatRows.first { $0.peerID == geoDMPeer }
+        #expect(geoRow?.displayName == geoDMPeer.bare)
+
+        // While that person is visible in the geohash roster, the chat row
+        // collapses — same absent-from-rosters contract as mesh.
+        viewModel.participantTracker.setActiveGeohash("u4pruy")
+        viewModel.participantTracker.recordParticipant(pubkeyHex: pubkeyHex, geohash: "u4pruy")
+
+        await waitUntil {
+            !peerListModel.recentChatRows.contains { $0.peerID == geoDMPeer }
+        }
+        #expect(!peerListModel.recentChatRows.contains { $0.peerID == geoDMPeer })
+        #expect(peerListModel.recentChatRows.map(\.peerID) == [offlinePeerID])
     }
 
     @Test("PrivateConversationModel resolves canonical header state for the selected DM")

--- a/bitchatTests/AppArchitectureTests.swift
+++ b/bitchatTests/AppArchitectureTests.swift
@@ -458,6 +458,56 @@ struct AppArchitectureTests {
         #expect(chromeModel.showingFingerprintFor == nil)
     }
 
+    @Test("Recent chats list direct conversations with people absent from the rosters")
+    @MainActor
+    func peerListModelSurfacesRecentChatsForAbsentPeers() async {
+        let viewModel = makeArchitectureViewModel()
+        let offlinePeerID = PeerID(str: "00000000000000aa")
+        let groupPeerID = PeerID(groupID: Data(repeating: 0xAB, count: 16))
+
+        // A DM thread from a passerby who has since gone offline: not in
+        // allPeers, not a favorite — previously unreachable once read.
+        viewModel.seedPrivateChat([
+            BitchatMessage(
+                id: "dm-1",
+                sender: "passerby",
+                content: "hello from the train",
+                timestamp: Date(timeIntervalSince1970: 100),
+                isRelay: false,
+                isPrivate: true,
+                recipientNickname: "me",
+                senderPeerID: offlinePeerID
+            )
+        ], for: offlinePeerID)
+        // Group threads have their own section and must not duplicate here.
+        viewModel.seedPrivateChat([
+            BitchatMessage(
+                id: "gm-1",
+                sender: "member",
+                content: "group hello",
+                timestamp: Date(timeIntervalSince1970: 200),
+                isRelay: false,
+                isPrivate: true,
+                recipientNickname: "me",
+                senderPeerID: groupPeerID
+            )
+        ], for: groupPeerID)
+
+        let peerListModel = PeerListModel(
+            chatViewModel: viewModel,
+            conversations: viewModel.conversations
+        )
+
+        await waitUntil {
+            peerListModel.recentChatRows.contains { $0.peerID == offlinePeerID }
+        }
+
+        #expect(peerListModel.recentChatRows.map(\.peerID) == [offlinePeerID])
+        #expect(peerListModel.recentChatRows.first?.lastActivity == Date(timeIntervalSince1970: 100))
+        // The roster doesn't list this peer — that's exactly why the row exists.
+        #expect(!peerListModel.meshRows.contains { $0.peerID == offlinePeerID })
+    }
+
     @Test("PrivateConversationModel resolves canonical header state for the selected DM")
     @MainActor
     func privateConversationModelResolvesSelectedHeaderState() async {


### PR DESCRIPTION
## What

The largest information-architecture hole from the design/UX audit: **a DM conversation could become unreachable while still in memory.**

`UnifiedPeerService` filters the roster to connected / reachable / mutual-favorite; the header envelope only exists while `hasUnreadPrivateMessages`; `/msg` can't resolve offline strangers; and `openMostRelevantPrivateChat()`'s recent-chats fallback was unreachable code (its only caller is gated on unread). Read a DM from a passerby, close the sheet, and the thread had no row anywhere in the UI.

### The fix

- **`PeerListModel.recentChatRows`**: derived from the `ConversationStore`'s `.direct` conversations — people **absent from the rosters above it**, newest activity first, with unread state. Conversations mirrored under both an ephemeral and a stable peer ID collapse to one row per fingerprint (newest wins), matching how the private-chat coordinators consolidate on open. Groups (own section) and blocked peers are excluded.
- **`RecentChatList`**: a "chats" section in the people sheet, same `PeopleSectionHeader` shape as `#mesh`/groups — name, relative timestamp, unread envelope, full VoiceOver description. Renders nothing when empty. Present on **both** mesh and location channels, so a geoDM opened from a channel you've since left stays reachable too (this also plugs part of the geohash-unread blind spot).
- Tap → existing `startConversation(with:)` path (peer-ID migration/consolidation already handled there; sends to unreachable peers route via outbox/courier since #1415).
- Rebuilds subscribe to the store's `changes` **filtered to direct conversations**, so public-timeline traffic (which emits a change per message) doesn't churn the sheet, and rows participate in `renderID`.

Deliberately *not* in this PR: persistence (private chats are RAM-only by design — this list covers the session, which is where the hole was) and any restructuring of the people-sheet/DM modal double duty.

## Tests

- New `peerListModelSurfacesRecentChatsForAbsentPeers` pins: offline stranger's thread gets a row, group threads don't, roster stays clean.
- `AppArchitectureTests` + `LocalizationCoverageTests` + `ViewSmokeTests`: 40/40 green (count-verified).
- 2 new strings with all-30-locale coverage; iOS + macOS builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)