### PR TITLE
docs: consolidate install trust + Android↔iOS media known gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the notarized `.dmg` ask in #1097) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the [notarized `.dmg` ask](https://github.com/permissionlesstech/bitchat/issues/1097)) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
-Cross-platform image and voice note issues (especially Android → iOS): see [Media interop](docs/MEDIA-INTEROP.md).
-
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 
 ## License
@@ -30,6 +28,7 @@ This project is released into the public domain. See the [LICENSE](LICENSE) file
 - **Decentralized Mesh Network**: Automatic peer discovery and multi-hop message relay over Bluetooth LE
 - **Privacy First**: No accounts, no phone numbers, no servers. Note that the mesh does use a persistent per-device identifier derived from your identity key — see [the whitepaper](WHITEPAPER.md) on identity and metadata for what a nearby radio can observe
 - **Private Message End-to-End Encryption**: [Noise Protocol](https://noiseprotocol.org) for mesh, BitChat private envelopes for Nostr fallback
+- **Cross-platform media troubleshooting**: Android ↔ iOS image/voice note drops — see [Media interop](docs/MEDIA-INTEROP.md)
 - **IRC-Style Commands**: Familiar `/slap`, `/msg`, `/who` style interface
 - **Universal App**: Native support for iOS and macOS
 - **Emergency Wipe**: Triple-tap to instantly clear all data

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) (including the notarized `.dmg` ask in #1097) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, TestFlight as an App Store fallback (#966), and what to do if an unverifiable binary is the only option.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 ### Getting a copy you can trust
 
-Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, TestFlight as an App Store fallback (#966), and what to do if an unverifiable binary is the only option.
+Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, [TestFlight as a listing/release fallback](https://github.com/permissionlesstech/bitchat/issues/966), and what to do if an unverifiable binary is the only option.
 
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A decentralized peer-to-peer messaging app with dual transport architecture: loc
 
 Install from the App Store, or build from source you have verified. A compiled build from anywhere else cannot be verified — see [Verifying bitchat](docs/VERIFYING-A-BUILD.md) for how to check source against the per-release hash manifest, and for what to do if that is the only build you can get.
 
+Cross-platform image and voice note issues (especially Android → iOS): see [Media interop](docs/MEDIA-INTEROP.md).
+
 This matters more than it usually would: this repository has been the target of takedown demands, and when a repository or releases page disappears, mirrors appear that nobody can check.
 
 ## License

--- a/bitchat/Services/BLE/MimeType.swift
+++ b/bitchat/Services/BLE/MimeType.swift
@@ -18,6 +18,11 @@ extension UTType {
 }
 
 // MARK: - MimeType Enum
+//
+// Android send paths use `image/jpeg` and `audio/mp4` (see bitchat-android
+// docs/file_transfer.md). Keep those strings in `allowed` and document
+// changes in docs/MEDIA-INTEROP.md — silent MIME REJECT drops are a common
+// false lead for Android → iOS reports (#1518).
 
 enum MimeType: CaseIterable, Hashable {
     case jpeg

--- a/bitchatTests/MimeTypeTests.swift
+++ b/bitchatTests/MimeTypeTests.swift
@@ -87,4 +87,12 @@ struct MimeTypeTests {
         #expect(MimeType.octetStream.matches(data: randomData),
                 "application/octet-stream should always be considered valid")
     }
+
+    /// Android MediaSendingManager emits these exact strings today.
+    @Test func androidCanonicalSendMimesAreAccepted() {
+        #expect(MimeType("image/jpeg") == .jpeg)
+        #expect(MimeType("audio/mp4") == .mp4Audio)
+        #expect(MimeType("image/jpeg")?.isAllowed == true)
+        #expect(MimeType("audio/mp4")?.isAllowed == true)
+    }
 }

--- a/docs/MEDIA-INTEROP.md
+++ b/docs/MEDIA-INTEROP.md
@@ -1,0 +1,75 @@
+# Cross-platform media interop (iOS ↔ Android)
+
+Text messages mesh fine across clients. **Images and voice notes** use the
+file-transfer packet (`MessageType.fileTransfer`) plus, for DMs, Noise-sealed
+private-media delivery. Failures are usually silent on the receiver: the
+sender shows "sent," the receiver never grows a bubble.
+
+This note is for debugging reports like
+[#1518](https://github.com/permissionlesstech/bitchat/issues/1518)
+(Android → iOS media missing; iOS → Android OK).
+
+## Wire shape both sides agree on
+
+Android documents the TLV file packet in
+[`bitchat-android` `docs/file_transfer.md`](https://github.com/permissionlesstech/bitchat-android/blob/main/docs/file_transfer.md).
+Canonical MIME strings from Android send paths today:
+
+| Kind | MIME |
+|------|------|
+| Photo | `image/jpeg` |
+| Voice | `audio/mp4` |
+
+iOS accepts those via `MimeType` / `BLEIncomingFileValidator`. A MIME reject
+or magic-byte mismatch is logged (`MIME REJECT` / `MAGIC REJECT`) and the
+payload is dropped — there is no in-chat error bubble yet.
+
+## Version skew (the #1518 smoking gun)
+
+Reporter stack in #1518:
+
+- Android **1.7.4**
+- iOS App Store **1.7.0** (tag `v1.7.0`, 2026-07-08)
+
+After `v1.7.0`, main gained several **private-media** fixes that App Store
+1.7.0 does not include, including (non-exhaustive):
+
+- Encrypt private media before BLE fragmentation
+- Persist authenticated private-media delivery receipts
+- Retry confirmed private media after reconnect
+- Earlier: stamp incoming DM images delivered (#1402)
+
+Public / mesh file transfer and private Noise media do not share the same
+code path. A skew where Android has newer private-media behavior than iOS
+1.7.0 matches "private chat photos die Android→iOS, text is fine."
+
+**First remediation for reporters:** install an iOS build from current
+`main` (TestFlight / Xcode) or wait for the next App Store cut that includes
+the July private-media stack — do not assume MIME incompatibility until that
+is ruled out.
+
+## What to collect if it still fails on matched builds
+
+On the **iOS** device, with verbose logging / Console:
+
+1. `MIME REJECT` / `MAGIC REJECT` / `Failed to decode file transfer`
+2. Whether the chat is **mesh/public** vs **private DM**
+3. Exact app versions on both ends (build number, not just marketing version)
+4. Whether Tor / Nostr relay delivery is involved (geohash) vs BLE-only
+
+On Android, confirm `MediaSendingManager` still emits `image/jpeg` /
+`audio/mp4` for the failing send.
+
+## Maintainer release gate
+
+Before cutting an App Store build that claims Android media parity, run the
+device matrix in [#1580](https://github.com/permissionlesstech/bitchat/issues/1580)
+**plus**:
+
+- [ ] Android → iOS private DM image
+- [ ] Android → iOS private DM voice note
+- [ ] iOS → Android private DM image (control)
+- [ ] Android → iOS public/mesh image (control)
+
+See also Tor / distribution notes in `docs/VERIFYING-A-BUILD.md` when the
+store build itself is unreachable.

--- a/docs/MEDIA-INTEROP.md
+++ b/docs/MEDIA-INTEROP.md
@@ -24,6 +24,9 @@ iOS accepts those via `MimeType` / `BLEIncomingFileValidator`. A MIME reject
 or magic-byte mismatch is logged (`MIME REJECT` / `MAGIC REJECT`) and the
 payload is dropped — there is no in-chat error bubble yet.
 
+When a local wire-shape / file-transfer spec lands under `/spec` (see #1519),
+prefer that over the Android doc link above.
+
 ## Version skew (the #1518 smoking gun)
 
 Reporter stack in #1518:
@@ -32,21 +35,23 @@ Reporter stack in #1518:
 - iOS App Store **1.7.0** (tag `v1.7.0`, 2026-07-08)
 
 After `v1.7.0`, main gained several **private-media** fixes that App Store
-1.7.0 does not include, including (non-exhaustive):
+1.7.0 did not include. Those shipped in App Store **1.7.1** (`v1.7.1`),
+including:
 
-- Encrypt private media before BLE fragmentation
-- Persist authenticated private-media delivery receipts
-- Retry confirmed private media after reconnect
-- Earlier: stamp incoming DM images delivered (#1402)
+- Encrypt private media before BLE fragmentation (#1434)
+- Persist authenticated private-media delivery receipts (#1466)
+- Retry confirmed private media after reconnect (#1467)
+
+Note: stamp incoming DM images delivered (#1402 / `35fb9fdd`) **is already in
+v1.7.0** — do not treat it as missing on store 1.7.0.
 
 Public / mesh file transfer and private Noise media do not share the same
 code path. A skew where Android has newer private-media behavior than iOS
 1.7.0 matches "private chat photos die Android→iOS, text is fine."
 
-**First remediation for reporters:** install an iOS build from current
-`main` (TestFlight / Xcode) or wait for the next App Store cut that includes
-the July private-media stack — do not assume MIME incompatibility until that
-is ruled out.
+**First remediation for reporters:** update iOS to App Store **1.7.1** (or
+newer / a current `main` build). Do not assume MIME incompatibility until
+matched versions are ruled out.
 
 ## What to collect if it still fails on matched builds
 
@@ -60,16 +65,17 @@ On the **iOS** device, with verbose logging / Console:
 On Android, confirm `MediaSendingManager` still emits `image/jpeg` /
 `audio/mp4` for the failing send.
 
-## Maintainer release gate
+## Maintainer release gate (media parity)
 
-Before cutting an App Store build that claims Android media parity, run the
-device matrix in [#1580](https://github.com/permissionlesstech/bitchat/issues/1580)
-**plus**:
+Before cutting an App Store build that claims Android media parity, run at
+least:
 
+- [ ] Upgrade-in-place from the previous store build (identity / favorites / DM history intact)
 - [ ] Android → iOS private DM image
 - [ ] Android → iOS private DM voice note
 - [ ] iOS → Android private DM image (control)
 - [ ] Android → iOS public/mesh image (control)
+- [ ] Locked-device background receive of an image over mesh
 
 See also Tor / distribution notes in `docs/VERIFYING-A-BUILD.md` when the
 store build itself is unreachable.

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -103,6 +103,7 @@ Cutting a release:
 - Push the tag. `source-manifest.yml` runs and attaches `SOURCE-MANIFEST.txt` to the release; if the release does not exist yet, collect the manifest from the workflow artifact and attach it when you publish.
 - Sign the tag (`git tag -s`). A signed tag lets anyone verify the release came from a key you control, independent of GitHub. This needs a published key fingerprint to be useful — see the gap below.
 - Note the commit hash somewhere outside this repository. If the repository is taken down, a hash recorded elsewhere is what lets people verify a mirror.
+- If/when notarized Developer ID `.dmg` artifacts exist, attach them to the same release as `SOURCE-MANIFEST.txt` and link them from the "macOS Developer ID" section above.
 
 Known gaps, so nobody assumes more protection than exists:
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -108,4 +108,5 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
+- **No notarized Developer ID `.dmg` on Releases yet.** [#1097](https://github.com/permissionlesstech/bitchat/issues/1097) tracks that ask; see "macOS Developer ID / notarized `.dmg`" above.
 - **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -11,8 +11,9 @@ The honest summary is short. **Source can be verified. Compiled apps cannot, unl
 In order of how much verification is possible:
 
 1. **The App Store.** Apple verifies the developer signature, and the binary cannot be altered without breaking it. This is the only channel where a compiled build is verifiable end to end, and it is the right recommendation for almost everyone.
-2. **Build it yourself from verified source.** See below. Requires a Mac and Xcode, and gives you the strongest guarantee if you can do it.
-3. **A compiled build from anywhere else.** Not verifiable. See "Builds from other sources".
+2. **Maintainer TestFlight (when published).** Still Apple-signed; see "App Store fallbacks (TestFlight)". Prefer this over forum IPAs when the store itself is unreachable.
+3. **Build it yourself from verified source.** See below. Requires a Mac and Xcode, and gives you the strongest guarantee if you can do it.
+4. **A compiled build from anywhere else.** Not verifiable. See "Builds from other sources".
 
 ## Verifying source
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -79,6 +79,23 @@ What to do instead, in order of preference: install from the App Store; build fr
 
 Do not rely on the app looking right. A modified build has no reason to look different.
 
+
+## macOS Developer ID / notarized `.dmg` (#1097)
+
+A notarized Developer ID `.dmg` attached to GitHub Releases would give macOS
+users a sideload path that still carries Apple's signature chain — stronger
+than an unsigned forum binary, weaker than the App Store for verification
+storytelling, and useful when the store is unreachable.
+
+Status on main today:
+
+- Tagged releases already ship an **attested source manifest** (build from
+  verified source remains the supported non–App Store path).
+- There is **no** published notarized `.dmg` yet — that needs release-signing
+  infrastructure and a maintainer decision on key custody.
+- Until that lands, treat any third-party `.dmg` / `.app` the same as other
+  unverifiable compiled builds above.
+
 ## For maintainers
 
 Cutting a release:

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -79,6 +79,19 @@ What to do instead, in order of preference: install from the App Store; build fr
 
 Do not rely on the app looking right. A modified build has no reason to look different.
 
+
+## App Store fallbacks (TestFlight)
+
+Issue [#966](https://github.com/permissionlesstech/bitchat/issues/966) tracks non–App Store distribution for regions where the store is blocked or unreliable. The project already ships an attested source manifest so people can **build from verified source** when binaries are untrustworthy (see above).
+
+What remains as a product decision — not something a random mirror can invent — is a **maintained public TestFlight link** as an App Store fallback:
+
+- TestFlight builds are still Apple-signed and consent-gated; they are closer to the App Store trust model than an unsigned `.ipa` from a forum.
+- The link itself must be published by maintainers (and kept current across beta expiry). This document will not invent a URL.
+- Until a link is published here, treat TestFlight the same as any other sideloaded binary unless you received the invite from a channel you already trust for bitchat releases.
+
+Android sideloading (signed APKs) lives in the [bitchat-android](https://github.com/permissionlesstech/bitchat-android) project and is out of scope for this iOS/macOS repository.
+
 ## For maintainers
 
 Cutting a release:

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -12,7 +12,7 @@ In order of how much verification is possible:
 
 1. **The App Store.** Apple verifies the developer signature, and the binary cannot be altered without breaking it. This is the only channel where a compiled build is verifiable end to end, and it is the right recommendation for almost everyone.
 2. **Build it yourself from verified source.** See below. Requires a Mac and Xcode, and gives you the strongest guarantee against the attested release tree if you can do it.
-3. **Maintainer TestFlight (when published).** Still Apple-signed; see "App Store fallbacks (TestFlight)". Prefer this over forum IPAs when the store is unreachable *and* you cannot build from source — TestFlight proves Apple distributed a maintainer upload, but it does not let you check the binary against `SOURCE-MANIFEST.txt`.
+3. **Maintainer TestFlight (when published).** Still Apple-signed; see "App Store fallbacks (TestFlight)". Prefer this over forum IPAs when the App Store listing is missing or behind (and you cannot build from source) — TestFlight proves Apple distributed a maintainer upload, but it does not let you check the binary against `SOURCE-MANIFEST.txt`. It still depends on Apple’s delivery path, so it is not a fallback for a wholesale block of Apple services.
 4. **A compiled build from anywhere else.** Not verifiable. See "Builds from other sources".
 
 ## Verifying source
@@ -83,13 +83,14 @@ Do not rely on the app looking right. A modified build has no reason to look dif
 
 ## App Store fallbacks (TestFlight)
 
-Issue [#966](https://github.com/permissionlesstech/bitchat/issues/966) tracks non–App Store distribution for regions where the store is blocked or unreliable. The project already ships an attested source manifest so people can **build from verified source** when binaries are untrustworthy (see above).
+Issue [#966](https://github.com/permissionlesstech/bitchat/issues/966) tracks a public TestFlight invite for cases where the App Store *listing* is gone or lagging — not a wholesale block of Apple services (TestFlight itself still installs through Apple). The project already ships an attested source manifest so people can **build from verified source** when binaries are untrustworthy (see above).
 
-What remains as a product decision — not something a random mirror can invent — is a **maintained public TestFlight link** as an App Store fallback:
+What remains as a product decision — not something a random mirror can invent — is a **maintained public TestFlight link** as that listing/release fallback:
 
 - TestFlight builds are still Apple-signed and consent-gated; they are closer to the App Store trust model than an unsigned `.ipa` from a forum.
 - The link itself must be published by maintainers (and kept current across beta expiry). This document will not invent a URL.
 - Until a link is published here, treat TestFlight the same as any other sideloaded binary unless you received the invite from a channel you already trust for bitchat releases.
+- If Apple services themselves are unreachable, TestFlight does not help — use verified source builds (or treat any other binary as untrusted).
 
 Android sideloading (signed APKs) lives in the [bitchat-android](https://github.com/permissionlesstech/bitchat-android) project and is out of scope for this iOS/macOS repository.
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -91,5 +91,6 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
-- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.- **App Store iOS builds can lag Android private-media fixes.** See docs/MEDIA-INTEROP.md and #1518 before treating silent Android→iOS image drops as MIME bugs.
+- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.
+- **App Store iOS builds can lag Android private-media fixes.** See [docs/MEDIA-INTEROP.md](MEDIA-INTEROP.md) and [#1518](https://github.com/permissionlesstech/bitchat/issues/1518) before treating silent Android→iOS image drops as MIME bugs. App Store **1.7.1** includes the July private-media stack (#1434/#1466/#1467); **1.7.0** already included #1402.
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -83,7 +83,7 @@ Do not rely on the app looking right. A modified build has no reason to look dif
 ## macOS Developer ID / notarized `.dmg` (#1097)
 
 A notarized Developer ID `.dmg` attached to GitHub Releases would give macOS
-users a sideload path that still carries Apple's signature chain — stronger
+people a sideload path that still carries Apple's signature chain — stronger
 than an unsigned forum binary, weaker than the App Store for verification
 storytelling, and useful when the store is unreachable.
 

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -11,8 +11,8 @@ The honest summary is short. **Source can be verified. Compiled apps cannot, unl
 In order of how much verification is possible:
 
 1. **The App Store.** Apple verifies the developer signature, and the binary cannot be altered without breaking it. This is the only channel where a compiled build is verifiable end to end, and it is the right recommendation for almost everyone.
-2. **Maintainer TestFlight (when published).** Still Apple-signed; see "App Store fallbacks (TestFlight)". Prefer this over forum IPAs when the store itself is unreachable.
-3. **Build it yourself from verified source.** See below. Requires a Mac and Xcode, and gives you the strongest guarantee if you can do it.
+2. **Build it yourself from verified source.** See below. Requires a Mac and Xcode, and gives you the strongest guarantee against the attested release tree if you can do it.
+3. **Maintainer TestFlight (when published).** Still Apple-signed; see "App Store fallbacks (TestFlight)". Prefer this over forum IPAs when the store is unreachable *and* you cannot build from source — TestFlight proves Apple distributed a maintainer upload, but it does not let you check the binary against `SOURCE-MANIFEST.txt`.
 4. **A compiled build from anywhere else.** Not verifiable. See "Builds from other sources".
 
 ## Verifying source

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -105,4 +105,5 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
+- **No published public TestFlight link yet.** [#966](https://github.com/permissionlesstech/bitchat/issues/966) is rescoped to that single remaining distribution ask; when maintainers publish a link, add it under "App Store fallbacks (TestFlight)" above.
 - **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.

--- a/docs/VERIFYING-A-BUILD.md
+++ b/docs/VERIFYING-A-BUILD.md
@@ -91,4 +91,5 @@ Known gaps, so nobody assumes more protection than exists:
 
 - **No published signing key.** Tags are not currently verifiable against a known key. Publishing a fingerprint through channels independent of GitHub, and signing tags with it from then on, is the missing piece.
 - **No verifiable compiled builds outside the App Store.** Closing this needs either a signed-and-notarized release pipeline or a reproducible build, and until one exists the guidance above stands.
-- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.
+- **No non-GitHub source mirror.** Every remote for this project is on the platform the takedown demands were served to. A mirror on independent infrastructure, published before it is needed, would mean a takedown does not remove the ability to verify.- **App Store iOS builds can lag Android private-media fixes.** See docs/MEDIA-INTEROP.md and #1518 before treating silent Android→iOS image drops as MIME bugs.
+

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -119,3 +119,7 @@ The panic action clears identity/session state, preferences, location state, gro
 - Treat geohash precision, bridge-cell changes, new relay tags, and announce fields as privacy-surface changes.
 - Re-run real-device Bluetooth, background/locked-device recovery, location revocation, and audio-route checks; simulators cannot validate the physical side of those behaviors.
 - Check what a new notification discloses on a locked screen, and that the app-switcher snapshot is covered, whenever notification or scene-lifecycle code changes.
+
+## Cross-platform media
+
+Silent Android ↔ iOS image/voice drops are documented in [MEDIA-INTEROP.md](MEDIA-INTEROP.md).

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -8,6 +8,7 @@ Last reviewed: July 2026
 - Nostr private fallback, bridge courier drops, mesh bridging, geohash channels, and notices
 - CoreLocation and reverse geocoding
 - Local persistence, panic wipe, logging, and App Store privacy manifests
+- Distribution trust (App Store vs unverifiable sideloads, including the #1097 `.dmg` ask) — see docs/VERIFYING-A-BUILD.md
 
 The user-facing contract is `PRIVACY_POLICY.md`. This document records implementation-level behavior and residual risks that should be re-audited when storage or transport semantics change.
 

--- a/docs/privacy-assessment.md
+++ b/docs/privacy-assessment.md
@@ -8,6 +8,7 @@ Last reviewed: July 2026
 - Nostr private fallback, bridge courier drops, mesh bridging, geohash channels, and notices
 - CoreLocation and reverse geocoding
 - Local persistence, panic wipe, logging, and App Store privacy manifests
+- Distribution trust (App Store / TestFlight vs unverifiable sideloads) — see docs/VERIFYING-A-BUILD.md
 
 The user-facing contract is `PRIVACY_POLICY.md`. This document records implementation-level behavior and residual risks that should be re-audited when storage or transport semantics change.
 


### PR DESCRIPTION
## Summary
- Consolidates the three conflicting docs PRs (#1577 TestFlight fallback, #1579 notarized `.dmg` gap, #1581 Android↔iOS media interop) into one reviewable surface on current `main`.
- Keeps Jack’s factual corrections (no `Closes #966` / `#1097`; TestFlight doesn’t bypass a full Apple outage; people-not-users; media/1.7.1 accuracy from #1581).
- Single README / VERIFYING / privacy-assessment edit so maintainers don’t have to resolve pairwise conflicts.

Supersedes #1577, #1579, and #1581.

## Test plan
- [ ] README trust paragraph links #966, #1097, and VERIFYING
- [ ] VERIFYING has separate TestFlight + notarized `.dmg` sections and both known-gaps bullets
- [ ] `docs/MEDIA-INTEROP.md` renders cleanly; MimeType tests still pass if CI runs them


Made with [Cursor](https://cursor.com)