### PR TITLE
feat: preserve original bytes during re-encoding of packets with foreign encoders

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -137,7 +137,16 @@ public struct BinaryProtocol {
         var payload = packet.payload
         var isCompressed = false
         var originalPayloadSize: Int?
-        if CompressionUtil.shouldCompress(payload) {
+        // Re-encode of a decoded packet: reuse the originator's bytes (see WirePayload).
+        if let wire = packet.wirePayload, wire.forPayload == packet.payload {
+            if wire.compressed {
+                payload = wire.bytes
+                originalPayloadSize = packet.payload.count
+                isCompressed = true
+            }
+            // Uncompressed on the wire: keep it that way. shouldCompress agrees across
+            // clients, but the "only if smaller" check need not.
+        } else if CompressionUtil.shouldCompress(payload) {
             // Only compress when we can represent the original length in the outbound frame
             let maxRepresentable = version == 2 ? Int(UInt32.max) : Int(UInt16.max)
             if payload.count <= maxRepresentable,
@@ -356,6 +365,8 @@ public struct BinaryProtocol {
 
             // Payload: payloadLength is exactly the payload size (+ compression preamble if compressed)
             let payload: Data
+            // Kept so the packet can be re-encoded byte-identically (see WirePayload).
+            var receivedCompressed: Data? = nil
             if isCompressed {
                 guard payloadLength >= lengthFieldBytes else { return nil }
                 let originalSize: Int
@@ -379,6 +390,7 @@ public struct BinaryProtocol {
                 guard let decompressed = CompressionUtil.decompress(compressed, originalSize: originalSize),
                       decompressed.count == originalSize else { return nil }
                 payload = decompressed
+                receivedCompressed = compressed
             } else {
                 guard let rawPayload = readData(payloadLength) else { return nil }
                 payload = rawPayload
@@ -402,7 +414,12 @@ public struct BinaryProtocol {
                 ttl: ttl,
                 version: version,
                 route: route,
-                isRSR: isRSR
+                isRSR: isRSR,
+                wirePayload: WirePayload(
+                    bytes: receivedCompressed ?? payload,
+                    compressed: receivedCompressed != nil,
+                    forPayload: payload
+                )
             )
         }
     }

--- a/localPackages/BitFoundation/Sources/BitFoundation/BitchatPacket.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BitchatPacket.swift
@@ -8,6 +8,29 @@
 
 import struct Foundation.Data
 
+/// Payload as it arrived on the wire, set by `BinaryProtocol.decode`.
+///
+/// Signatures cover a re-encoding of the packet, and verification re-encodes too.
+/// DEFLATE output is not canonical and clients use different encoders (Apple's
+/// `compression_encode_buffer` here, `java.util.zip.Deflater` on Android), so
+/// re-compressing can change the preimage and reject a valid packet. Reusing these
+/// bytes also stops a relay, which re-encodes on TTL decrement, from substituting
+/// its own encoding.
+///
+/// `forPayload` ties the bytes to the payload they decode to: replace the payload
+/// and the encoder compresses instead.
+public struct WirePayload {
+    public let bytes: Data
+    public let compressed: Bool
+    public let forPayload: Data
+
+    public init(bytes: Data, compressed: Bool, forPayload: Data) {
+        self.bytes = bytes
+        self.compressed = compressed
+        self.forPayload = forPayload
+    }
+}
+
 /// The core packet structure for all BitChat protocol messages.
 /// Encapsulates all data needed for routing through the mesh network,
 /// including TTL for hop limiting and optional encryption.
@@ -23,8 +46,17 @@ public struct BitchatPacket: Codable {
     public var ttl: UInt8
     public var route: [Data]?
     public var isRSR: Bool
-    
-    public init(type: UInt8, senderID: Data, recipientID: Data?, timestamp: UInt64, payload: Data, signature: Data?, ttl: UInt8, version: UInt8 = 1, route: [Data]? = nil, isRSR: Bool = false) {
+    /// Set by `BinaryProtocol.decode`. Not part of the encoded form, so it is left
+    /// out of `CodingKeys`; the default lets the synthesized `Decodable` init skip
+    /// it. Losing it only costs a re-compression.
+    public var wirePayload: WirePayload? = nil
+
+    /// Explicit so `wirePayload` stays out of the encoded form.
+    private enum CodingKeys: String, CodingKey {
+        case version, type, senderID, recipientID, timestamp, payload, signature, ttl, route, isRSR
+    }
+
+    public init(type: UInt8, senderID: Data, recipientID: Data?, timestamp: UInt64, payload: Data, signature: Data?, ttl: UInt8, version: UInt8 = 1, route: [Data]? = nil, isRSR: Bool = false, wirePayload: WirePayload? = nil) {
         self.version = version
         self.type = type
         self.senderID = senderID
@@ -35,6 +67,7 @@ public struct BitchatPacket: Codable {
         self.ttl = ttl
         self.route = route
         self.isRSR = isRSR
+        self.wirePayload = wirePayload
     }
 
     public func toBinaryData(padding: Bool = true) -> Data? {
@@ -61,7 +94,8 @@ public struct BitchatPacket: Codable {
             ttl: 0, // Use fixed TTL=0 for signing to ensure relay compatibility
             version: version,
             route: route,
-            isRSR: false // RSR flag is mutable and not part of the signature
+            isRSR: false, // RSR flag is mutable and not part of the signature
+            wirePayload: wirePayload // preimage must use the originator's bytes
         )
         return BinaryProtocol.encode(unsignedPacket)
     }

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
@@ -312,7 +312,60 @@ struct BinaryProtocolTests {
         
         #expect(decodedPacket.payload == largePayload)
     }
-    
+
+    /// Verification re-encodes the packet, so a re-encode must reproduce the
+    /// originator's bytes. Android compresses with java.util.zip.Deflater, which
+    /// need not match Apple's compression_encode_buffer byte for byte.
+    ///
+    /// The payload is wrapped in a raw-DEFLATE "stored" block (BTYPE=00): valid, it
+    /// inflates correctly, and no compressor would emit it, so it stands in for a
+    /// foreign encoder without a second library.
+    @Test("Re-encoding preserves a foreign encoder's compressed payload")
+    func reEncodePreservesForeignCompressedPayload() throws {
+        let payload = Data(String(repeating: "the mesh is up near the north gate. relay running all evening. ",
+                                  count: 4).utf8)
+
+        // Raw DEFLATE stored block: BFINAL=1 BTYPE=00, then LEN and NLEN little-endian.
+        let len = UInt16(payload.count)
+        let nlen = ~len
+        var stored = Data([0x01])
+        stored.append(UInt8(len & 0xFF))
+        stored.append(UInt8(len >> 8))
+        stored.append(UInt8(nlen & 0xFF))
+        stored.append(UInt8(nlen >> 8))
+        stored.append(payload)
+
+        let senderID = Data([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88])
+        let timestamp: UInt64 = 1_709_600_000_000
+        let payloadLength = UInt32(stored.count + 4) // payload + originalSize field
+
+        var raw = Data()
+        raw.append(2) // version = 2
+        raw.append(1) // type
+        raw.append(5) // ttl
+        for shift in stride(from: 56, through: 0, by: -8) {
+            raw.append(UInt8((timestamp >> UInt64(shift)) & 0xFF))
+        }
+        raw.append(BinaryProtocol.Flags.isCompressed) // flags
+        for shift in stride(from: 24, through: 0, by: -8) {
+            raw.append(UInt8((payloadLength >> UInt32(shift)) & 0xFF))
+        }
+        raw.append(senderID)
+        for shift in stride(from: 24, through: 0, by: -8) {
+            raw.append(UInt8((UInt32(payload.count) >> UInt32(shift)) & 0xFF))
+        }
+        raw.append(stored)
+
+        let decoded = try #require(BinaryProtocol.decode(raw), "Foreign-encoded frame must decode")
+        #expect(decoded.payload == payload, "Payload must inflate to the original")
+
+        // Compared unpadded so the result does not depend on how padding is generated.
+        let reEncoded = try #require(BinaryProtocol.encode(decoded, padding: false),
+                                     "Re-encode must succeed")
+        #expect(reEncoded == raw,
+                "Re-encode must reproduce the originator's bytes, or a valid signature stops verifying")
+    }
+
     @Test("Small payloads should not be compressed")
     func smallPayloadNoCompression() throws {
         let smallPayload = Data("Hi".utf8)


### PR DESCRIPTION
## Problem

* signed packets could fail signature verification when compressed by a different DEFLATE implementation, since encoding recompressed the payload before signing and verification
* relay forwarding made the issue worse by recompressing payloads when updating the packet, breaking signatures for downstream peers

## Fix

* preserves the original compressed payload bytes during decode and reuses them when re-encoding, avoiding unnecessary recompression
* only reuses the stored bytes while they still match the decoded payload, otherwise falling back to normal compression
* keeps the wire format unchanged with no compatibility impact

## Tests

* adds a regression test using a handcrafted raw DEFLATE stored block to simulate a packet produced by a different encoder
* verifies that decoding and re-encoding preserves the original wire bytes, ensuring signature verification remains valid across implementations

Related PR: https://github.com/permissionlesstech/bitchat-android/pull/863