### PR TITLE
docs: why iOS keeps the ~1.13 MiB framed payload cap

### DIFF
--- a/docs/PRIVATE-MEDIA-MIGRATION.md
+++ b/docs/PRIVATE-MEDIA-MIGRATION.md
@@ -120,3 +120,21 @@ contract, rather than a guessed byte threshold, stays correct as route overhead
 changes. A future Android client that adopts `0x20` but still caps its
 reassembler would need to negotiate an explicit per-peer fragment limit
 (tracked as a #1434 follow-up).
+
+## Compressed mesh payload ceiling (iOS vs Android)
+
+`FileTransferLimits.maxFramedFileBytes` (~1.13 MiB) is also the pre-decompress
+cap in `BinaryProtocol.decodeCore` for any compressed mesh/public payload, not
+only private media. Android currently allows a 10 MiB expanded size
+(`AppConstants.Protocol.MAX_PAYLOAD_LENGTH`).
+
+That disagreement can drop an otherwise-valid Android→iOS compressed message
+(#1618 / #1629). Closing it by raising the iOS bound is unsafe: decompress
+allocates `originalSize` bytes from the wire-declared field, and the
+50 000:1 compression-ratio guard runs *after* the size check, so a small
+compressed body can already force a ~1.13 MiB allocation — and would force
+~10 MiB if the caps matched Android.
+
+Prefer keeping the tighter iOS ceiling. Visible logging of the reject is
+tracked separately (#1628). Reconciling Android *downward* toward the iOS send
+cap (~1 MiB content) is the memory-safe direction if the constants must meet.

--- a/localPackages/BitFoundation/Sources/BitFoundation/FileTransferLimits.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/FileTransferLimits.swift
@@ -7,6 +7,17 @@ public enum FileTransferLimits {
     /// Compressed images after downscaling should comfortably fit under this budget.
     public static let maxImageBytes: Int = 512 * 1024 // 512 KiB
     /// Worst-case size once TLV metadata and binary packet framing are included for the largest payloads.
+    ///
+    /// Also the allocation bound for compressed mesh payloads in
+    /// `BinaryProtocol.decodeCore`: a declared `originalSize` above this is
+    /// rejected before `CompressionUtil.decompress` allocates. Android's
+    /// `MAX_PAYLOAD_LENGTH` is currently 10 MiB, so a well-compressed Android
+    /// packet can declare an original size iOS will refuse (#1618 / #1629).
+    /// Raising this to match Android would let a ~210-byte compressed body
+    /// force a ~10 MiB allocation on the more memory-constrained platform —
+    /// the 50 000:1 ratio guard runs *after* the size check. Prefer keeping
+    /// the tighter iOS bound (and logging the reject; see #1628) over growing
+    /// the cheap remote allocation.
     public static let maxFramedFileBytes: Int = {
         let maxMetadataBytes = Int(UInt16.max) * 2 // fileName + mimeType TLVs
         let tlvEnvelopeOverhead = 18 + maxMetadataBytes // TLV tags + lengths + metadata bytes


### PR DESCRIPTION
## Summary
- documents why iOS should **not** raise `maxFramedFileBytes` to Android's 10 MiB expanded size (#1618 / #1629)
- decompress allocates from the wire-declared `originalSize` *before* the 50 000:1 ratio guard, so matching Android would grow a cheap remote allocation on the tighter platform
- logging the silent reject stays #1628 / open log PRs — this only records the safe direction

## Test plan
- [ ] skim `FileTransferLimits.maxFramedFileBytes` comment + new PRIVATE-MEDIA section
- [ ] no behavior change

Refs #1618 #1629

Made with [Cursor](https://cursor.com)