### PR TITLE
fix: enforce MessageDeduplicator count bounds for marked IDs

### DIFF
--- a/bitchat/Utils/MessageDeduplicator.swift
+++ b/bitchat/Utils/MessageDeduplicator.swift
@@ -61,6 +61,7 @@ final class MessageDeduplicator {
             let now = Date()
             entries.append(Entry(id: id, timestamp: now))
             lookup[id] = now
+            trimIfNeeded()
         }
     }
 

--- a/bitchat/Utils/MessageDeduplicator.swift
+++ b/bitchat/Utils/MessageDeduplicator.swift
@@ -57,8 +57,10 @@ final class MessageDeduplicator {
         lock.lock()
         defer { lock.unlock() }
 
+        let now = Date()
+        cleanupOldEntries(before: now.addingTimeInterval(-maxAge))
+
         if lookup[id] == nil {
-            let now = Date()
             entries.append(Entry(id: id, timestamp: now))
             lookup[id] = now
             trimIfNeeded()

--- a/bitchat/Utils/MessageDeduplicator.swift
+++ b/bitchat/Utils/MessageDeduplicator.swift
@@ -16,6 +16,7 @@ final class MessageDeduplicator {
     private let lock = NSLock()
     private let maxAge: TimeInterval
     private let maxCount: Int
+    private let dateProvider: () -> Date
 
     /// Initialize with default config from TransportConfig
     convenience init() {
@@ -26,9 +27,14 @@ final class MessageDeduplicator {
     }
 
     /// Initialize with custom config for content deduplication
-    init(maxAge: TimeInterval, maxCount: Int) {
+    init(
+        maxAge: TimeInterval,
+        maxCount: Int,
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
         self.maxAge = maxAge
         self.maxCount = maxCount
+        self.dateProvider = dateProvider
     }
 
     /// Check if message is duplicate and add if not.
@@ -38,7 +44,7 @@ final class MessageDeduplicator {
         lock.lock()
         defer { lock.unlock() }
 
-        let now = Date()
+        let now = dateProvider()
         cleanupOldEntries(before: now.addingTimeInterval(-maxAge))
 
         if lookup[id] != nil {
@@ -57,7 +63,7 @@ final class MessageDeduplicator {
         lock.lock()
         defer { lock.unlock() }
 
-        let now = Date()
+        let now = dateProvider()
         cleanupOldEntries(before: now.addingTimeInterval(-maxAge))
 
         if lookup[id] == nil {
@@ -109,7 +115,7 @@ final class MessageDeduplicator {
         lock.lock()
         defer { lock.unlock() }
 
-        cleanupOldEntries(before: Date().addingTimeInterval(-maxAge))
+        cleanupOldEntries(before: dateProvider().addingTimeInterval(-maxAge))
 
         // Shrink capacity if significantly oversized
         if entries.capacity > maxCount * 2 && entries.count < maxCount {

--- a/bitchatTests/MessageDeduplicatorTests.swift
+++ b/bitchatTests/MessageDeduplicatorTests.swift
@@ -13,7 +13,12 @@ import Testing
 @Suite("Message Deduplicator")
 struct MessageDeduplicatorTests {
     @Test func markProcessed_enforcesMaximumCount() {
-        let deduplicator = MessageDeduplicator(maxAge: 300, maxCount: 4)
+        let now = Date(timeIntervalSince1970: 1_000)
+        let deduplicator = MessageDeduplicator(
+            maxAge: 300,
+            maxCount: 4,
+            dateProvider: { now }
+        )
 
         for id in ["a", "b", "c", "d", "e"] {
             deduplicator.markProcessed(id)
@@ -26,11 +31,16 @@ struct MessageDeduplicatorTests {
         #expect(deduplicator.contains("e"))
     }
 
-    @Test func markProcessed_cleansExpiredEntriesBeforeCountTrim() async {
-        let deduplicator = MessageDeduplicator(maxAge: 0.1, maxCount: 4)
+    @Test func markProcessed_cleansExpiredEntriesBeforeCountTrim() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let deduplicator = MessageDeduplicator(
+            maxAge: 300,
+            maxCount: 4,
+            dateProvider: { now }
+        )
 
         deduplicator.markProcessed("expired")
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        now.addTimeInterval(301)
 
         for id in ["b", "c", "d", "e"] {
             deduplicator.markProcessed(id)

--- a/bitchatTests/MessageDeduplicatorTests.swift
+++ b/bitchatTests/MessageDeduplicatorTests.swift
@@ -25,4 +25,20 @@ struct MessageDeduplicatorTests {
         #expect(deduplicator.contains("d"))
         #expect(deduplicator.contains("e"))
     }
+
+    @Test func markProcessed_cleansExpiredEntriesBeforeCountTrim() async {
+        let deduplicator = MessageDeduplicator(maxAge: 0.1, maxCount: 4)
+
+        deduplicator.markProcessed("expired")
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        for id in ["b", "c", "d", "e"] {
+            deduplicator.markProcessed(id)
+        }
+
+        #expect(deduplicator.contains("b"))
+        #expect(deduplicator.contains("c"))
+        #expect(deduplicator.contains("d"))
+        #expect(deduplicator.contains("e"))
+    }
 }

--- a/bitchatTests/MessageDeduplicatorTests.swift
+++ b/bitchatTests/MessageDeduplicatorTests.swift
@@ -1,0 +1,28 @@
+//
+// MessageDeduplicatorTests.swift
+// bitchatTests
+//
+// Tests for MessageDeduplicator.
+// This is free and unencumbered software released into the public domain.
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+@Suite("Message Deduplicator")
+struct MessageDeduplicatorTests {
+    @Test func markProcessed_enforcesMaximumCount() {
+        let deduplicator = MessageDeduplicator(maxAge: 300, maxCount: 4)
+
+        for id in ["a", "b", "c", "d", "e"] {
+            deduplicator.markProcessed(id)
+        }
+
+        #expect(!deduplicator.contains("a"))
+        #expect(!deduplicator.contains("b"))
+        #expect(deduplicator.contains("c"))
+        #expect(deduplicator.contains("d"))
+        #expect(deduplicator.contains("e"))
+    }
+}


### PR DESCRIPTION
## What changed

I added the existing expiry cleanup before `markProcessed(_:)` checks the ID, then apply count trimming after a new insertion. Duplicate marks remain a no-op.

I also added an injectable clock with `Date.init` as the production default, matching the existing repository pattern. The expiry regression can now advance time directly instead of sleeping against the wall clock.

## Why

`isDuplicate(_:)` already trims after insertion, but `markProcessed(_:)` did not. `BLEService` shares one deduplicator across both entry points, so marked IDs could overshoot the configured `maxCount` between a `markProcessed(_:)` call and the next `isDuplicate(_:)` or explicit cleanup. This change makes `markProcessed(_:)` enforce the same bound immediately.

One regression uses a maximum count of four and inserts five IDs. It fails before this change because all five remain present; after the fix, the existing 75% trim policy removes the two oldest IDs and retains the newest three.

The second regression mixes an expired ID with four current IDs. It verifies that the expired entry is removed before count trimming can evict a still-valid ID. Both tests use a deterministic clock.

## Tests

- `swift test --filter MessageDeduplicatorTests` — 2 tests passed
- `swift test --quiet` — 2,006 tests passed

This is one of four independent findings from an audit of `main`. It does not depend on the other changes and can be reviewed or merged separately.

<details>
<summary>Related independent findings</summary>

- #1636 — prevent manual source manifests from overwriting releases
- #1637 — exclude blocked people from geohash participant counts
- #1638 — make dedup cache eviction generation-aware

</details>
