### PR TITLE
fix(ble): reject negative and overlapping offsets in inbound write buffer

### DIFF
--- a/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
+++ b/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
@@ -18,6 +18,7 @@ struct BLEInboundWriteBuffer {
         case decoded(packet: BitchatPacket, metadata: BLEInboundWriteAppendMetadata)
         case waiting(metadata: BLEInboundWriteAppendMetadata)
         case oversized(metadata: BLEInboundWriteAppendMetadata)
+        case invalid(metadata: BLEInboundWriteAppendMetadata)
     }
 
     private var buffersByCentralID: [String: Data] = [:]
@@ -34,10 +35,28 @@ struct BLEInboundWriteBuffer {
         var combined = buffersByCentralID[centralID] ?? Data()
         var appendedBytes = 0
         var offsets: [Int] = []
+        // New chunks must not overlap bytes already buffered for this central.
+        var lastEnd = combined.count
 
         for chunk in chunks where !chunk.data.isEmpty {
             offsets.append(chunk.offset)
+
+            // Reject malformed writes before touching the buffer: a negative
+            // offset traps `Data.replaceSubrange`, and non-monotonic or
+            // overlapping offsets corrupt previously written bytes.
+            guard chunk.offset >= 0, chunk.offset >= lastEnd else {
+                let metadata = BLEInboundWriteAppendMetadata(
+                    accumulatedBytes: combined.count,
+                    appendedBytes: appendedBytes,
+                    offsets: offsets,
+                    packetType: combined.count >= 2 ? combined[1] : nil
+                )
+                buffersByCentralID.removeValue(forKey: centralID)
+                return .invalid(metadata: metadata)
+            }
+
             let end = chunk.offset + chunk.data.count
+            lastEnd = end
 
             if combined.count < end {
                 combined.append(Data(repeating: 0, count: end - combined.count))

--- a/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
+++ b/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
@@ -41,6 +41,14 @@ struct BLEInboundWriteBuffer {
         for chunk in chunks where !chunk.data.isEmpty {
             offsets.append(chunk.offset)
 
+            // `.withoutResponse` writes always land at offset 0, so an
+            // offset-0 chunk arriving on a non-empty buffer is a fresh frame
+            // replacing stale partial bytes, not an overlap.
+            if chunk.offset == 0, !combined.isEmpty {
+                combined.removeAll()
+                lastEnd = 0
+            }
+
             // Reject malformed writes before touching the buffer: a negative
             // offset traps `Data.replaceSubrange`, and non-monotonic or
             // overlapping offsets corrupt previously written bytes.

--- a/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
+++ b/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
@@ -284,6 +284,11 @@ extension BLEService: CBPeripheralManagerDelegate {
                 logAccumulatedCentralWrite(metadata, centralUUID: centralUUID)
                 SecureLogger.warning("⚠️ Dropping oversized pending write buffer (\(metadata.accumulatedBytes) bytes) for central \(centralUUID.prefix(8))…", category: .session)
                 logFailedSingleWriteIfNeeded(hasMultiple: hasMultiple, sortedRequests: sorted)
+
+            case let .invalid(metadata):
+                logAccumulatedCentralWrite(metadata, centralUUID: centralUUID)
+                SecureLogger.warning("⚠️ Dropping malformed pending write (offsets=\(metadata.offsets)) for central \(centralUUID.prefix(8))…", category: .session)
+                logFailedSingleWriteIfNeeded(hasMultiple: hasMultiple, sortedRequests: sorted)
             }
         }
     }

--- a/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
+++ b/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
@@ -244,14 +244,16 @@ extension BLEService: CBPeripheralManagerDelegate {
         if requests.count > 1 {
             SecureLogger.debug("📥 Received \(requests.count) write requests from central", category: .session)
         }
-        
-        // IMPORTANT: Respond immediately to prevent timeouts!
-        // We must respond within a few milliseconds or the central will timeout
-        for request in requests {
-            peripheral.respond(to: request, withResult: .success)
+
+        // While panic-suspended we drop everything; still ACK so centrals
+        // do not stall waiting on a response.
+        guard !isPanicSuspended else {
+            for request in requests {
+                peripheral.respond(to: request, withResult: .success)
+            }
+            return
         }
-        guard !isPanicSuspended else { return }
-        
+
         // Process writes. For long writes, CoreBluetooth may deliver multiple CBATTRequest values with offsets.
         // Combine per-central request values by offset before decoding.
         // Process directly on our message queue to match transport context
@@ -270,6 +272,20 @@ extension BLEService: CBPeripheralManagerDelegate {
                 for: centralUUID,
                 capBytes: TransportConfig.blePendingWriteBufferCapBytes
             )
+
+            // IMPORTANT: respond within a few milliseconds or the central will
+            // time out. Reject malformed writes with an ATT error instead of a
+            // silent success, so a central sending poisoned offsets learns the
+            // write failed instead of retrying into a cleared buffer.
+            if case .invalid = result {
+                for request in group {
+                    peripheral.respond(to: request, withResult: .invalidOffset)
+                }
+            } else {
+                for request in group {
+                    peripheral.respond(to: request, withResult: .success)
+                }
+            }
 
             switch result {
             case let .decoded(packet, metadata):

--- a/bitchatTests/Services/BLEInboundWriteBufferTests.swift
+++ b/bitchatTests/Services/BLEInboundWriteBufferTests.swift
@@ -126,6 +126,105 @@ struct BLEInboundWriteBufferTests {
         }
     }
 
+    @Test
+    func appendRejectsNegativeOffsetAndClearsBuffer() throws {
+        var buffer = BLEInboundWriteBuffer()
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x01, count: 4))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        let result = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: -1, data: Data([0x02]))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [-1])
+        } else {
+            Issue.record("Expected negative offset to be rejected")
+        }
+
+        // The poisoned buffer was cleared, so a clean full frame still decodes.
+        let packet = makePacket(timestamp: 0x123)
+        let frame = try #require(packet.toBinaryData(padding: false))
+        let decoded = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame)],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .decoded(decodedPacket, _) = decoded {
+            #expect(decodedPacket.timestamp == packet.timestamp)
+        } else {
+            Issue.record("Expected clean frame to decode after invalid write reset the buffer")
+        }
+    }
+
+    @Test
+    func appendRejectsOverlappingChunks() {
+        var buffer = BLEInboundWriteBuffer()
+
+        let result = buffer.append(
+            chunks: [
+                BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x01, count: 8)),
+                BLEInboundWriteChunk(offset: 4, data: Data(repeating: 0x02, count: 4))
+            ],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [0, 4])
+        } else {
+            Issue.record("Expected overlapping chunks to be rejected")
+        }
+    }
+
+    @Test
+    func appendRejectsNonMonotonicChunks() {
+        var buffer = BLEInboundWriteBuffer()
+
+        let result = buffer.append(
+            chunks: [
+                BLEInboundWriteChunk(offset: 8, data: Data(repeating: 0x01, count: 4)),
+                BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x02, count: 4))
+            ],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [8, 0])
+        } else {
+            Issue.record("Expected non-monotonic chunks to be rejected")
+        }
+    }
+
+    @Test
+    func appendRejectsOverlapWithPreviouslyBufferedBytes() {
+        var buffer = BLEInboundWriteBuffer()
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x01, count: 8))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        let result = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 4, data: Data(repeating: 0x02, count: 4))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .invalid(metadata) = result {
+            #expect(metadata.offsets == [4])
+        } else {
+            Issue.record("Expected overlap with buffered bytes to be rejected")
+        }
+    }
+
     private func makePacket(timestamp: UInt64 = 0x0102030405) -> BitchatPacket {
         BitchatPacket(
             type: MessageType.message.rawValue,

--- a/bitchatTests/Services/BLEInboundWriteBufferTests.swift
+++ b/bitchatTests/Services/BLEInboundWriteBufferTests.swift
@@ -190,16 +190,46 @@ struct BLEInboundWriteBufferTests {
         let result = buffer.append(
             chunks: [
                 BLEInboundWriteChunk(offset: 8, data: Data(repeating: 0x01, count: 4)),
-                BLEInboundWriteChunk(offset: 0, data: Data(repeating: 0x02, count: 4))
+                BLEInboundWriteChunk(offset: 4, data: Data(repeating: 0x02, count: 4))
             ],
             for: "central-1",
             capBytes: 1024
         )
 
         if case let .invalid(metadata) = result {
-            #expect(metadata.offsets == [8, 0])
+            #expect(metadata.offsets == [8, 4])
         } else {
             Issue.record("Expected non-monotonic chunks to be rejected")
+        }
+    }
+
+    @Test
+    func appendTreatsOffsetZeroOnStaleBufferAsRestart() throws {
+        var buffer = BLEInboundWriteBuffer()
+        let packet = makePacket(timestamp: 0x456)
+        let frame = try #require(packet.toBinaryData(padding: false))
+        let splitIndex = max(1, frame.count / 2)
+
+        // Stale partial frame left pending from an earlier write.
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame.prefix(splitIndex))],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        // A fresh `.withoutResponse` write lands at offset 0 and replaces it
+        // instead of being rejected as an overlap with the stale bytes.
+        let result = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame)],
+            for: "central-1",
+            capBytes: 1024
+        )
+
+        if case let .decoded(decoded, metadata) = result {
+            #expect(decoded.timestamp == packet.timestamp)
+            #expect(metadata.offsets == [0])
+        } else {
+            Issue.record("Expected offset-0 write to restart the stale buffer")
         }
     }
 


### PR DESCRIPTION
## Summary

- Hardens `BLEInboundWriteBuffer.append(chunks:for:capBytes:)` against malformed chunk sequences: rejects negative offsets, non-monotonic sequences, and overlapping chunks (including overlaps with bytes buffered by an earlier callback), and drops the offending per-central buffer (`AppendResult.invalid`).
- An offset-0 chunk arriving on a non-empty buffer is treated as a **fresh frame replacing stale partial bytes** (clear, then apply). This is intentional: our central role writes `.withoutResponse`, so legit writes always land at offset 0 and a restart must overwrite, not be rejected.
- The peripheral write handler now responds to malformed writes with `CBATTError.Code.invalidOffset` instead of silently ACKing them, so the sending central aborts the transfer instead of retrying into a cleared buffer.

## Details

`CBATTRequest.offset` is attacker-controlled input from the remote central, fed straight into:

```swift
combined.replaceSubrange(chunk.offset..<end, with: chunk.data)
```

Note on reachability: the ATT wire field is 16-bit unsigned, so a negative offset cannot be produced over the air; the `offset < 0` guard is defense-in-depth for the `Int`-based buffer API. The reachable hardening is the overlap/rewrite protection: duplicate or out-of-order offsets previously let a sender silently rewrite already-buffered bytes of a pending frame.

The fix validates each non-empty chunk against a running `lastEnd` cursor (seeded with the already-buffered byte count) before touching the buffer. On violation it clears the per-central buffer and returns `.invalid(metadata:)`; the caller NACKs the requests and keeps operating. Legitimate CoreBluetooth long writes (ascending, non-overlapping offsets, including zero-padded gaps) are unaffected.

Known limitation: CoreBluetooth does not distinguish write-with-response from write-without-response in `didReceiveWrite`, so an offset-0 restart from a `withResponse` multi-chunk transfer retry is indistinguishable from a fresh `withoutResponse` frame; both are treated as a restart (replace).

## Tests

Added to `BLEInboundWriteBufferTests`:

- negative offset is rejected and the cleared buffer still decodes a later clean frame
- overlapping chunks are rejected (within one call and against previously buffered bytes)
- non-monotonic chunks are rejected
- offset-0 write on a stale buffer restarts cleanly

Note: tests were authored on a machine without an Xcode toolchain, so they have not been executed locally â€” relying on CI.

Supersedes #1665 (same change; branch history was rewritten for authorship).
