### PR TITLE
Timestamp sanity windows: future-dated QR codes and implausible Nostr DM rumors

### DIFF
--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -216,6 +216,10 @@ enum TransportConfig {
     static let nostrGeohashSampleLookbackSeconds: TimeInterval = 300
     static let nostrGeohashSampleLimit: Int = 100
     static let nostrDMSubscribeLookbackSeconds: TimeInterval = 86400
+    // Tolerated clock skew for the client-side rumor-timestamp window on
+    // inbound Nostr DMs (senders stamp the inner rumor with real time; only
+    // the outer gift wrap is randomized per NIP-17).
+    static let nostrDMMaxClockSkewSeconds: TimeInterval = 900
     // A sampled chat message this recent means "a conversation is happening
     // there" for the empty-timeline nearby-activity hint.
     static let uiGeohashChatActivityWindowSeconds: TimeInterval = 900

--- a/bitchat/Services/VerificationService.swift
+++ b/bitchat/Services/VerificationService.swift
@@ -106,9 +106,10 @@ final class VerificationService {
     /// Verify a scanned QR and return the parsed payload if valid (signature + freshness checks)
     func verifyScannedQR(_ urlString: String, maxAge: TimeInterval = TransportConfig.verificationQRMaxAgeSeconds) -> VerificationQR? {
         guard let url = URL(string: urlString), let qr = VerificationQR.fromURL(url) else { return nil }
-        // Freshness
+        // Freshness, in both directions: a future-dated timestamp must not
+        // buy a QR a longer validity window than a fresh one gets.
         let now = Date().timeIntervalSince1970
-        if now - Double(qr.ts) > maxAge { return nil }
+        if abs(now - Double(qr.ts)) > maxAge { return nil }
         // Verify signature using embedded ed25519 signKey
         guard let sig = Data(hexString: qr.sigHex), let signKey = Data(hexString: qr.signKeyHex) else { return nil }
         guard let transport = transport else { return nil }

--- a/bitchat/ViewModels/NostrInboundPipeline.swift
+++ b/bitchat/ViewModels/NostrInboundPipeline.swift
@@ -357,6 +357,13 @@ final class NostrInboundPipeline {
             return
         }
 
+        guard Self.isPlausibleRumorTimestamp(rumorTs) else {
+            if verbose {
+                SecureLogger.warning("GeoDM: dropping gift-wrap with implausible rumor timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+            }
+            return
+        }
+
         if verbose {
             SecureLogger.debug(
                 "GeoDM: decrypted gift-wrap id=\(giftWrap.id.prefix(16))... from=\(senderPubkey.prefix(8))...",
@@ -444,6 +451,11 @@ final class NostrInboundPipeline {
                 giftWrap: giftWrap,
                 recipientIdentity: currentIdentity
             )
+
+            guard Self.isPlausibleRumorTimestamp(rumorTimestamp) else {
+                SecureLogger.warning("Dropping Nostr DM with implausible rumor timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+                return
+            }
 
             if content.hasPrefix("verify:") {
                 return
@@ -539,6 +551,22 @@ final class NostrInboundPipeline {
             category: .session
         )
         return nil
+    }
+}
+
+extension NostrInboundPipeline {
+    /// Client-side mirror of the relay-side `since` filter on DM
+    /// subscriptions: a relay that ignores `since` — or replays archived
+    /// events — must not inject stale or future-dated DMs. The inner rumor
+    /// timestamp is the sender's true send time (only the outer gift wrap
+    /// is randomized per NIP-17), so the plausible window is the
+    /// subscription lookback plus tolerated clock skew on both ends.
+    /// Internal (not private) so tests can pin the window directly.
+    static func isPlausibleRumorTimestamp(_ ts: Int, now: Date = Date()) -> Bool {
+        let age = now.timeIntervalSince1970 - TimeInterval(ts)
+        return age >= -TransportConfig.nostrDMMaxClockSkewSeconds
+            && age <= TransportConfig.nostrDMSubscribeLookbackSeconds
+                + TransportConfig.nostrDMMaxClockSkewSeconds
     }
 }
 

--- a/bitchatTests/NostrInboundPipelineTimestampTests.swift
+++ b/bitchatTests/NostrInboundPipelineTimestampTests.swift
@@ -1,0 +1,32 @@
+//
+// NostrInboundPipelineTimestampTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Foundation
+import Testing
+@testable import bitchat
+
+struct NostrInboundPipelineTimestampTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let nowSeconds = 1_700_000_000
+    private let skew = Int(TransportConfig.nostrDMMaxClockSkewSeconds)
+    private let lookback = Int(TransportConfig.nostrDMSubscribeLookbackSeconds)
+
+    @Test("Rumor timestamps inside the lookback-plus-skew window are accepted")
+    func acceptsPlausibleTimestamps() {
+        #expect(NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds, now: now))
+        #expect(NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds - lookback + 60, now: now))
+        // A sender clock slightly ahead of the receiver is tolerated.
+        #expect(NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds + skew - 60, now: now))
+    }
+
+    @Test("Future-dated and stale rumor timestamps are rejected")
+    func rejectsImplausibleTimestamps() {
+        #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds + skew + 60, now: now))
+        #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds - lookback - skew - 60, now: now))
+    }
+}

--- a/bitchatTests/Services/VerificationServiceTests.swift
+++ b/bitchatTests/Services/VerificationServiceTests.swift
@@ -39,6 +39,19 @@ final class VerificationServiceTests: XCTestCase {
         XCTAssertNil(service.verifyScannedQR(qrString, maxAge: 60))
     }
 
+    func test_verifyScannedQR_rejectsFutureDatedPayload() throws {
+        let (service, noise) = makeService()
+        let futureTimestamp = Int64(Date().addingTimeInterval(3600).timeIntervalSince1970)
+        let qrString = try makeSignedQR(
+            noise: noise,
+            nickname: "future-\(UUID().uuidString)",
+            npub: nil,
+            ts: futureTimestamp
+        )
+
+        XCTAssertNil(service.verifyScannedQR(qrString, maxAge: 60))
+    }
+
     func test_verifyScannedQR_rejectsTamperedSignature() throws {
         let (service, noise) = makeService()
         let badSignature = Data(repeating: 0xAA, count: 64)


### PR DESCRIPTION
Two confirmed findings from the follow-up assessment.

## Future-dated verification QRs (trivial, confirmed)

`verifyScannedQR` checked freshness one-sided: `now - ts > maxAge`. A future-dated `ts` makes the difference negative and passes, so a forged timestamp bought a longer validity window than an honest one. The check is now symmetric (`abs(now - ts) > maxAge`) — a future-dated QR is rejected exactly like a stale one. Regression test added.

## Client-side created_at window on inbound Nostr DMs

There was no client-side rumor-timestamp validation; the age bound relied entirely on relays honoring the subscription's `since` filter (all three gift-wrap subscriptions pass `since: now − lookback`), plus persistent gift-wrap dedup for replay of seen events. The gap: a malicious relay can ignore `since` and push arbitrarily old or future-dated events.

Both decrypt paths in `NostrInboundPipeline` now drop rumors outside `[now − lookback − skew, now + skew]` (lookback 24h, skew 15min, both in `TransportConfig`). The window is deliberately anchored to the *inner rumor* timestamp — the sender's true send time — not the outer gift-wrap timestamp, which NIP-17 randomizes into the past by up to 2 days; and since an honest relay's `since` filter on the wrap timestamp already implies the rumor is newer than `now − lookback`, this client-side check mirrors the honest-relay guarantee without dropping anything a compliant relay would deliver.

The window helper is internal (not private) so the bounds are pinned by direct unit tests.

## Testing

- Full SwiftPM suite green: 2,007 tests / 217 suites.
- New tests count-verified to execute: `test_verifyScannedQR_rejectsFutureDatedPayload` (10 VerificationServiceTests cases run) and both `NostrInboundPipelineTimestampTests` cases.
- `swiftlint lint --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)