### PR TITLE
Drop stale "instantly" claim from panic_note's source defaultValue

### DIFF
--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -120,7 +120,7 @@ struct AppInfoView: View {
 
             static let dangerTitle = String(localized: "app_info.settings.danger.title", defaultValue: "DANGER ZONE", comment: "Section header (uppercase) for destructive actions in settings")
             static let panicButton = String(localized: "app_info.settings.danger.panic_button", defaultValue: "panic wipe", comment: "Button in the settings danger zone that erases all local data after confirmation")
-            static let panicNote = String(localized: "app_info.settings.danger.panic_note", defaultValue: "erases all messages, keys, and identity. triple-tapping the bitchat/ logo does the same, instantly.", comment: "Caption under the panic wipe button explaining what it does and the triple-tap shortcut")
+            static let panicNote = String(localized: "app_info.settings.danger.panic_note", defaultValue: "erases all messages, keys, and identity. triple-tapping the bitchat/ logo does the same.", comment: "Caption under the panic wipe button explaining what it does and the triple-tap shortcut")
             static let panicConfirmTitle = String(localized: "app_info.settings.danger.panic_confirm_title", defaultValue: "wipe all data?", comment: "Title of the confirmation dialog before a panic wipe")
             static let panicConfirmAction = String(localized: "app_info.settings.danger.panic_confirm_action", defaultValue: "wipe everything", comment: "Destructive confirmation button that performs the panic wipe")
         }


### PR DESCRIPTION
Tiny follow-up to #1588, found while checking whether #152 was resolved.

#1588 correctly updated `Localizable.xcstrings`'s `app_info.settings.danger.panic_note` entry to drop the "instantly" claim once the triple-tap wipe gained a confirmation dialog. It didn't update the matching `defaultValue:` in `AppInfoView.swift`'s `String(localized:defaultValue:)` call -- that's just the extraction fallback (the catalog entry is what actually renders, since it exists), so nobody sees the wrong text today. But it's a live discrepancy in source: a future catalog regen or extraction pass reading only the Swift default would resurface "triple-tapping the bitchat/ logo does the same, instantly" as the caption text, silently reintroducing the exact claim #1588 removed.

One line, brings the fallback back in sync with the catalog value.

No Xcode/Swift toolchain available here, so this is verified by reading -- confirmed the new defaultValue is character-for-character identical to the current `Localizable.xcstrings` `en` value for this key, and that `panicNote` has exactly one other call site (`AppInfoView.swift:572`, unaffected -- it renders the catalog value, not the default).