### PR TITLE
Log the oversized-payload rejection instead of dropping in silence

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -366,7 +366,19 @@ public struct BinaryProtocol {
                     guard let rawSize = read16() else { return nil }
                     originalSize = Int(rawSize)
                 }
-                guard originalSize >= 0 && originalSize <= FileTransferLimits.maxFramedFileBytes else { return nil }
+                // Logged, not silent: this is the sibling of the ratio
+                // rejection below and drops the packet just as completely, but
+                // returning `nil` bare left no trace anywhere. A peer whose
+                // ceiling is higher than ours (issue #1618: Android permits a
+                // 10 MiB expanded payload against our ~1.13 MiB) then looks to
+                // both sides like a message that simply never arrived.
+                guard originalSize >= 0 && originalSize <= FileTransferLimits.maxFramedFileBytes else {
+                    SecureLogger.warning(
+                        "🚫 Declared expanded payload \(originalSize) B exceeds the \(FileTransferLimits.maxFramedFileBytes) B ceiling",
+                        category: .security
+                    )
+                    return nil
+                }
                 let compressedSize = payloadLength - lengthFieldBytes
                 guard compressedSize > 0, let compressed = readData(compressedSize) else { return nil }
 


### PR DESCRIPTION
Follow-up to #1618, and useful whichever way that ceiling is reconciled.

`BinaryProtocol.decodeCore` refuses a compressed packet whose declared
expanded size exceeds `FileTransferLimits.maxFramedFileBytes` by returning
`nil` with nothing logged. The suspicious-ratio guard on the next lines drops
the packet just as completely and logs a warning. So of the two ways a
compressed payload can be refused during decode, one is diagnosable and one
leaves no trace at all.

That gap has a cost now: #1618 reports Android allowing a 10 MiB expanded
payload against this ~1.13 MiB ceiling, and every message caught by it dies
here invisibly — no error on the sender, nothing on the receiver. It took
reading the decoder to find, which is exactly what a log would have saved.

This adds a matching `SecureLogger.warning` with the declared size and the
ceiling. Behavior is unchanged: the packet is still refused, and the existing
`Reject payloads larger than the framed file cap` test still covers it.
BitFoundation builds clean; 165 tests pass.

Deliberately does not touch the constant itself — which of the two ceilings
should move is the design call in #1618, and I have left a note there on why
reconciling *upward* is the riskier direction (that cap is also the
allocation bound for `CompressionUtil.decompress`, and the 50,000:1 ratio
guard admits a 1.13 MiB claim from a ~24-byte body today).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
