### PR TITLE
Make the Periphery scan blocking

### DIFF
--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -11,9 +11,11 @@ jobs:
     name: Periphery scan
     runs-on: macos-latest
     timeout-minutes: 30
-    # Advisory, like SwiftLint (#1361): findings annotate the PR but don't
-    # block merges. Drop continue-on-error once the baseline proves stable.
-    continue-on-error: true
+    # Blocking, like SwiftLint since #1646. The baseline (committed July 8)
+    # has been stable across a month of merges — the "drop continue-on-error
+    # once the baseline proves stable" condition this job shipped with is met.
+    # Known macOS-scan false positives stay suppressed by the baseline; only
+    # NEW dead code fails the job (--strict below).
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Follow-up to #1646 (SwiftLint blocking), closing the other half of the "advisory gates" finding.

The Periphery job shipped with its own promotion condition in a comment: *"Drop continue-on-error once the baseline proves stable."* That condition is met — the baseline landed July 8 (#1410) and has been stable across a month of merges since (including the BLE V3 refactor slices). The scan already runs `--strict` against the committed baseline, so known macOS-only false positives (iOS-conditional code invisible to the macOS scheme) stay suppressed; the only behavior change is that NEW dead code now blocks instead of annotating.

One-line change: remove `continue-on-error: true`, update the comment to record why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)