### PR TITLE
fix(ble): reject negative and overlapping offsets in inbound write buffer

### DIFF
--- a/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
+++ b/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
@@ -18,6 +18,7 @@ struct BLEInboundWriteBuffer {
         case decoded(packet: BitchatPacket, metadata: BLEInboundWriteAppendMetadata)
         case waiting(metadata: BLEInboundWriteAppendMetadata)
         case oversized(metadata: BLEInboundWriteAppendMetadata)
+        case invalid(metadata: BLEInboundWriteAppendMetadata)
     }
 
     private var buffersByCentralID: [String: Data] = [:]
@@ -34,10 +35,27 @@ struct BLEInboundWriteBuffer {
         var combined = buffersByCentralID[centralID] ?? Data()
         var appendedBytes = 0
         var offsets: [Int] = []
+        var lastEnd = 0
 
         for chunk in chunks where !chunk.data.isEmpty {
             offsets.append(chunk.offset)
+
+            // Reject malformed writes before touching the buffer: a negative
+            // offset traps `Data.replaceSubrange`, and non-monotonic or
+            // overlapping offsets corrupt previously written bytes.
+            guard chunk.offset >= 0, chunk.offset >= lastEnd else {
+                let metadata = BLEInboundWriteAppendMetadata(
+                    accumulatedBytes: combined.count,
+                    appendedBytes: appendedBytes,
+                    offsets: offsets,
+                    packetType: combined.count >= 2 ? combined[1] : nil
+                )
+                buffersByCentralID.removeValue(forKey: centralID)
+                return .invalid(metadata: metadata)
+            }
+
             let end = chunk.offset + chunk.data.count
+            lastEnd = end
 
             if combined.count < end {
                 combined.append(Data(repeating: 0, count: end - combined.count))

--- a/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
+++ b/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
@@ -284,6 +284,11 @@ extension BLEService: CBPeripheralManagerDelegate {
                 logAccumulatedCentralWrite(metadata, centralUUID: centralUUID)
                 SecureLogger.warning("⚠️ Dropping oversized pending write buffer (\(metadata.accumulatedBytes) bytes) for central \(centralUUID.prefix(8))…", category: .session)
                 logFailedSingleWriteIfNeeded(hasMultiple: hasMultiple, sortedRequests: sorted)
+
+            case let .invalid(metadata):
+                logAccumulatedCentralWrite(metadata, centralUUID: centralUUID)
+                SecureLogger.warning("⚠️ Dropping malformed pending write (offsets=\(metadata.offsets)) for central \(centralUUID.prefix(8))…", category: .session)
+                logFailedSingleWriteIfNeeded(hasMultiple: hasMultiple, sortedRequests: sorted)
             }
         }
     }

--- a/bitchatTests/Services/BLEInboundWriteBufferTests.swift
+++ b/bitchatTests/Services/BLEInboundWriteBufferTests.swift
@@ -126,6 +126,83 @@ struct BLEInboundWriteBufferTests {
         }
     }
 
+    @Test
+    func appendRejectsNegativeOffsetAndClearsBuffer() throws {
+        var buffer = BLEInboundWriteBuffer()
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x01, count: 4))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        let result = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: -1, data: Data([0x02]))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [-1])
+        } else {
+            Issue.record("Expected negative offset to be rejected")
+        }
+
+        // The poisoned buffer was cleared, so a clean full frame still decodes.
+        let packet = makePacket(timestamp: 0x123)
+        let frame = try #require(packet.toBinaryData(padding: false))
+        let decoded = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame)],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .decoded(decodedPacket, _) = decoded {
+            #expect(decodedPacket.timestamp == packet.timestamp)
+        } else {
+            Issue.record("Expected clean frame to decode after invalid write reset the buffer")
+        }
+    }
+
+    @Test
+    func appendRejectsOverlappingChunks() {
+        var buffer = BLEInboundWriteBuffer()
+
+        let result = buffer.append(
+            chunks: [
+                BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x01, count: 8)),
+                BLEInboundWriteChunk(offset: 4, data: Data(repeating: 0x02, count: 4))
+            ],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [0, 4])
+        } else {
+            Issue.record("Expected overlapping chunks to be rejected")
+        }
+    }
+
+    @Test
+    func appendRejectsNonMonotonicChunks() {
+        var buffer = BLEInboundWriteBuffer()
+
+        let result = buffer.append(
+            chunks: [
+                BLEInboundWriteChunk(offset: 8, data: Data(repeating: 0x01, count: 4)),
+                BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x02, count: 4))
+            ],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [8, 0])
+        } else {
+            Issue.record("Expected non-monotonic chunks to be rejected")
+        }
+    }
+
     private func makePacket(timestamp: UInt64 = 0x0102030405) -> BitchatPacket {
         BitchatPacket(
             type: MessageType.message.rawValue,


### PR DESCRIPTION
## Summary

- Fixes a remotely triggerable crash: a BLE central can send ATT writes with a **negative offset**, which flows through `BLEInboundWriteBuffer.append(chunks:for:capBytes:)` into `Data.replaceSubrange` and traps at runtime, crashing any BitChat peripheral that receives the write (denial of service).
- `BLEInboundWriteBuffer` now validates each chunk before mutating the buffer: rejects `offset < 0`, non-monotonic sequences, and overlapping chunks, and drops the offending per-central buffer (`AppendResult.invalid`).
- The peripheral-role write handler logs and discards malformed writes instead of crashing.

## Details

In `didReceiveWrite`, `CBATTRequest.offset` is attacker-controlled by the remote central. Requests are sorted ascending, but nothing rejects a negative offset:

```swift
combined.replaceSubrange(chunk.offset..<end, with: chunk.data)
```

With `chunk.offset < 0`, the range `chunk.offset..<end` is invalid (and if `end` lands below the buffer start, `replaceSubrange` also traps), so a single crafted write crashes the app. Duplicate or overlapping offsets additionally let a sender silently rewrite previously buffered bytes.

The fix validates each non-empty chunk against a running `lastEnd` cursor before touching the buffer. On violation it clears the per-central buffer and returns a new `.invalid(metadata:)` result; the caller logs the offending offsets and keeps operating. Legitimate CoreBluetooth long writes (ascending, non-overlapping offsets, including zero-padded gaps) are unaffected.

## Tests

Added to `BLEInboundWriteBufferTests`:

- negative offset is rejected and the cleared buffer still decodes a later clean frame
- overlapping chunks are rejected
- non-monotonic chunks are rejected

Note: tests were authored on a machine without an Xcode toolchain, so they have not been executed locally — relying on CI.
