### PR TITLE
fix: exclude blocked people from geohash participant counts

### DIFF
--- a/bitchat/Services/GeohashParticipantTracker.swift
+++ b/bitchat/Services/GeohashParticipantTracker.swift
@@ -80,7 +80,10 @@ final class GeohashParticipantTracker: ObservableObject {
     /// Record activity from a participant in a specific geohash
     func recordParticipant(pubkeyHex: String, geohash: String) {
         let key = pubkeyHex.lowercased()
-        guard context?.isBlocked(key) != true else { return }
+        if context?.isBlocked(key) == true {
+            removeParticipant(pubkeyHex: key)
+            return
+        }
 
         var map = participants[geohash] ?? [:]
         map[key] = Date()

--- a/bitchat/Services/GeohashParticipantTracker.swift
+++ b/bitchat/Services/GeohashParticipantTracker.swift
@@ -80,6 +80,8 @@ final class GeohashParticipantTracker: ObservableObject {
     /// Record activity from a participant in a specific geohash
     func recordParticipant(pubkeyHex: String, geohash: String) {
         let key = pubkeyHex.lowercased()
+        guard context?.isBlocked(key) != true else { return }
+
         var map = participants[geohash] ?? [:]
         map[key] = Date()
         participants[geohash] = map
@@ -107,7 +109,9 @@ final class GeohashParticipantTracker: ObservableObject {
     func participantCount(for geohash: String) -> Int {
         let cutoff = Date().addingTimeInterval(activityCutoff)
         let map = participants[geohash] ?? [:]
-        return map.values.filter { $0 >= cutoff }.count
+        return map.filter { key, lastSeen in
+            lastSeen >= cutoff && context?.isBlocked(key) != true
+        }.count
     }
 
     /// Get the visible people list for the active geohash (read-only query)

--- a/bitchatTests/GeohashParticipantTrackerTests.swift
+++ b/bitchatTests/GeohashParticipantTrackerTests.swift
@@ -131,6 +131,57 @@ struct GeohashParticipantTrackerTests {
         #expect(people.first?.id == "pubkey1")
     }
 
+    @Test func recordParticipant_ignoresBlockedParticipant() {
+        let tracker = GeohashParticipantTracker()
+        let context = MockParticipantContext()
+        context.blockedPubkeys = ["blocked"]
+        tracker.configure(context: context)
+        tracker.setActiveGeohash("abc123")
+
+        tracker.recordParticipant(pubkeyHex: "BLOCKED")
+
+        #expect(tracker.participantCount(for: "abc123") == 0)
+        #expect(tracker.getVisiblePeople().isEmpty)
+    }
+
+    @Test func participantCount_excludesParticipantBlockedAfterRecording() {
+        let tracker = GeohashParticipantTracker()
+        let context = MockParticipantContext()
+        tracker.configure(context: context)
+        tracker.setActiveGeohash("abc123")
+        tracker.recordParticipant(pubkeyHex: "later-blocked")
+
+        context.blockedPubkeys.insert("later-blocked")
+        tracker.refresh()
+
+        #expect(tracker.participantCount(for: "abc123") == 0)
+        #expect(tracker.visiblePeople.isEmpty)
+    }
+
+    @Test func participantCount_matchesVisiblePeopleWithMixedBlockStatus() {
+        let tracker = GeohashParticipantTracker()
+        let context = MockParticipantContext()
+        tracker.configure(context: context)
+        tracker.setActiveGeohash("abc123")
+        tracker.recordParticipant(pubkeyHex: "visible")
+        tracker.recordParticipant(pubkeyHex: "later-blocked")
+
+        context.blockedPubkeys.insert("later-blocked")
+        tracker.refresh()
+
+        #expect(tracker.participantCount(for: "abc123") == 1)
+        #expect(tracker.visiblePeople.count == 1)
+        #expect(tracker.visiblePeople.first?.id == "visible")
+    }
+
+    @Test func participantCount_withoutContext_preservesRecordedParticipants() {
+        let tracker = GeohashParticipantTracker()
+
+        tracker.recordParticipant(pubkeyHex: "participant", geohash: "abc123")
+
+        #expect(tracker.participantCount(for: "abc123") == 1)
+    }
+
     @Test func getVisiblePeople_usesDisplayNameFromContext() async {
         let tracker = GeohashParticipantTracker()
         let context = MockParticipantContext()

--- a/bitchatTests/GeohashParticipantTrackerTests.swift
+++ b/bitchatTests/GeohashParticipantTrackerTests.swift
@@ -158,6 +158,20 @@ struct GeohashParticipantTrackerTests {
         #expect(tracker.visiblePeople.isEmpty)
     }
 
+    @Test func recordParticipant_blockedRepeatRemovesStaleVisibleParticipant() {
+        let tracker = GeohashParticipantTracker()
+        let context = MockParticipantContext()
+        tracker.configure(context: context)
+        tracker.setActiveGeohash("abc123")
+        tracker.recordParticipant(pubkeyHex: "later-blocked")
+
+        context.blockedPubkeys.insert("later-blocked")
+        tracker.recordParticipant(pubkeyHex: "LATER-BLOCKED")
+
+        #expect(tracker.participantCount(for: "abc123") == 0)
+        #expect(tracker.visiblePeople.isEmpty)
+    }
+
     @Test func participantCount_matchesVisiblePeopleWithMixedBlockStatus() {
         let tracker = GeohashParticipantTracker()
         let context = MockParticipantContext()


### PR DESCRIPTION
## Summary

Blocked people were already filtered from the visible participant list, but their recent activity could still increase the numeric participant count. I now reject blocked keys in the central recording path and defensively exclude entries that become blocked after they were recorded.

When no participant context is configured, recording and counting keep their existing behavior.

## Tests

- `swift test --filter GeohashParticipantTrackerTests` — 23 tests passed
- `swift test --quiet` — 2,009 tests passed

The regressions cover blocking before recording, blocking after recording without explicit removal, clearing a stale visible row when a later blocked event is rejected, mixed blocked/unblocked count-to-list agreement, and nil-context behavior.

This is one of four independent findings from an audit of `main`. It does not depend on the other changes and can be reviewed or merged separately.

<details>
<summary>Related independent findings</summary>

- #1635 — enforce the `MessageDeduplicator` count bound for marked IDs
- #1636 — prevent manual source manifests from overwriting releases
- #1638 — make dedup cache eviction generation-aware

</details>
