### PR TITLE
feat: export chat as plaintext with sealing warning

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -3907,6 +3907,1866 @@
         }
       }
     },
+    "chat.export.accessibility" : {
+      "comment" : "Accessibility label for the export-chat control",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat as plaintext"
+          }
+        }
+      }
+    },
+    "chat.export.action" : {
+      "comment" : "Button that exports the current chat as unsealed plaintext",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "export chat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export chat"
+          }
+        }
+      }
+    },
+    "chat.export.confirm_action" : {
+      "comment" : "Confirms exporting chat history after the sealing warning",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "export anyway"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export anyway"
+          }
+        }
+      }
+    },
+    "chat.export.confirm_message" : {
+      "comment" : "Body of the export confirmation explaining the file is readable by anyone who gets a copy",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "this creates a plain text file with the full conversation. anyone who receives, backs up, or syncs the file can read it — sealing and encryption do not apply after export."
+          }
+        }
+      }
+    },
+    "chat.export.confirm_title" : {
+      "comment" : "Title of the confirmation shown before exporting chat history as plaintext",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "export unsealed plaintext?"
+          }
+        }
+      }
+    },
+    "chat.export.empty" : {
+      "comment" : "Line shown when an exported chat contains no messages",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(no messages in this conversation)"
+          }
+        }
+      }
+    },
+    "chat.export.scope.dm" : {
+      "comment" : "Export header naming a private conversation; %@ is the peer nickname",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dm with @%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dm with @%@"
+          }
+        }
+      }
+    },
+    "chat.export.scope.geohash" : {
+      "comment" : "Export header for a location channel; %@ is the geohash",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "geohash #%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "geohash #%@"
+          }
+        }
+      }
+    },
+    "chat.export.scope.mesh" : {
+      "comment" : "Export header for the public mesh channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mesh"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "mesh"
+          }
+        }
+      }
+    },
+    "chat.export.sealing_warning" : {
+      "comment" : "Warning line at the top of an exported chat file",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "warning: this file is unsealed plaintext. anyone with a copy can read it."
+          }
+        }
+      }
+    },
     "chats.accessibility.open_hint" : {
       "comment" : "Accessibility hint on a recent chat row explaining activation opens the direct conversation",
       "extractionState" : "manual",

--- a/bitchat/Utils/ChatPlaintextExporter.swift
+++ b/bitchat/Utils/ChatPlaintextExporter.swift
@@ -1,0 +1,54 @@
+import BitFoundation
+import Foundation
+
+/// Formats on-device chat history as unsealed plaintext for export.
+enum ChatPlaintextExporter {
+    struct Context: Equatable {
+        let scopeTitle: String
+        let exportedAt: Date
+
+        init(scopeTitle: String, exportedAt: Date = Date()) {
+            self.scopeTitle = scopeTitle
+            self.exportedAt = exportedAt
+        }
+    }
+
+    static func exportText(messages: [BitchatMessage], context: Context) -> String {
+        let header = [
+            "bitchat export — \(context.scopeTitle)",
+            "exported \(exportTimestamp(context.exportedAt))",
+            "",
+            warningLine,
+            "",
+        ].joined(separator: "\n")
+
+        guard !messages.isEmpty else {
+            return header + String(localized: "chat.export.empty", comment: "Line shown when an export contains no messages")
+        }
+
+        let body = messages.map { line(for: $0) }.joined(separator: "\n")
+        return header + body + "\n"
+    }
+
+    private static var warningLine: String {
+        String(
+            localized: "chat.export.sealing_warning",
+            comment: "Warning that an exported chat file is unsealed plaintext readable by anyone with a copy"
+        )
+    }
+
+    private static func line(for message: BitchatMessage) -> String {
+        let stamp = exportTimestamp(message.timestamp)
+        let sender = message.sender.trimmingCharacters(in: .whitespacesAndNewlines)
+        let content = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "[\(stamp)] \(sender): \(content)"
+    }
+
+    private static func exportTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: date)
+    }
+}

--- a/bitchat/Utils/ChatPlaintextExporter.swift
+++ b/bitchat/Utils/ChatPlaintextExporter.swift
@@ -19,7 +19,7 @@ enum ChatPlaintextExporter {
             "exported \(exportTimestamp(context.exportedAt))",
             "",
             warningLine,
-            "",
+            ""
         ].joined(separator: "\n")
 
         guard !messages.isEmpty else {

--- a/bitchat/Utils/ChatPlaintextExporter.swift
+++ b/bitchat/Utils/ChatPlaintextExporter.swift
@@ -23,7 +23,11 @@ enum ChatPlaintextExporter {
         ].joined(separator: "\n")
 
         guard !messages.isEmpty else {
-            return header + String(localized: "chat.export.empty", comment: "Line shown when an export contains no messages")
+            return header + String(
+                localized: "chat.export.empty",
+                defaultValue: "(no messages in this conversation)",
+                comment: "Line shown when an export contains no messages"
+            )
         }
 
         let body = messages.map { line(for: $0) }.joined(separator: "\n")
@@ -33,6 +37,7 @@ enum ChatPlaintextExporter {
     private static var warningLine: String {
         String(
             localized: "chat.export.sealing_warning",
+            defaultValue: "warning: this file is unsealed plaintext. anyone with a copy can read it.",
             comment: "Warning that an exported chat file is unsealed plaintext readable by anyone with a copy"
         )
     }

--- a/bitchat/Views/MessageListView.swift
+++ b/bitchat/Views/MessageListView.swift
@@ -40,6 +40,9 @@ struct MessageListView: View {
 
     @State private var showMessageActions = false
     @State private var showClearConfirmation = false
+    @State private var showExportConfirmation = false
+    @State private var showExportSheet = false
+    @State private var exportPlaintext = ""
     @State private var lastScrollTime: Date = .distantPast
     @State private var scrollThrottleTimer: Timer?
     @State private var unseenCount = 0
@@ -188,6 +191,11 @@ struct MessageListView: View {
                     jumpToLatestPill(proxy: proxy)
                 }
             }
+            .overlay(alignment: .bottomLeading) {
+                if !messageItems.isEmpty {
+                    exportChatButton()
+                }
+            }
             .onOpenURL(perform: handleOpenURL)
             .onTapGesture(count: 3) {
                 showClearConfirmation = true
@@ -201,6 +209,21 @@ struct MessageListView: View {
                     conversationUIModel.clearCurrentConversation()
                 }
                 Button("common.cancel", role: .cancel) {}
+            }
+            .confirmationDialog(
+                String(localized: "chat.export.confirm_title", comment: "Title of the confirmation shown before exporting chat history as plaintext"),
+                isPresented: $showExportConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "chat.export.confirm_action", comment: "Confirms exporting chat history after the sealing warning")) {
+                    beginExport(messages: messages)
+                }
+                Button("common.cancel", role: .cancel) {}
+            } message: {
+                Text(String(localized: "chat.export.confirm_message", comment: "Body of the export confirmation explaining the file is readable by anyone who gets a copy"))
+            }
+            .sheet(isPresented: $showExportSheet) {
+                ShareActivityView(text: exportPlaintext)
             }
             .onAppear {
                 scrollToBottom(on: proxy)
@@ -741,6 +764,58 @@ private extension MessageListView {
 
     func privateMessageCount(for privatePeer: PeerID?) -> Int {
         conversationMessages(for: privatePeer).count
+    }
+
+    func exportChatButton() -> some View {
+        Button {
+            showExportConfirmation = true
+        } label: {
+            Image(systemName: "square.and.arrow.up")
+                .font(.bitchatSystem(size: 11, weight: .semibold))
+                .foregroundColor(palette.primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(palette.background.opacity(0.92))
+                .clipShape(Capsule())
+                .overlay(Capsule().stroke(palette.secondary.opacity(0.35), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, 12)
+        .padding(.bottom, 8)
+        .accessibilityLabel(
+            String(localized: "chat.export.accessibility", comment: "Accessibility label for the export-chat control")
+        )
+    }
+
+    func beginExport(messages: [BitchatMessage]) {
+        exportPlaintext = ChatPlaintextExporter.exportText(
+            messages: messages,
+            context: ChatPlaintextExporter.Context(scopeTitle: exportScopeTitle())
+        )
+        showExportSheet = true
+    }
+
+    func exportScopeTitle() -> String {
+        if privatePeer != nil {
+            let name = privateConversationModel.selectedHeaderState?.displayName
+                ?? conversationMessages(for: privatePeer).last(where: { $0.sender != "system" })?.sender
+                ?? privatePeer!.id
+            return String(
+                format: String(localized: "chat.export.scope.dm", comment: "Export header naming a private conversation; %@ is the peer nickname"),
+                locale: .current,
+                name
+            )
+        }
+        switch locationChannelsModel.selectedChannel {
+        case .mesh:
+            return String(localized: "chat.export.scope.mesh", comment: "Export header for the public mesh channel")
+        case .location(let channel):
+            return String(
+                format: String(localized: "chat.export.scope.geohash", comment: "Export header for a location channel; %@ is the geohash"),
+                locale: .current,
+                channel.geohash
+            )
+        }
     }
 }
 

--- a/bitchatTests/ChatPlaintextExporterTests.swift
+++ b/bitchatTests/ChatPlaintextExporterTests.swift
@@ -1,0 +1,54 @@
+import BitFoundation
+import Foundation
+import Testing
+
+struct ChatPlaintextExporterTests {
+    private static let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func exportIncludesSealingWarningAndScope() {
+        let message = BitchatMessage(
+            sender: "alice",
+            content: "hello mesh",
+            timestamp: Self.fixedDate,
+            isRelay: false
+        )
+        let text = ChatPlaintextExporter.exportText(
+            messages: [message],
+            context: ChatPlaintextExporter.Context(scopeTitle: "mesh", exportedAt: Self.fixedDate)
+        )
+        #expect(text.contains("bitchat export — mesh"))
+        #expect(text.contains("warning: this file is unsealed plaintext"))
+        #expect(text.contains("alice: hello mesh"))
+    }
+
+    @Test func emptyConversationStillWarns() {
+        let text = ChatPlaintextExporter.exportText(
+            messages: [],
+            context: ChatPlaintextExporter.Context(scopeTitle: "dm with @bob", exportedAt: Self.fixedDate)
+        )
+        #expect(text.contains("warning: this file is unsealed plaintext"))
+        #expect(text.contains("(no messages in this conversation)"))
+    }
+
+    @Test func messagesPreserveChronologicalOrder() {
+        let first = BitchatMessage(
+            sender: "a",
+            content: "one",
+            timestamp: Self.fixedDate,
+            isRelay: false
+        )
+        let second = BitchatMessage(
+            sender: "b",
+            content: "two",
+            timestamp: Self.fixedDate.addingTimeInterval(60),
+            isRelay: false
+        )
+        let text = ChatPlaintextExporter.exportText(
+            messages: [first, second],
+            context: ChatPlaintextExporter.Context(scopeTitle: "mesh", exportedAt: Self.fixedDate)
+        )
+        let oneRange = text.range(of: "one")!
+        let twoRange = text.range(of: "two")!
+        #expect(oneRange.lowerBound < twoRange.lowerBound)
+    }
+}

--- a/bitchatTests/ChatPlaintextExporterTests.swift
+++ b/bitchatTests/ChatPlaintextExporterTests.swift
@@ -1,6 +1,7 @@
 import BitFoundation
 import Foundation
 import Testing
+@testable import bitchat
 
 struct ChatPlaintextExporterTests {
     private static let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)


### PR DESCRIPTION
## Summary
- Add `ChatPlaintextExporter` to format mesh, geohash, and DM timelines as plain text with an explicit unsealed-plaintext warning header.
- Expose an export control on non-empty timelines; confirm before writing plaintext, then open the system share sheet.
- Localize export actions, confirmation copy, scope titles, and accessibility labels (en + needs_review for other locales).

## Test plan
- [ ] Export a mesh conversation and verify the warning line appears at the top
- [ ] Export a DM and confirm scope title uses the peer nickname
- [ ] Cancel the confirmation dialog and confirm no file is shared
- [ ] Run `ChatPlaintextExporterTests`


Made with [Cursor](https://cursor.com)