### PR TITLE
Say in the app that tor here has no bridges or pluggable transports

### DIFF
--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -3535,6 +3535,192 @@
         }
       }
     },
+    "app_info.settings.tor.no_bridges_note" : {
+      "comment" : "Caption shown under the tor toggle while tor is on, disclosing that the bundled tor client ships without bridges or pluggable transports, so a network operator can identify the connection as tor",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا توجد جسور أو وسائل نقل قابلة للتوصيل بعد: يمكن لمشغّل الشبكة أن يرى أنك تستخدم tor، وإن لم يرَ ما ترسله. توخَّ الحذر حيث يكون استخدام tor بحد ذاته خطرًا."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এখনও ব্রিজ বা প্লাগেবল ট্রান্সপোর্ট নেই: নেটওয়ার্ক অপারেটর দেখতে পায় যে আপনি tor ব্যবহার করছেন, যদিও আপনি কী পাঠাচ্ছেন তা নয়। যেখানে tor ব্যবহার করাই ঝুঁকিপূর্ণ, সেখানে সতর্ক থাকুন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "noch keine bridges oder pluggable transports: ein netzbetreiber kann sehen, dass du tor benutzt, aber nicht, was du sendest. vorsicht dort, wo schon die nutzung von tor riskant ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "no bridges or pluggable transports yet: a network operator can see that you use tor, though not what you send. take care where using tor is itself risky."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "todavía sin puentes ni transportes conectables: un operador de red puede ver que usas tor, aunque no lo que envías. ten cuidado donde usar tor ya sea arriesgado."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هنوز پل یا ترابری اتصال‌پذیر وجود ندارد: اپراتور شبکه می‌تواند ببیند که از tor استفاده می‌کنید، هرچند نه آنچه می‌فرستید. جایی که خودِ استفاده از tor خطرناک است، احتیاط کنید."
+          }
+        },
+        "fil" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wala pang bridges o pluggable transports: makikita ng operator ng network na gumagamit ka ng tor, kahit hindi kung ano ang ipinapadala mo. mag-ingat kung saan mapanganib na ang paggamit mismo ng tor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pas encore de bridges ni de pluggable transports : un opérateur réseau peut voir que tu utilises tor, mais pas ce que tu envoies. prudence là où utiliser tor est déjà risqué."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "עדיין אין גשרים או תעבורות מתחלפות: מפעיל הרשת יכול לראות שאתה משתמש ב-tor, אך לא מה שאתה שולח. היזהר במקומות שבהם עצם השימוש ב-tor מסוכן."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अभी ब्रिज या प्लगेबल ट्रांसपोर्ट नहीं हैं: नेटवर्क ऑपरेटर देख सकता है कि आप tor इस्तेमाल कर रहे हैं, हालाँकि यह नहीं कि आप क्या भेज रहे हैं। जहाँ tor का इस्तेमाल ही जोखिम भरा हो, वहाँ सावधानी बरतें।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "belum ada bridge atau pluggable transport: operator jaringan dapat melihat bahwa kamu memakai tor, meski tidak apa yang kamu kirim. hati-hati di tempat yang memakai tor saja sudah berisiko."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ancora nessun bridge o pluggable transport: un operatore di rete può vedere che usi tor, anche se non cosa invii. attenzione dove usare tor è già di per sé rischioso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブリッジやプラガブルトランスポートはまだありません。ネットワーク事業者は、送信内容までは見えなくても、あなたが tor を使っていることは分かります。tor の使用自体が危険な場所では注意してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 브리지나 플러거블 트랜스포트가 없습니다. 네트워크 운영자는 보내는 내용은 볼 수 없어도 tor를 쓴다는 사실은 알 수 있습니다. tor 사용 자체가 위험한 곳에서는 주의하세요."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "belum ada bridge atau pluggable transport: pengendali rangkaian boleh nampak bahawa anda menggunakan tor, walaupun bukan apa yang anda hantar. berhati-hati di tempat yang penggunaan tor itu sendiri berisiko."
+          }
+        },
+        "ne" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अहिलेसम्म ब्रिज वा प्लगेबल ट्रान्सपोर्ट छैन: तपाईंले के पठाउनुभयो भन्ने नदेखे पनि नेटवर्क सञ्चालकले तपाईंले tor प्रयोग गरेको देख्न सक्छ। जहाँ tor प्रयोग गर्नु नै जोखिमपूर्ण छ, त्यहाँ होसियार हुनुहोस्।"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nog geen bridges of pluggable transports: een netwerkbeheerder kan zien dat je tor gebruikt, al niet wat je verstuurt. wees voorzichtig waar het gebruik van tor op zich al riskant is."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "brak jeszcze mostków i pluggable transports: operator sieci widzi, że używasz tora, choć nie to, co wysyłasz. uważaj tam, gdzie samo używanie tora jest ryzykowne."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ainda sem pontes nem transportes conectáveis: um operador de rede consegue ver que usas tor, embora não o que envias. tem cuidado onde usar tor já é arriscado."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ainda sem pontes nem transportes plugáveis: um operador de rede consegue ver que você usa tor, embora não o que você envia. tenha cuidado onde usar tor já é arriscado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мостов и подключаемых транспортов пока нет: оператор сети видит, что вы используете tor, хотя и не видит, что вы отправляете. будьте осторожны там, где само использование tor рискованно."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "inga bryggor eller pluggable transports än: en nätverksoperatör kan se att du använder tor, men inte vad du skickar. var försiktig där det redan är riskabelt att använda tor."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இன்னும் பிரிட்ஜ்கள் அல்லது பிளக்கபிள் ட்ரான்ஸ்போர்ட்கள் இல்லை: நீங்கள் எதை அனுப்புகிறீர்கள் என்பதைப் பார்க்க முடியாவிட்டாலும், நீங்கள் tor பயன்படுத்துவதை நெட்வொர்க் இயக்குநர் பார்க்க முடியும். tor பயன்படுத்துவதே ஆபத்தான இடங்களில் கவனமாக இருங்கள்."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ยังไม่มีบริดจ์หรือ pluggable transport: ผู้ให้บริการเครือข่ายมองเห็นว่าคุณใช้ tor แม้จะไม่เห็นสิ่งที่คุณส่ง โปรดระวังในที่ซึ่งการใช้ tor เองก็เสี่ยงอยู่แล้ว"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "henüz köprü veya takılabilir taşıma yok: ağ operatörü ne gönderdiğini görmese de tor kullandığını görebilir. tor kullanmanın kendisinin riskli olduğu yerlerde dikkatli ol."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "мостів і підключних транспортів поки немає: оператор мережі бачить, що ви користуєтеся tor, хоча й не бачить, що ви надсилаєте. будьте обережні там, де саме використання tor ризиковане."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ابھی برجز یا پلگ ایبل ٹرانسپورٹس نہیں ہیں: نیٹ ورک آپریٹر دیکھ سکتا ہے کہ آپ tor استعمال کر رہے ہیں، اگرچہ یہ نہیں کہ آپ کیا بھیج رہے ہیں۔ جہاں tor کا استعمال ہی خطرناک ہو، وہاں احتیاط کریں۔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chưa có cầu nối hay pluggable transport: nhà mạng có thể thấy bạn dùng tor, dù không thấy bạn gửi gì. hãy thận trọng ở nơi mà chỉ riêng việc dùng tor đã rủi ro."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未支持网桥或可插拔传输：网络运营方虽看不到你发送的内容，但能看出你在使用 tor。在使用 tor 本身就有风险的地方请多加小心。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未支援橋接或可插拔傳輸：網路營運方雖看不到你傳送的內容，但能看出你正在使用 tor。在使用 tor 本身就有風險的地方請多加小心。"
+          }
+        }
+      }
+    },
     "app_info.settings.tor.off_warning" : {
       "comment" : "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address",
       "extractionState" : "manual",

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -3644,7 +3644,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "brak jeszcze mostków i pluggable transports: operator sieci widzi, że używasz tora, choć nie to, co wysyłasz. uważaj tam, gdzie samo używanie tora jest ryzykowne."
+            "value" : "brak jeszcze bridges i pluggable transports: operator sieci widzi, że używasz tora, choć nie to, co wysyłasz. uważaj tam, gdzie samo używanie tora jest ryzykowne."
           }
         },
         "pt" : {
@@ -3668,7 +3668,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "inga bryggor eller pluggable transports än: en nätverksoperatör kan se att du använder tor, men inte vad du skickar. var försiktig där det redan är riskabelt att använda tor."
+            "value" : "inga bridges eller pluggable transports än: en nätverksoperatör kan se att du använder tor, men inte vad du skickar. var försiktig där det redan är riskabelt att använda tor."
           }
         },
         "ta" : {
@@ -3680,7 +3680,7 @@
         "th" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ยังไม่มีบริดจ์หรือ pluggable transport: ผู้ให้บริการเครือข่ายมองเห็นว่าคุณใช้ tor แม้จะไม่เห็นสิ่งที่คุณส่ง โปรดระวังในที่ซึ่งการใช้ tor เองก็เสี่ยงอยู่แล้ว"
+            "value" : "ยังไม่มี bridge หรือ pluggable transport: ผู้ให้บริการเครือข่ายมองเห็นว่าคุณใช้ tor แม้จะไม่เห็นสิ่งที่คุณส่ง โปรดระวังในที่ซึ่งการใช้ tor เองก็เสี่ยงอยู่แล้ว"
           }
         },
         "tr" : {
@@ -3704,7 +3704,7 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "chưa có cầu nối hay pluggable transport: nhà mạng có thể thấy bạn dùng tor, dù không thấy bạn gửi gì. hãy thận trọng ở nơi mà chỉ riêng việc dùng tor đã rủi ro."
+            "value" : "chưa có bridge hay pluggable transport: nhà mạng có thể thấy bạn dùng tor, dù không thấy bạn gửi gì. hãy thận trọng ở nơi mà chỉ riêng việc dùng tor đã rủi ro."
           }
         },
         "zh-Hans" : {
@@ -3914,181 +3914,181 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت. الموصى به: تشغيل."
+            "value" : "يرسل حركة الإنترنت عبر tor، فيرى مشغّلو المرحّلات عنوان tor بدلاً من عنوانك. يشمل قنوات الموقع والرسائل الخاصة المسلَّمة عبر الإنترنت."
           }
         },
         "bn" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে। সুপারিশ: চালু।"
+            "value" : "ইন্টারনেট ট্রাফিক Tor দিয়ে পাঠায়, তাই রিলে পরিচালকেরা আপনার ঠিকানার বদলে Tor-এর ঠিকানা দেখে। লোকেশন চ্যানেল ও ইন্টারনেটে পাঠানো ব্যক্তিগত বার্তা এর আওতায় পড়ে।"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden. empfohlen: an."
+            "value" : "sendet internetverkehr über tor, sodass relay-betreiber die adresse von tor statt deiner sehen. gilt für standortkanäle und private nachrichten, die über das internet zugestellt werden."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on."
+            "value" : "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet. recomendado: activado."
+            "value" : "envía el tráfico de internet a través de Tor, así quienes gestionan los relays ven la dirección de Tor en lugar de la tuya. cubre los canales de ubicación y los mensajes privados entregados por internet."
           }
         },
         "fa" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد. توصیه: روشن."
+            "value" : "ترافیک اینترنت را از طریق Tor می‌فرستد، بنابراین گردانندگان رله به‌جای نشانی شما نشانی Tor را می‌بینند. کانال‌های موقعیت و پیام‌های خصوصی که از اینترنت تحویل می‌شوند را پوشش می‌دهد."
           }
         },
         "fil" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet. inirerekomenda: naka-on."
+            "value" : "ipinapadala ang trapiko sa internet sa pamamagitan ng tor, kaya nakikita ng mga nagpapatakbo ng relay ang address ng tor at hindi ang sa iyo. saklaw nito ang mga channel ng lokasyon at ang mga pribadong mensaheng ipinapadala sa internet."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet. recommandé : activé."
+            "value" : "envoie le trafic internet par tor, donc ceux qui gèrent les relais voient l'adresse de tor et pas la tienne. couvre les canaux de localisation et les messages privés livrés par internet."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט. מומלץ: פעיל."
+            "value" : "שולח את תעבורת האינטרנט דרך tor, כך שמפעילי ממסרים רואים את הכתובת של tor במקום שלך. חל על ערוצי מיקום ועל הודעות פרטיות שנשלחות דרך האינטרנט."
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है। अनुशंसित: चालू।"
+            "value" : "इंटरनेट ट्रैफ़िक Tor से भेजता है, जिससे रिले चलाने वालों को आपके पते की जगह Tor का पता दिखता है। यह लोकेशन चैनलों और इंटरनेट से पहुँचाए जाने वाले निजी संदेशों पर लागू होता है।"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet. disarankan: aktif."
+            "value" : "mengirim lalu lintas internet lewat tor, jadi pengelola relay melihat alamat tor bukan alamatmu. berlaku untuk kanal lokasi dan pesan pribadi yang dikirim lewat internet."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet. consigliato: attivo."
+            "value" : "invia il traffico internet attraverso tor, così chi gestisce i relay vede l'indirizzo di tor invece del tuo. riguarda i canali posizione e i messaggi privati consegnati via internet."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。推奨: オン"
+            "value" : "インターネット通信をtor経由で送るため、リレーの運営者にはあなたの代わりにtorのアドレスが見えます。ロケーションチャンネルと、インターネット経由で届くプライベートメッセージが対象です。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다. 권장: 켜기."
+            "value" : "인터넷 트래픽을 tor를 통해 보내므로 릴레이를 운영하는 쪽에는 내 주소가 아니라 tor의 주소가 보입니다. 위치 채널과 인터넷으로 전달되는 비공개 메시지에 적용됩니다."
           }
         },
         "ms" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet. disarankan: aktif."
+            "value" : "menghantar trafik internet melalui tor, jadi pengendali relay melihat alamat tor dan bukan alamat anda. ia merangkumi kanal lokasi dan pesan peribadi yang dihantar melalui internet."
           }
         },
         "ne" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ। सिफारिस: अन।"
+            "value" : "इन्टरनेट ट्राफिक tor मार्फत पठाउँछ, त्यसैले रिले चलाउनेहरूले तिम्रो ठेगानाको सट्टा tor को ठेगाना देख्छन्। यो स्थान च्यानल र इन्टरनेटबाट पुग्ने निजी सन्देशमा लागू हुन्छ।"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd. aanbevolen: aan."
+            "value" : "stuurt internetverkeer via tor, zodat relaybeheerders het adres van tor zien in plaats van het jouwe. geldt voor locatiekanalen en privéberichten die via internet worden bezorgd."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet. zalecane: włączone."
+            "value" : "wysyła ruch internetowy przez tor, więc osoby prowadzące relay widzą adres tor, a nie twój. dotyczy kanałów lokalizacji i wiadomości prywatnych dostarczanych przez internet."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+            "value" : "envia o tráfego de internet através do Tor, por isso quem opera os relés vê o endereço do Tor em vez do teu. abrange os canais de localização e as mensagens privadas entregues pela internet."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet. recomendado: ligado."
+            "value" : "envia o tráfego de internet pelo tor, então quem opera os relays vê o endereço do tor em vez do seu. vale para os canais de localização e as mensagens privadas entregues pela internet."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет. рекомендуем включить."
+            "value" : "отправляет интернет-трафик через tor, поэтому операторы реле видят адрес tor, а не твой. распространяется на каналы локации и приватные сообщения, доставляемые через интернет."
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet. rekommenderas: på."
+            "value" : "skickar internettrafik via tor, så de som driver reläer ser tors adress i stället för din. gäller platskanaler och privata meddelanden som levereras över internet."
           }
         },
         "ta" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும். பரிந்துரை: இயக்கவும்."
+            "value" : "இணைய போக்குவரத்தை tor வழியாக அனுப்புகிறது, அதனால் ரிலேகளை நடத்துபவர்கள் உங்கள் முகவரிக்குப் பதிலாக tor இன் முகவரியைப் பார்க்கிறார்கள். இட சேனல்களுக்கும் இணையம் வழியாக வழங்கப்படும் தனிப்பட்ட செய்திகளுக்கும் இது பொருந்தும்."
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต แนะนำให้เปิด"
+            "value" : "ส่งทราฟฟิกอินเทอร์เน็ตผ่าน tor ผู้ดูแลรีเลย์จึงเห็นที่อยู่ของ tor แทนที่อยู่ของคุณ ครอบคลุมช่องตามตำแหน่งและข้อความส่วนตัวที่ส่งผ่านอินเทอร์เน็ต"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar. önerilen: açık."
+            "value" : "internet trafiğini Tor üzerinden gönderir; böylece röle işletenler sizin adresiniz yerine Tor'un adresini görür. konum kanallarını ve internet üzerinden iletilen özel mesajları kapsar."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет. рекомендовано ввімкнути."
+            "value" : "надсилає інтернет-трафік через tor, тож оператори релеїв бачать адресу tor, а не твою. охоплює канали локації та приватні повідомлення, що доставляються через інтернет."
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔ تجویز: آن رکھیں۔"
+            "value" : "انٹرنیٹ ٹریفک tor کے ذریعے بھیجتا ہے، اس لیے ریلے چلانے والوں کو آپ کے پتے کی جگہ tor کا پتہ نظر آتا ہے۔ اس میں لوکیشن چینلز اور انٹرنیٹ سے پہنچائے جانے والے نجی پیغامات شامل ہیں۔"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet. khuyến nghị: bật."
+            "value" : "gửi lưu lượng internet qua tor, nên bên vận hành relay thấy địa chỉ của tor thay vì địa chỉ của bạn. áp dụng cho kênh vị trí và tin nhắn riêng được gửi qua internet."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。推荐：开启。"
+            "value" : "通过 tor 发送互联网流量，中继运营方看到的是 tor 的地址而不是你的。适用于位置频道和经互联网投递的私密消息。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。推薦：開啟。"
+            "value" : "透過 tor 傳送網際網路流量，中繼營運方看到的是 tor 的位址而不是你的。適用於位置頻道和經網際網路投遞的私密訊息。"
           }
         }
       }

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -87,7 +87,12 @@ struct AppInfoView: View {
             // setting as location-channels-only. It covers private messages and
             // relay-directory refreshes too, and said nothing about the cost of
             // switching it off.
-            static let torSubtitle = String(localized: "app_info.settings.tor.subtitle", defaultValue: "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on.", comment: "Subtitle for the tor routing toggle in settings, explaining what it covers")
+            //
+            // No longer says "recommended: on": torNoBridgesNote below states,
+            // while tor is on, that this build cannot back that advice up
+            // everywhere. An unconditional recommendation two lines above a
+            // caption qualifying it read as the screen contradicting itself.
+            static let torSubtitle = String(localized: "app_info.settings.tor.subtitle", defaultValue: "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet.", comment: "Subtitle for the tor routing toggle in settings, explaining what it covers")
             static let torOffWarning = String(localized: "app_info.settings.tor.off_warning", defaultValue: "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages.", comment: "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address")
             static let torNoBridgesNote = String(localized: "app_info.settings.tor.no_bridges_note", defaultValue: "no bridges or pluggable transports yet: a network operator can see that you use tor, though not what you send. take care where using tor is itself risky.", comment: "Caption shown under the tor toggle while tor is on, disclosing that the bundled tor client ships without bridges or pluggable transports, so a network operator can identify the connection as tor")
 

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -89,6 +89,7 @@ struct AppInfoView: View {
             // switching it off.
             static let torSubtitle = String(localized: "app_info.settings.tor.subtitle", defaultValue: "sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. recommended: on.", comment: "Subtitle for the tor routing toggle in settings, explaining what it covers")
             static let torOffWarning = String(localized: "app_info.settings.tor.off_warning", defaultValue: "tor is off: every relay you connect to can see your IP address, including relays carrying your private messages.", comment: "Warning shown under the tor toggle while tor is switched off, stating that relay operators can see the device IP address")
+            static let torNoBridgesNote = String(localized: "app_info.settings.tor.no_bridges_note", defaultValue: "no bridges or pluggable transports yet: a network operator can see that you use tor, though not what you send. take care where using tor is itself risky.", comment: "Caption shown under the tor toggle while tor is on, disclosing that the bundled tor client ships without bridges or pluggable transports, so a network operator can identify the connection as tor")
 
             static let relaysTitle = String(localized: "app_info.settings.relays.title", defaultValue: "private message relays", comment: "Title of the relay list editor in settings")
             static let relaysSubtitle = String(localized: "app_info.settings.relays.subtitle", defaultValue: "when the mesh can't reach someone, private messages travel through these relays. the built-in ones are well-known addresses that a network filter can block, so you can add your own — including .onion addresses.", comment: "Subtitle explaining what the relay list is for and why someone would add a relay")
@@ -455,6 +456,19 @@ struct AppInfoView: View {
                         Text(verbatim: Strings.Settings.torOffWarning)
                             .bitchatFont(size: 11)
                             .foregroundColor(palette.alertRed)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        // Issue #1549: the vendored arti is built without
+                        // pt-client or bridge-client, so the connection is
+                        // identifiable as tor even though its contents are
+                        // not. Someone deciding whether to rely on this in a
+                        // country that blocks tor has to know that here, not
+                        // only in docs/TOR-INTEGRATION.md. Not red: this is a
+                        // standing limitation of what is on, not a warning
+                        // that something is wrong.
+                        Text(verbatim: Strings.Settings.torNoBridgesNote)
+                            .bitchatFont(size: 11)
+                            .foregroundColor(secondaryTextColor)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }

--- a/docs/TOR-INTEGRATION.md
+++ b/docs/TOR-INTEGRATION.md
@@ -46,6 +46,8 @@ Private messages target the built-in relay set plus any relays added by hand (`N
 
 So in a country that blocks Tor by blocking the public relays and directory authorities, bootstrap never completes. The app reports that clearly now instead of appearing to start forever, and the BLE mesh is unaffected, but there is no circumvention path: obfs4, snowflake, and meek are all unavailable.
 
+The other half of the cost is detectability rather than reachability: a direct connection to the public Tor network is recognisable as Tor to anyone inspecting the traffic, so in a place where *using* Tor is itself the risk, turning this on is a disclosure. The settings toggle says so under `app_info.settings.tor.no_bridges_note` while Tor is on, so the limitation is visible where the choice is made and not only here.
+
 Closing this means enabling the pluggable-transport features, plumbing bridge configuration through the FFI and a settings surface, and rebuilding the xcframework under the pinned toolchain with a provenance-manifest update. That is the single largest remaining gap in censorship resilience for the internet transport.
 
 ## Dev bypass (local only)


### PR DESCRIPTION
Refs #1549. **This does not close it** — see "What this is not" below.

## The gap

`docs/TOR-INTEGRATION.md` has documented since the integration landed that the vendored Arti has no bridges and no pluggable transports:

> `arti-client` is built with `default-features = false` and features `["tokio", "rustls"]` only — no `pt-client`, no `bridge-client`

I checked the source and it is exactly that — `localPackages/Arti/arti-bitchat/Cargo.toml:12-15`, and `arti-bitchat/src/lib.rs:262-270` bootstraps from `TorClientConfigBuilder::from_directories(...).build()` with no bridge lines and no configurable directory authorities. A repo-wide search for `pluggable|obfs4|snowflake|pt_client|bridge-client` across Swift, Rust, TOML and shell returns nothing. (Every `bridge` identifier in the Swift tree is the unrelated BLE↔Nostr mesh bridge.)

Nothing in the app says it. The toggle reads:

> sends internet traffic through tor, so relay operators see tor's address instead of yours. covers location channels and private messages delivered over the internet. **recommended: on.**

and the only caption underneath (`AppInfoView.swift:454-459`) appears when tor is **off**. So the screen is candid about the cost of switching tor off and silent about the cost of leaving it on: a direct connection to the public Tor network is recognisable as Tor to anyone inspecting the traffic. The nearest the UI ever comes is `system.tor.blocked` — "this network may be blocking it" — which is about reachability, after the fact, and offers no remedy.

That is the asymmetry this fixes. Where using Tor is itself the risk — the case that motivates bridges existing at all — "recommended: on" is advice the app can't back up, and the person acting on it has no way to know.

## The change

A caption under the toggle, shown while tor is **on**, in the app's voice:

> no bridges or pluggable transports yet: a network operator can see that you use tor, though not what you send. take care where using tor is itself risky.

Deliberately **not** red like the off-warning: this is a standing limitation of the feature as shipped, not a fault condition. It uses `secondaryTextColor`, matching the mesh-bridge caption directly above it.

Three files, +202/−0: the string and the `else` branch in `AppInfoView.swift`, the catalog entry, and two sentences in `docs/TOR-INTEGRATION.md` recording that the gap is now stated in-app and not only in docs.

## Localization

New key `app_info.settings.tor.no_bridges_note`, populated for **all 30 locales** — `LocalizationCoverageTests.mainCatalogCoversAllLocalesForEveryKey` asserts every key covers the union of locales in the catalog, so an English-only entry would fail CI.

I wrote those 30 translations, so **please have native speakers check them** — fa, zh-Hans, ru and ar especially, since those are the audiences the string is for and a mistranslated security caveat is worse than none. Happy to take corrections in review or drop any locale back to English.

## What this is not

This is not a fix for #1549 and should not close it. Real circumvention needs the pluggable-transport cargo features enabled, bridge configuration plumbed through an FFI that currently exports seven functions (`arti_start`, `arti_stop`, `arti_is_running`, `arti_bootstrap_progress`, `arti_bootstrap_summary`, `arti_go_dormant`, `arti_wake`) and none of which accept config, plus a rebuild under the pinned Rust 1.96.0 toolchain and a provenance-manifest update — all in one PR, per `arti-provenance.yml`. That is a build-side change this cannot substitute for.

I also did not take the issue's other suggestion of defaulting tor off. That trades a detectability risk for an unconditional one — every relay seeing every user's IP, including relays carrying private messages — and it is a product decision for maintainers, not a drive-by change. This closes the disclosure gap in the meantime, which costs nothing and helps someone today.

## Verification status

I have no Xcode/Swift toolchain on this machine, so I have **not** compiled the project or run the suite — CI is the first real check on the Swift.

The catalog edit I did verify locally: the file parses as JSON (428 keys), and I re-implemented `LocalizationCoverageTests`' logic against it — every key, including the new one, covers all 30 locales. The diff is +186 lines in the catalog with no reformatting of existing entries.
