### PR TITLE
ci: prevent manual source manifests from overwriting releases

### DIFF
--- a/.github/workflows/source-manifest.yml
+++ b/.github/workflows/source-manifest.yml
@@ -98,7 +98,7 @@ jobs:
           path: SOURCE-MANIFEST.txt
 
       - name: Attach to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## What changed

I restricted the release-attachment step in the source-manifest workflow to tag-push events. Manual dispatches still build, verify, attest, and upload the manifest as a workflow artifact.

## Why

A manual run can use a tagged workflow revision while its `ref` input points to a different tag, branch, or commit. The workflow builds the manifest from that input, but the previous condition still attached it to `github.ref_name` with `--clobber`. That could replace a release asset with a manifest for a different source tree.

The updated condition prevents manual runs from mutating release assets. Tag-push reruns retain their existing behavior and are outside this change:

| Event | Attach to release |
| --- | --- |
| Tag push | Yes |
| Manual dispatch from a tag | No |
| Manual dispatch from a branch | No |
| Manual dispatch whose input names a tag | No |

## Validation

- `git diff --check`
- Reviewed the event matrix above against the exact workflow condition
- `actionlint` v1.7.12

This is one of four independent findings from an audit of `main`. It does not depend on the other changes and can be reviewed or merged separately.

<details>
<summary>Related independent findings</summary>

- #1635 — enforce `MessageDeduplicator` count bounds for marked IDs
- #1637 — exclude blocked people from geohash participant counts
- #1638 — make dedup cache eviction generation-aware

</details>
