### PR TITLE
fix: return after peer color cache hit

### DIFF
--- a/bitchat/Utils/Color+Peer.swift
+++ b/bitchat/Utils/Color+Peer.swift
@@ -10,12 +10,22 @@ import SwiftUI
 
 extension Color {
     private static var peerColorCache: [String: Color] = [:]
-    
+
+    #if DEBUG
+    /// Counts cache-miss computations; exposed only so regression tests can
+    /// verify a repeated seed hits the cache instead of recomputing.
+    static var _peerColorComputeCountForTesting = 0
+    #endif
+
     init(peerSeed: String, isDark: Bool) {
         let cacheKey = peerSeed + (isDark ? "|dark" : "|light")
         if let cached = Self.peerColorCache[cacheKey] {
             self = cached
+            return
         }
+        #if DEBUG
+        Self._peerColorComputeCountForTesting += 1
+        #endif
         let h = peerSeed.djb2()
         var hue = Double(h % 1000) / 1000.0
         let orange = 30.0 / 360.0

--- a/bitchatTests/Utils/ColorPeerTests.swift
+++ b/bitchatTests/Utils/ColorPeerTests.swift
@@ -9,6 +9,10 @@ import Testing
 import SwiftUI
 @testable import bitchat
 
+/// Serialized: the compute-count assertions read a process-global counter,
+/// so a sibling test computing a colour between two reads would fail them for
+/// the wrong reason. The seeds are unique per test, but the counter is not.
+@Suite(.serialized)
 struct ColorPeerTests {
 
     @Test func repeatedSeedHitsCacheInsteadOfRecomputing() {

--- a/bitchatTests/Utils/ColorPeerTests.swift
+++ b/bitchatTests/Utils/ColorPeerTests.swift
@@ -1,0 +1,45 @@
+//
+// ColorPeerTests.swift
+// bitchatTests
+//
+// Tests for Color(peerSeed:isDark:) caching
+//
+
+import Testing
+import SwiftUI
+@testable import bitchat
+
+struct ColorPeerTests {
+
+    @Test func repeatedSeedHitsCacheInsteadOfRecomputing() {
+        let seed = "cache-hit-\(UUID().uuidString)"
+
+        let before = Color._peerColorComputeCountForTesting
+        let first = Color(peerSeed: seed, isDark: true)
+        let afterFirst = Color._peerColorComputeCountForTesting
+        let second = Color(peerSeed: seed, isDark: true)
+        let afterSecond = Color._peerColorComputeCountForTesting
+
+        #expect(afterFirst == before + 1)
+        #expect(afterSecond == afterFirst)
+        #expect(first == second)
+    }
+
+    @Test func differentAppearanceForSameSeedIsNotCachedTogether() {
+        let seed = "appearance-\(UUID().uuidString)"
+
+        let before = Color._peerColorComputeCountForTesting
+        _ = Color(peerSeed: seed, isDark: true)
+        _ = Color(peerSeed: seed, isDark: false)
+        let after = Color._peerColorComputeCountForTesting
+
+        #expect(after == before + 2)
+    }
+
+    @Test func sameSeedProducesSameColor() {
+        let seed = "deterministic-\(UUID().uuidString)"
+        let a = Color(peerSeed: seed, isDark: false)
+        let b = Color(peerSeed: seed, isDark: false)
+        #expect(a == b)
+    }
+}


### PR DESCRIPTION
peer color cache checked for a hit but never returned, so every call recomputed the color and rewrote the same cache entry. added a debug-only counter so a test can actually assert the cache short-circuits.