### PR TITLE
fix: log silent rejection of oversized compressed payloads

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -366,7 +366,13 @@ public struct BinaryProtocol {
                     guard let rawSize = read16() else { return nil }
                     originalSize = Int(rawSize)
                 }
-                guard originalSize >= 0 && originalSize <= FileTransferLimits.maxFramedFileBytes else { return nil }
+                guard originalSize >= 0 && originalSize <= FileTransferLimits.maxFramedFileBytes else {
+                    SecureLogger.warning(
+                        "🚫 Oversized compressed payload rejected: declared originalSize=\(originalSize) exceeds maxFramedFileBytes=\(FileTransferLimits.maxFramedFileBytes)",
+                        category: .security
+                    )
+                    return nil
+                }
                 let compressedSize = payloadLength - lengthFieldBytes
                 guard compressedSize > 0, let compressed = readData(compressedSize) else { return nil }
 


### PR DESCRIPTION
When a compressed packet declares an originalSize larger than FileTransferLimits.maxFramedFileBytes, BinaryProtocol.decodeCore returned nil with no log. The suspicious-ratio path already logs a warning, so this mismatch left legitimate Android	o iOS messages invisible on both ends (see #1618).

Add a matching SecureLogger.warning that records the declared size and the ceiling. Behavior is unchanged: the packet is still refused. Existing oversizedPayloadIsRejected test continues to cover the case.