### PR TITLE
fix: stop NoiseRateLimiter retaining every peer it has ever seen

### DIFF
--- a/bitchat/Noise/NoiseRateLimiter.swift
+++ b/bitchat/Noise/NoiseRateLimiter.swift
@@ -13,16 +13,43 @@ import Foundation
 final class NoiseRateLimiter {
     private var handshakeTimestamps: [PeerID: [Date]] = [:]
     private var messageTimestamps: [PeerID: [Date]] = [:]
+    private var lastPrune: Date = .distantPast
     
     // Global rate limiting
     private var globalHandshakeTimestamps: [Date] = []
     private var globalMessageTimestamps: [Date] = []
     
     private let queue = DispatchQueue(label: "chat.bitchat.noise.ratelimit", attributes: .concurrent)
+
+    /// Clock seam. Every sibling limiter takes `now` as a parameter
+    /// (`SyncResponseRateLimiter`, `BLESubscriptionAnnounceLimiter`,
+    /// `BLEAnnounceThrottle`); this one read `Date()` inline, which is why its
+    /// time-dependent behaviour had no coverage. Injected here instead of
+    /// threading a parameter through nine call sites.
+    private let currentDate: () -> Date
+
+    /// Sweeping every peer on every admission would put an O(peers) walk on the
+    /// message path, which runs up to `maxGlobalMessagesPerSecond` times a
+    /// second. Once a second is frequent enough to keep both maps to peers seen
+    /// inside their own windows.
+    private static let pruneInterval: TimeInterval = 1
+
+    init(currentDate: @escaping () -> Date = Date.init) {
+        self.currentDate = currentDate
+    }
+
+    /// Peers currently retained in either map. Mirrors
+    /// `BLESubscriptionAnnounceLimiter.trackedCentralCount`.
+    var trackedPeerCount: Int {
+        queue.sync {
+            Set(handshakeTimestamps.keys).union(messageTimestamps.keys).count
+        }
+    }
     
     func allowHandshake(from peerID: PeerID) -> Bool {
         return queue.sync(flags: .barrier) {
-            let now = Date()
+            let now = currentDate()
+            pruneStalePeersLocked(now: now)
             let oneMinuteAgo = now.addingTimeInterval(-60)
             
             // Check global rate limit first
@@ -51,7 +78,8 @@ final class NoiseRateLimiter {
     
     func allowMessage(from peerID: PeerID) -> Bool {
         return queue.sync(flags: .barrier) {
-            let now = Date()
+            let now = currentDate()
+            pruneStalePeersLocked(now: now)
             let oneSecondAgo = now.addingTimeInterval(-1)
             
             // Check global rate limit first
@@ -78,6 +106,30 @@ final class NoiseRateLimiter {
         }
     }
     
+    /// Drops peers whose timestamps have all aged out of their window.
+    ///
+    /// Without this the two maps only ever grew: a peer's array was filtered
+    /// when that same peer was next queried, but a peer that never came back
+    /// kept its entry for the lifetime of the process. `reset(for:)` below is
+    /// the per-peer counterpart and is never called from production code, so
+    /// nothing else reclaimed them. Must be called with the barrier held.
+    private func pruneStalePeersLocked(now: Date) {
+        guard now.timeIntervalSince(lastPrune) >= Self.pruneInterval else { return }
+        lastPrune = now
+
+        let handshakeCutoff = now.addingTimeInterval(-60)
+        handshakeTimestamps = handshakeTimestamps.compactMapValues { timestamps in
+            let recent = timestamps.filter { $0 > handshakeCutoff }
+            return recent.isEmpty ? nil : recent
+        }
+
+        let messageCutoff = now.addingTimeInterval(-1)
+        messageTimestamps = messageTimestamps.compactMapValues { timestamps in
+            let recent = timestamps.filter { $0 > messageCutoff }
+            return recent.isEmpty ? nil : recent
+        }
+    }
+
     func reset(for peerID: PeerID) {
         queue.async(flags: .barrier) {
             self.handshakeTimestamps.removeValue(forKey: peerID)

--- a/bitchatTests/Noise/NoiseRateLimiterTests.swift
+++ b/bitchatTests/Noise/NoiseRateLimiterTests.swift
@@ -67,4 +67,79 @@ final class NoiseRateLimiterTests: XCTestCase {
     private func makePeerID(_ value: Int) -> PeerID {
         PeerID(str: String(format: "%016x", value))
     }
+
+    // MARK: - Peer-map retention
+
+    /// Drives the limiter's clock so window expiry is observable.
+    private final class TestClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _now: Date
+        init(_ start: Date) { _now = start }
+        var now: Date { lock.withLock { _now } }
+        func advance(_ seconds: TimeInterval) { lock.withLock { _now += seconds } }
+    }
+
+    func test_handshakeMap_doesNotRetainPeersPastTheirWindow() {
+        let clock = TestClock(Date(timeIntervalSince1970: 10_000))
+        let limiter = NoiseRateLimiter(currentDate: { clock.now })
+
+        // A burst of one-shot peers, each handshaking once and never returning.
+        // Stay inside the global per-minute budget so every one is admitted.
+        let peerCount = min(20, NoiseSecurityConstants.maxGlobalHandshakesPerMinute - 1)
+        for index in 0..<peerCount {
+            XCTAssertTrue(limiter.allowHandshake(from: makePeerID(index + 1)))
+        }
+        XCTAssertEqual(limiter.trackedPeerCount, peerCount)
+
+        // Past the one-minute handshake window, none of them is still relevant.
+        clock.advance(61)
+        _ = limiter.allowHandshake(from: makePeerID(200))
+
+        XCTAssertEqual(
+            limiter.trackedPeerCount,
+            1,
+            "departed peers must not be retained once their handshake window has passed"
+        )
+    }
+
+    func test_messageMap_doesNotRetainPeersPastTheirWindow() {
+        let clock = TestClock(Date(timeIntervalSince1970: 20_000))
+        let limiter = NoiseRateLimiter(currentDate: { clock.now })
+
+        let peerCount = min(10, NoiseSecurityConstants.maxGlobalMessagesPerSecond - 1)
+        for index in 0..<peerCount {
+            XCTAssertTrue(limiter.allowMessage(from: makePeerID(index + 1)))
+        }
+        XCTAssertEqual(limiter.trackedPeerCount, peerCount)
+
+        clock.advance(2)
+        _ = limiter.allowMessage(from: makePeerID(200))
+
+        XCTAssertEqual(
+            limiter.trackedPeerCount,
+            1,
+            "departed peers must not be retained once their message window has passed"
+        )
+    }
+
+    func test_pruningKeepsAPeerStillInsideItsWindow() {
+        // The counterpart: pruning must not discard a peer whose budget is still
+        // being enforced, or the limit becomes trivially bypassable by waiting.
+        let clock = TestClock(Date(timeIntervalSince1970: 30_000))
+        let limiter = NoiseRateLimiter(currentDate: { clock.now })
+        let peerID = makePeerID(7)
+
+        for _ in 0..<NoiseSecurityConstants.maxHandshakesPerMinute {
+            XCTAssertTrue(limiter.allowHandshake(from: peerID))
+        }
+        XCTAssertFalse(limiter.allowHandshake(from: peerID))
+
+        // Well past the prune interval, but well inside the one-minute window.
+        clock.advance(5)
+        XCTAssertFalse(
+            limiter.allowHandshake(from: peerID),
+            "a peer still inside its window must stay rate limited across a prune"
+        )
+        XCTAssertEqual(limiter.trackedPeerCount, 1)
+    }
 }


### PR DESCRIPTION
Found by reading `NoiseRateLimiter`, not from an issue.

## The bug

`allowHandshake(from:)` and `allowMessage(from:)` filter stale timestamps for
**the peer being queried**:

```swift
var timestamps = handshakeTimestamps[peerID] ?? []
timestamps = timestamps.filter { $0 > oneMinuteAgo }
```

Nothing filters the dictionaries themselves. A peer that handshakes or messages
once and never returns keeps its entry — with its now-meaningless timestamps —
for the lifetime of the process, because the only code that would drop it is the
filter that runs when *that same peer* is queried again.

So both maps grow with every distinct `PeerID` the node has ever admitted. That
is not a bounded set: geohash peers churn, and identities rotate.

Two things confirm nothing else reclaims them:

- `reset(for:)` is the per-peer counterpart and is **never called from
  production code** — the only reference is its own test,
  `test_reset_clearsPerPeerHandshakeLimit`. Peer cleanup was evidently intended
  and never wired up.
- `resetAll()` runs only from `clearEphemeralStateForPanic()`.

It is also the component least able to afford this: an attacker can add an entry
per spoofed `PeerID` at the cost of one admitted handshake each, against the very
type that exists to bound handshake cost.

For contrast, the sibling `SyncResponseRateLimiter` already has
`prune(now:)` — *"Drops history outside the window so departed peers don't
accumulate"*. This type is the outlier.

## The fix

Sweep peers whose timestamps have **all** aged out of their own window (60 s for
handshakes, 1 s for messages), so each map holds only peers seen inside that
window.

Rate-limited at once per second. Sweeping on every admission would put an
O(peers) walk on the message path, which runs up to
`maxGlobalMessagesPerSecond` times a second; once a second is frequent enough
given the windows being enforced are 1 s and 60 s.

**Also injects the clock.** Every sibling limiter takes `now` as a parameter —
`SyncResponseRateLimiter.shouldRespond(to:now:)`,
`BLESubscriptionAnnounceLimiter.decision(for:now:)`,
`BLEAnnounceThrottle.shouldSend(force:now:)` — while this one called `Date()`
inline. That is precisely why none of its time-dependent behaviour had coverage,
and why this went unnoticed. The default argument (`= Date.init`) leaves all nine
call sites untouched.

`trackedPeerCount` mirrors `BLESubscriptionAnnounceLimiter.trackedCentralCount`
so retention is observable from a test.

## Test plan

- [x] `swift test` — **213 XCTest cases and 2018 swift-testing cases, 0 failures**.
      Baseline on `main`: 210 XCTest and 2018 swift-testing, also green. The delta
      is exactly the 3 tests added here.
- [x] The two retention tests were written before the fix and confirmed to fail
      against unmodified `main`:
      `XCTAssertEqual failed: ("21") is not equal to ("1")` for handshakes and
      `("11") is not equal to ("1")` for messages — i.e. every departed peer was
      still held.
- [x] Teeth re-checked after the fix by deleting only the two
      `pruneStalePeersLocked(now:)` calls and re-running: the same two tests fail
      and nothing else does.
- [x] No new warnings.

New coverage:

- *handshake map does not retain peers past their window* — a burst of one-shot
  peers, then one query past 60 s; only the live peer should remain.
- *message map does not retain peers past their window* — same shape against the
  1 s window.
- *pruning keeps a peer still inside its window* — the counterpart. A peer that
  has exhausted its per-peer budget must **stay** rate limited across a prune,
  so the sweep cannot be "simplified" into something that resets budgets and
  makes the limit bypassable by waiting one second.

The five existing tests are untouched and still pass.

## Not in scope

`reset(for:)` is still uncalled. Wiring it to peer departure would reclaim
entries sooner, but it needs a disconnect hook and is a separate change; the
sweep here bounds the maps regardless of whether that ever lands.
