### PR TITLE
fix(formatting): resolve overlapping rich-text matches before rendering

### DIFF
--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -368,8 +368,25 @@ final class MessageFormattingEngine {
             allMatches.append(ContentMatch(range: match.range(at: 0), type: .lnurl))
         }
 
-        // Sort by position
-        return allMatches.sorted { $0.range.location < $1.range.location }
+        // Sort by position, then drop any match that overlaps one already
+        // kept. The per-type checks above only guard specific known pairs
+        // (e.g. bolt11/lnurl against url/lightning) -- they don't cover every
+        // combination, so an ordinary message can still produce overlapping
+        // matches of two OTHER types the checks never compared (e.g. a URL
+        // whose path embeds a "cashuA..."-shaped token). formatContent's
+        // single linear pass assumes non-overlapping, strictly-increasing
+        // ranges; without this pass a nested match re-renders already-shown
+        // text and can walk `lastEnd` backwards, duplicating a trailing
+        // slice of content a second time.
+        let sorted = allMatches.sorted { $0.range.location < $1.range.location }
+        var resolved: [ContentMatch] = []
+        var occupiedUntil = 0
+        for match in sorted {
+            guard match.range.location >= occupiedUntil else { continue }
+            resolved.append(match)
+            occupiedUntil = match.range.location + match.range.length
+        }
+        return resolved
     }
 
     private static func formatPlainContent(_ content: String, baseColor: Color, isSelf: Bool) -> AttributedString {

--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -368,23 +368,35 @@ final class MessageFormattingEngine {
             allMatches.append(ContentMatch(range: match.range(at: 0), type: .lnurl))
         }
 
-        // Sort by position, then drop any match that overlaps one already
-        // kept. The per-type checks above only guard specific known pairs
-        // (e.g. bolt11/lnurl against url/lightning) -- they don't cover every
+        // The per-type checks above only guard specific known pairs (e.g.
+        // bolt11/lnurl against url/lightning) -- they don't cover every
         // combination, so an ordinary message can still produce overlapping
         // matches of two OTHER types the checks never compared (e.g. a URL
-        // whose path embeds a "cashuA..."-shaped token). formatContent's
-        // single linear pass assumes non-overlapping, strictly-increasing
-        // ranges; without this pass a nested match re-renders already-shown
-        // text and can walk `lastEnd` backwards, duplicating a trailing
-        // slice of content a second time.
-        let sorted = allMatches.sorted { $0.range.location < $1.range.location }
-        var resolved: [ContentMatch] = []
+        // whose path embeds a "cashuA..."-shaped token). Resolve any
+        // remaining overlap before handing matches to a rendering pass.
+        return resolveOverlappingMatches(allMatches) { $0.range }
+    }
+
+    /// Sorts matches by start position and greedily keeps only non-overlapping
+    /// ones, dropping any later match whose start falls inside an
+    /// already-kept match's range. Rendering passes that consume the result
+    /// (here and in `ChatMessageFormatter`, which has its own copy of the
+    /// match-collection logic above) assume non-overlapping,
+    /// strictly-increasing ranges; without this resolution a nested match
+    /// re-renders already-shown text and can walk the render cursor
+    /// backwards, duplicating a trailing slice of content a second time.
+    static func resolveOverlappingMatches<Match>(
+        _ matches: [Match],
+        range: (Match) -> NSRange
+    ) -> [Match] {
+        let sorted = matches.sorted { range($0).location < range($1).location }
+        var resolved: [Match] = []
         var occupiedUntil = 0
         for match in sorted {
-            guard match.range.location >= occupiedUntil else { continue }
+            let matchRange = range(match)
+            guard matchRange.location >= occupiedUntil else { continue }
             resolved.append(match)
-            occupiedUntil = match.range.location + match.range.length
+            occupiedUntil = matchRange.location + matchRange.length
         }
         return resolved
     }

--- a/bitchat/Services/MessageFormattingEngine.swift
+++ b/bitchat/Services/MessageFormattingEngine.swift
@@ -385,6 +385,13 @@ final class MessageFormattingEngine {
     /// strictly-increasing ranges; without this resolution a nested match
     /// re-renders already-shown text and can walk the render cursor
     /// backwards, duplicating a trailing slice of content a second time.
+    ///
+    /// Ties break by start position only, not length: whichever match starts
+    /// first wins outright, so an outer match (e.g. a URL) always keeps
+    /// priority over a shorter match nested inside it (e.g. an embedded cashu
+    /// token) rather than the other way around. That's intentional for
+    /// rendering — flip it to prefer the inner match only with a matching
+    /// change to how callers render the dropped outer span.
     static func resolveOverlappingMatches<Match>(
         _ matches: [Match],
         range: (Match) -> NSRange

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -190,11 +190,29 @@ final class ChatMessageFormatter {
                 }
                 allMatches.sort { $0.range.location < $1.range.location }
 
+                // Drop any match that overlaps one already kept. The
+                // per-type checks above only guard specific known pairs
+                // (e.g. bolt11/lnurl against url+lightning); they don't
+                // cover every combination, so an ordinary message can still
+                // produce overlapping matches of two OTHER types (e.g. a URL
+                // whose path embeds a "cashuA..."-shaped token). The render
+                // loop below assumes non-overlapping, strictly-increasing
+                // ranges; without this pass a nested cashu/lightning match
+                // renders as an extra spacer character injected into
+                // already-shown text instead of being skipped.
+                var resolvedMatches: [(range: NSRange, type: String)] = []
+                var occupiedUntil = 0
+                for match in allMatches {
+                    guard match.range.location >= occupiedUntil else { continue }
+                    resolvedMatches.append(match)
+                    occupiedUntil = match.range.location + match.range.length
+                }
+
                 var lastEnd = content.startIndex
                 let myNickname = viewModel.nickname.normalizedNickname
                 let isMentioned = message.mentions?.contains { $0.normalizedNickname == myNickname } ?? false
 
-                for (range, type) in allMatches {
+                for (range, type) in resolvedMatches {
                     guard let swiftRange = Range(range, in: content) else { continue }
 
                     if lastEnd < swiftRange.lowerBound {

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -188,25 +188,17 @@ final class ChatMessageFormatter {
                 where !overlapsMention(match.range(at: 0)) && !overlapsOccupied(match.range(at: 0)) {
                     allMatches.append((match.range(at: 0), "lnurl"))
                 }
-                allMatches.sort { $0.range.location < $1.range.location }
 
-                // Drop any match that overlaps one already kept. The
-                // per-type checks above only guard specific known pairs
+                // The per-type checks above only guard specific known pairs
                 // (e.g. bolt11/lnurl against url+lightning); they don't
                 // cover every combination, so an ordinary message can still
                 // produce overlapping matches of two OTHER types (e.g. a URL
                 // whose path embeds a "cashuA..."-shaped token). The render
                 // loop below assumes non-overlapping, strictly-increasing
-                // ranges; without this pass a nested cashu/lightning match
-                // renders as an extra spacer character injected into
-                // already-shown text instead of being skipped.
-                var resolvedMatches: [(range: NSRange, type: String)] = []
-                var occupiedUntil = 0
-                for match in allMatches {
-                    guard match.range.location >= occupiedUntil else { continue }
-                    resolvedMatches.append(match)
-                    occupiedUntil = match.range.location + match.range.length
-                }
+                // ranges; without resolving those first, a nested
+                // cashu/lightning match renders as an extra spacer character
+                // injected into already-shown text instead of being skipped.
+                let resolvedMatches = MessageFormattingEngine.resolveOverlappingMatches(allMatches) { $0.range }
 
                 var lastEnd = content.startIndex
                 let myNickname = viewModel.nickname.normalizedNickname

--- a/bitchatTests/MessageFormattingEngineTests.swift
+++ b/bitchatTests/MessageFormattingEngineTests.swift
@@ -349,6 +349,32 @@ struct MessageFormattingEngineTests {
 
         #expect(String(formatted.characters) == "<@alice> \(longContent) [\(message.formattedTimestamp)]")
     }
+
+    @MainActor
+    @Test func formatMessage_urlContainingCashuTokenIsNotDuplicated() {
+        // Bug: a URL match and a Cashu match are never cross-checked for
+        // overlap, only each independently against mentions. A URL whose
+        // path embeds a "cashuA..."-shaped segment (a perfectly ordinary
+        // mint redemption link) produces two overlapping matches; the
+        // single linear rendering pass then re-renders the nested cashu
+        // substring a second time and, because it walks `lastEnd` backwards,
+        // re-renders the URL's own trailing segment a third time.
+        let context = MockMessageFormattingContext(nickname: "carol")
+        let cashuToken = "cashuA" + String(repeating: "a", count: 44)
+        let url = "https://mint.example.com/redeem/\(cashuToken)/confirm"
+        let content = "redeem link \(url) now"
+        let message = BitchatMessage(
+            id: "url-cashu",
+            sender: "alice",
+            content: content,
+            timestamp: Date(timeIntervalSince1970: 1_700_001_111),
+            isRelay: false
+        )
+
+        let formatted = MessageFormattingEngine.formatMessage(message, context: context, colorScheme: .light)
+
+        #expect(String(formatted.characters) == "<@alice> \(content) [\(message.formattedTimestamp)]")
+    }
 }
 
 @MainActor

--- a/bitchatTests/MessageFormattingEngineTests.swift
+++ b/bitchatTests/MessageFormattingEngineTests.swift
@@ -375,6 +375,43 @@ struct MessageFormattingEngineTests {
 
         #expect(String(formatted.characters) == "<@alice> \(content) [\(message.formattedTimestamp)]")
     }
+
+    // MARK: - resolveOverlappingMatches Tests
+    //
+    // Direct coverage for the shared helper `ChatMessageFormatter` also
+    // calls, since its own match-collection logic (a hand-copy of
+    // findAllMatches above) isn't independently unit-testable without a
+    // live ChatViewModel.
+
+    @Test func resolveOverlappingMatches_dropsANestedOverlap() {
+        let outer = (range: NSRange(location: 0, length: 10), type: "outer")
+        let nested = (range: NSRange(location: 3, length: 2), type: "nested")
+
+        let resolved = MessageFormattingEngine.resolveOverlappingMatches([outer, nested]) { $0.range }
+
+        #expect(resolved.map(\.type) == ["outer"])
+    }
+
+    @Test func resolveOverlappingMatches_keepsNonOverlappingMatchesSortedByStart() {
+        let first = (range: NSRange(location: 0, length: 3), type: "first")
+        let second = (range: NSRange(location: 5, length: 3), type: "second")
+
+        // Passed out of order; the helper must sort internally.
+        let resolved = MessageFormattingEngine.resolveOverlappingMatches([second, first]) { $0.range }
+
+        #expect(resolved.map(\.type) == ["first", "second"])
+    }
+
+    @Test func resolveOverlappingMatches_adjacentNonOverlappingMatchesAreBothKept() {
+        // A match starting exactly where the previous one ends is not an
+        // overlap (NSRange upper bound is exclusive).
+        let first = (range: NSRange(location: 0, length: 5), type: "first")
+        let adjacent = (range: NSRange(location: 5, length: 5), type: "adjacent")
+
+        let resolved = MessageFormattingEngine.resolveOverlappingMatches([first, adjacent]) { $0.range }
+
+        #expect(resolved.map(\.type) == ["first", "adjacent"])
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Problem

`MessageFormattingEngine.findAllMatches` collects matches for mentions, hashtags, URLs, Cashu tokens, Lightning invoices, bolt11, and lnurl from independent regex/detector passes, then sorts them by start position for a single linear rendering pass in `formatContent`. Several pairs of match types are explicitly cross-checked for overlap (everything against mentions; bolt11/lnurl against url+lightning), but **url and cashu are never cross-checked against each other**.

An entirely ordinary message can trigger this: a URL whose path embeds a `cashuA...`/`cashuB...`-shaped segment (e.g. a Cashu mint redemption link like `https://mint.example.com/redeem/cashuA<50+ chars>/confirm`). `NSDataDetector` matches the **whole URL**; the Cashu regex (`cashu[AB][A-Za-z0-9._-]{40,}`) separately matches just the **nested token substring** inside it (the `/` before/after supplies the required `` boundaries). Both matches survive into `allMatches`.

`formatContent`'s single linear pass assumes matches are non-overlapping with a strictly increasing cursor (`lastEnd`). Given the nested pair (URL first by start position, cashu token nested inside it):
1. It renders the URL's full text and advances `lastEnd` to the URL's end.
2. It then processes the nested cashu match: since `lastEnd` is already past the cashu match's start, the "text before match" step is skipped, but the cashu substring is **unconditionally re-appended** a second time (styled differently) -- and `lastEnd` is set to the cashu match's end, which is *before* the URL's actual end, walking the cursor **backwards**.
3. The trailing "remaining text" check then re-appends the URL's own tail (whatever came after the nested token, e.g. `/confirm`) a **third time**.

Net effect: a deterministic, reproducible rendering-corruption bug (duplicated/misordered text in the chat view) triggered purely by ordinary message content from any peer -- no attacker privilege needed.

## Fix

Add a final resolution pass in `findAllMatches`: after sorting by start position, greedily keep only matches that don't overlap one already kept (a match is dropped if its start falls inside the previously-kept match's range). This is a general fix -- it resolves the url/cashu case and also guards any other pair of match types that isn't already covered by an explicit per-type check, without touching or duplicating the existing exclusion logic (mention overlap, `isStandaloneHashtag`, `attachedToMention`, the `occupied` list for bolt11/lnurl all still run exactly as before; this is a safety-net pass on top).

## Test plan

- [x] Added `formatMessage_urlContainingCashuTokenIsNotDuplicated` to `MessageFormattingEngineTests.swift`: a message containing a URL whose path embeds a Cashu-token-shaped segment, asserting the rendered plain text (`String(formatted.characters)`) exactly matches `<@sender> <original content unchanged> [timestamp]` -- i.e. no duplicated/reordered text.
- [x] Manually traced the test by hand against the pre-fix code (no Swift toolchain available in my environment -- see note below): the old code produces extra duplicated text (the cashu token substring, then the URL's own trailing segment, both re-appended) inserted before the final " now", so the assertion fails. With the fix, only the URL match survives the overlap resolution, and the rendered plain text is byte-identical to the original message content, so the assertion passes.
- [x] Manually re-verified this doesn't change behavior for any of the existing tests in the file: none of them contain overlapping matches of any type, so the new resolution pass is a no-op for all of them (every already-kept match's start is at or after the previous kept match's end).

**Disclosure:** I don't have Xcode/a Swift toolchain in my environment, so I could not run `swift test` directly -- I verified this change by careful manual trace of the exact regex/detector matching against the new test's specific input (documented above), but please treat CI / a maintainer's local run as the authoritative check before merging.
