### PR TITLE
l10n: localize the voice-recording cancel button

### DIFF
--- a/bitchat/Views/ContentComposerView.swift
+++ b/bitchat/Views/ContentComposerView.swift
@@ -238,7 +238,7 @@ private extension ContentComposerView {
             }
             Spacer()
             Button(action: voiceRecordingVM.cancel) {
-                Label("Cancel", systemImage: "xmark.circle")
+                Label("common.cancel", systemImage: "xmark.circle")
                     .labelStyle(.iconOnly)
                     .font(.bitchatSystem(size: 18))
                     .foregroundColor(.red)


### PR DESCRIPTION
the icon-only cancel button in the recording HUD used a raw Cancel literal, so voiceover announced english regardless of locale. switched it to the common.cancel key already used everywhere else.