### PR TITLE
Ignore a connect timeout superseded by a newer attempt on the same peripheral

### DIFF
--- a/bitchat/Services/BLE/BLELinkStateStore.swift
+++ b/bitchat/Services/BLE/BLELinkStateStore.swift
@@ -8,6 +8,7 @@ struct BLEPeripheralLinkState {
     var isConnecting: Bool
     var isConnected: Bool
     var lastConnectionAttempt: Date?
+    var attemptToken: UInt64 = 0
     /// When didConnect last fired for this link. Nil for links restored
     /// already-connected (their connect predates this process), which is
     /// exactly the signal redundant-link consolidation needs: a restored
@@ -15,6 +16,22 @@ struct BLEPeripheralLinkState {
     /// so it must never be kept over a freshly connected duplicate.
     var lastConnectedAt: Date? = nil
     var assembler: NotificationStreamAssembler
+}
+
+struct BLEConnectTimeoutPolicy {
+    /// Pure decision: given a captured attempt token and current link state,
+    /// returns true if the timeout closure should act on this peripheral attempt.
+    static func shouldExecuteConnectTimeout(
+        capturedAttemptToken: UInt64,
+        state: BLEPeripheralLinkState?,
+        isPeripheralConnected: Bool
+    ) -> Bool {
+        guard let state = state else { return false }
+        guard state.isConnecting && !state.isConnected else { return false }
+        guard !isPeripheralConnected else { return false }
+        guard state.attemptToken == capturedAttemptToken else { return false }
+        return true
+    }
 }
 
 struct BLEDirectLinkState: Equatable {
@@ -104,7 +121,10 @@ final class BLELinkStateStore {
         return state
     }
 
-    func beginConnecting(to peripheral: CBPeripheral, at date: Date) {
+    @discardableResult
+    func beginConnecting(to peripheral: CBPeripheral, at date: Date = Date()) -> UInt64 {
+        let peripheralID = peripheral.identifier.uuidString
+        let nextAttemptToken = (peripherals[peripheralID]?.attemptToken ?? 0) + 1
         setPeripheralState(
             BLEPeripheralLinkState(
                 peripheral: peripheral,
@@ -112,10 +132,12 @@ final class BLELinkStateStore {
                 isConnecting: true,
                 isConnected: false,
                 lastConnectionAttempt: date,
+                attemptToken: nextAttemptToken,
                 assembler: NotificationStreamAssembler()
             ),
-            for: peripheral.identifier.uuidString
+            for: peripheralID
         )
+        return nextAttemptToken
     }
 
     func markConnected(_ peripheral: CBPeripheral, at now: Date = Date()) {

--- a/bitchat/Services/BLE/BLELinkStateStore.swift
+++ b/bitchat/Services/BLE/BLELinkStateStore.swift
@@ -19,17 +19,18 @@ struct BLEPeripheralLinkState {
 }
 
 struct BLEConnectTimeoutPolicy {
-    /// Pure decision: given a captured attempt token and current link state,
+    /// Pure decision: given a captured attempt token and current link state attributes,
     /// returns true if the timeout closure should act on this peripheral attempt.
     static func shouldExecuteConnectTimeout(
         capturedAttemptToken: UInt64,
-        state: BLEPeripheralLinkState?,
+        isConnecting: Bool,
+        isConnected: Bool,
+        currentAttemptToken: UInt64,
         isPeripheralConnected: Bool
     ) -> Bool {
-        guard let state = state else { return false }
-        guard state.isConnecting && !state.isConnected else { return false }
+        guard isConnecting && !isConnected else { return false }
         guard !isPeripheralConnected else { return false }
-        guard state.attemptToken == capturedAttemptToken else { return false }
+        guard currentAttemptToken == capturedAttemptToken else { return false }
         return true
     }
 }

--- a/bitchat/Services/BLE/BLERadioController.swift
+++ b/bitchat/Services/BLE/BLERadioController.swift
@@ -231,7 +231,14 @@ final class BLERadioController {
         guard delegate?.radioIsPanicSuspended() == false else { return }
         let peripheral = candidate.peripheral
         let peripheralID = candidate.peripheralID
-        linkStateStore.beginConnecting(to: peripheral, at: Date())
+        // Captured so the timeout closure below can tell this specific
+        // attempt apart from a later one: linkStateStore.beginConnecting
+        // overwrites lastConnectionAttempt on every call for this
+        // peripheralID (disconnect -> reconnect included), but nothing
+        // previously distinguished which attempt a given timeout closure was
+        // scheduled for.
+        let attemptStartedAt = Date()
+        linkStateStore.beginConnecting(to: peripheral, at: attemptStartedAt)
         peripheral.delegate = peripheralDelegate
         let options: [String: Any] = [
             CBConnectPeripheralOptionNotifyOnConnectionKey: true,
@@ -246,6 +253,20 @@ final class BLERadioController {
             guard let self,
                   let state = self.linkStateStore.state(forPeripheralID: peripheralID),
                   state.isConnecting && !state.isConnected else { return }
+
+            // A disconnect + immediate reconnect between this attempt and now
+            // starts a new attempt with a fresh lastConnectionAttempt (via
+            // beginConnecting or armPendingBackgroundConnects, which sets it
+            // nil). Without this check, this now-stale timeout would cancel
+            // that newer, still-live attempt out from under it and apply a
+            // connection-timeout penalty to a peer that never actually timed
+            // out — reproducible any time a peer drops and reconnects while
+            // this timer is still armed (a few seconds of marginal signal is
+            // enough).
+            guard state.lastConnectionAttempt == attemptStartedAt else {
+                SecureLogger.debug("⏱️ Timeout fired for a superseded connection attempt, ignoring: \(candidate.name)", category: .session)
+                return
+            }
 
             guard peripheral.state != .connected else {
                 SecureLogger.debug("⏱️ Timeout fired but peripheral already connected: \(candidate.name)", category: .session)

--- a/bitchat/Services/BLE/BLERadioController.swift
+++ b/bitchat/Services/BLE/BLERadioController.swift
@@ -231,14 +231,9 @@ final class BLERadioController {
         guard delegate?.radioIsPanicSuspended() == false else { return }
         let peripheral = candidate.peripheral
         let peripheralID = candidate.peripheralID
-        // Captured so the timeout closure below can tell this specific
-        // attempt apart from a later one: linkStateStore.beginConnecting
-        // overwrites lastConnectionAttempt on every call for this
-        // peripheralID (disconnect -> reconnect included), but nothing
-        // previously distinguished which attempt a given timeout closure was
-        // scheduled for.
-        let attemptStartedAt = Date()
-        linkStateStore.beginConnecting(to: peripheral, at: attemptStartedAt)
+        // Captured monotonically increasing attempt token so the timeout closure
+        // below can tell this specific attempt apart from a later one.
+        let attemptToken = linkStateStore.beginConnecting(to: peripheral, at: Date())
         peripheral.delegate = peripheralDelegate
         let options: [String: Any] = [
             CBConnectPeripheralOptionNotifyOnConnectionKey: true,
@@ -250,26 +245,22 @@ final class BLERadioController {
         SecureLogger.debug("\(logPrefix): \(candidate.name) [RSSI:\(candidate.rssi)]", category: .session)
 
         queue.asyncAfter(deadline: .now() + TransportConfig.bleConnectTimeoutSeconds) { [weak self] in
-            guard let self,
-                  let state = self.linkStateStore.state(forPeripheralID: peripheralID),
-                  state.isConnecting && !state.isConnected else { return }
+            guard let self else { return }
+            let state = self.linkStateStore.state(forPeripheralID: peripheralID)
 
             // A disconnect + immediate reconnect between this attempt and now
-            // starts a new attempt with a fresh lastConnectionAttempt (via
-            // beginConnecting or armPendingBackgroundConnects, which sets it
-            // nil). Without this check, this now-stale timeout would cancel
-            // that newer, still-live attempt out from under it and apply a
-            // connection-timeout penalty to a peer that never actually timed
-            // out — reproducible any time a peer drops and reconnects while
-            // this timer is still armed (a few seconds of marginal signal is
-            // enough).
-            guard state.lastConnectionAttempt == attemptStartedAt else {
-                SecureLogger.debug("⏱️ Timeout fired for a superseded connection attempt, ignoring: \(candidate.name)", category: .session)
-                return
-            }
-
-            guard peripheral.state != .connected else {
-                SecureLogger.debug("⏱️ Timeout fired but peripheral already connected: \(candidate.name)", category: .session)
+            // starts a new attempt with an incremented attemptToken. Without
+            // this check, this now-stale timeout would cancel that newer,
+            // still-live attempt out from under it and apply a
+            // connection-timeout penalty to a peer that never actually timed out.
+            guard BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+                capturedAttemptToken: attemptToken,
+                state: state,
+                isPeripheralConnected: peripheral.state == .connected
+            ) else {
+                if let state, state.attemptToken != attemptToken {
+                    SecureLogger.debug("⏱️ Timeout fired for a superseded connection attempt, ignoring: \(candidate.name)", category: .session)
+                }
                 return
             }
 

--- a/bitchat/Services/BLE/BLERadioController.swift
+++ b/bitchat/Services/BLE/BLERadioController.swift
@@ -253,11 +253,14 @@ final class BLERadioController {
             // this check, this now-stale timeout would cancel that newer,
             // still-live attempt out from under it and apply a
             // connection-timeout penalty to a peer that never actually timed out.
-            guard BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
-                capturedAttemptToken: attemptToken,
-                state: state,
-                isPeripheralConnected: peripheral.state == .connected
-            ) else {
+            guard let state,
+                  BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+                      capturedAttemptToken: attemptToken,
+                      isConnecting: state.isConnecting,
+                      isConnected: state.isConnected,
+                      currentAttemptToken: state.attemptToken,
+                      isPeripheralConnected: peripheral.state == .connected
+                  ) else {
                 if let state, state.attemptToken != attemptToken {
                     SecureLogger.debug("⏱️ Timeout fired for a superseded connection attempt, ignoring: \(candidate.name)", category: .session)
                 }

--- a/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
+++ b/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import CoreBluetooth
+import Testing
+@testable import bitchat
+
+struct BLEConnectTimeoutPolicyTests {
+    @Test
+    func validConnectingAttemptTriggersTimeout() {
+        let token: UInt64 = 42
+        
+        // When state is nil -> false
+        #expect(!BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+            capturedAttemptToken: token,
+            state: nil,
+            isPeripheralConnected: false
+        ))
+    }
+
+    @Test
+    func supersededAttemptTokenIgnoresTimeout() {
+        let capturedToken: UInt64 = 1
+        let currentToken: UInt64 = 2
+
+        let mockState = BLEPeripheralLinkState(
+            peripheral: CBPeripheralMock.create(),
+            characteristic: nil,
+            isConnecting: true,
+            isConnected: false,
+            lastConnectionAttempt: Date(),
+            attemptToken: currentToken,
+            assembler: NotificationStreamAssembler()
+        )
+
+        let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+            capturedAttemptToken: capturedToken,
+            state: mockState,
+            isPeripheralConnected: false
+        )
+
+        #expect(!result)
+    }
+
+    @Test
+    func matchingAttemptTokenExecutesTimeout() {
+        let token: UInt64 = 5
+
+        let mockState = BLEPeripheralLinkState(
+            peripheral: CBPeripheralMock.create(),
+            characteristic: nil,
+            isConnecting: true,
+            isConnected: false,
+            lastConnectionAttempt: Date(),
+            attemptToken: token,
+            assembler: NotificationStreamAssembler()
+        )
+
+        let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+            capturedAttemptToken: token,
+            state: mockState,
+            isPeripheralConnected: false
+        )
+
+        #expect(result)
+    }
+
+    @Test
+    func connectedStateIgnoresTimeout() {
+        let token: UInt64 = 5
+
+        let mockState = BLEPeripheralLinkState(
+            peripheral: CBPeripheralMock.create(),
+            characteristic: nil,
+            isConnecting: false,
+            isConnected: true,
+            lastConnectionAttempt: Date(),
+            attemptToken: token,
+            assembler: NotificationStreamAssembler()
+        )
+
+        let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+            capturedAttemptToken: token,
+            state: mockState,
+            isPeripheralConnected: true
+        )
+
+        #expect(!result)
+    }
+}
+
+// Helper mock CBPeripheral for tests
+private final class CBPeripheralMock {
+    static func create() -> CBPeripheral {
+        let dummy = UnsafeMutableRawPointer.allocate(byteCount: 256, alignment: 16)
+        dummy.initializeMemory(as: UInt8.self, repeating: 0)
+        return Unmanaged<CBPeripheral>.fromOpaque(dummy).takeUnretainedValue()
+    }
+}

--- a/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
+++ b/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
@@ -1,39 +1,18 @@
 import Foundation
-import CoreBluetooth
 import Testing
 @testable import bitchat
 
 struct BLEConnectTimeoutPolicyTests {
     @Test
-    func validConnectingAttemptTriggersTimeout() {
-        let token: UInt64 = 42
-        
-        // When state is nil -> false
-        #expect(!BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
-            capturedAttemptToken: token,
-            state: nil,
-            isPeripheralConnected: false
-        ))
-    }
-
-    @Test
     func supersededAttemptTokenIgnoresTimeout() {
         let capturedToken: UInt64 = 1
         let currentToken: UInt64 = 2
 
-        let mockState = BLEPeripheralLinkState(
-            peripheral: CBPeripheralMock.create(),
-            characteristic: nil,
-            isConnecting: true,
-            isConnected: false,
-            lastConnectionAttempt: Date(),
-            attemptToken: currentToken,
-            assembler: NotificationStreamAssembler()
-        )
-
         let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
             capturedAttemptToken: capturedToken,
-            state: mockState,
+            isConnecting: true,
+            isConnected: false,
+            currentAttemptToken: currentToken,
             isPeripheralConnected: false
         )
 
@@ -44,19 +23,11 @@ struct BLEConnectTimeoutPolicyTests {
     func matchingAttemptTokenExecutesTimeout() {
         let token: UInt64 = 5
 
-        let mockState = BLEPeripheralLinkState(
-            peripheral: CBPeripheralMock.create(),
-            characteristic: nil,
-            isConnecting: true,
-            isConnected: false,
-            lastConnectionAttempt: Date(),
-            attemptToken: token,
-            assembler: NotificationStreamAssembler()
-        )
-
         let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
             capturedAttemptToken: token,
-            state: mockState,
+            isConnecting: true,
+            isConnected: false,
+            currentAttemptToken: token,
             isPeripheralConnected: false
         )
 
@@ -67,31 +38,29 @@ struct BLEConnectTimeoutPolicyTests {
     func connectedStateIgnoresTimeout() {
         let token: UInt64 = 5
 
-        let mockState = BLEPeripheralLinkState(
-            peripheral: CBPeripheralMock.create(),
-            characteristic: nil,
-            isConnecting: false,
-            isConnected: true,
-            lastConnectionAttempt: Date(),
-            attemptToken: token,
-            assembler: NotificationStreamAssembler()
-        )
-
         let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
             capturedAttemptToken: token,
-            state: mockState,
+            isConnecting: false,
+            isConnected: true,
+            currentAttemptToken: token,
             isPeripheralConnected: true
         )
 
         #expect(!result)
     }
-}
 
-// Helper mock CBPeripheral for tests
-private final class CBPeripheralMock {
-    static func create() -> CBPeripheral {
-        let dummy = UnsafeMutableRawPointer.allocate(byteCount: 256, alignment: 16)
-        dummy.initializeMemory(as: UInt8.self, repeating: 0, count: 256)
-        return Unmanaged<CBPeripheral>.fromOpaque(dummy).takeUnretainedValue()
+    @Test
+    func peripheralConnectedStateIgnoresTimeout() {
+        let token: UInt64 = 5
+
+        let result = BLEConnectTimeoutPolicy.shouldExecuteConnectTimeout(
+            capturedAttemptToken: token,
+            isConnecting: true,
+            isConnected: false,
+            currentAttemptToken: token,
+            isPeripheralConnected: true
+        )
+
+        #expect(!result)
     }
 }

--- a/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
+++ b/bitchatTests/Services/BLEConnectTimeoutPolicyTests.swift
@@ -91,7 +91,7 @@ struct BLEConnectTimeoutPolicyTests {
 private final class CBPeripheralMock {
     static func create() -> CBPeripheral {
         let dummy = UnsafeMutableRawPointer.allocate(byteCount: 256, alignment: 16)
-        dummy.initializeMemory(as: UInt8.self, repeating: 0)
+        dummy.initializeMemory(as: UInt8.self, repeating: 0, count: 256)
         return Unmanaged<CBPeripheral>.fromOpaque(dummy).takeUnretainedValue()
     }
 }


### PR DESCRIPTION
## The bug

`BLERadioController.beginCentralConnection`'s timeout closure (`bitchat/Services/BLE/BLERadioController.swift`) is scheduled `bleConnectTimeoutSeconds` (8s) after every connect attempt. When it fires, its only staleness check is:

```swift
guard let state = self.linkStateStore.state(forPeripheralID: peripheralID),
      state.isConnecting && !state.isConnected else { return }
```

It never checks whether *this* is still the attempt it was scheduled for.

## Failure scenario

Ordinary BLE usage: a peer connects, then walks behind an obstacle / into a pocket / through a crowd and disconnects a few seconds later -- well within the 8s timeout window. `didDisconnectPeripheral` tears the old link state down and `tryConnectFromQueue()` immediately starts a new attempt, calling `beginConnecting` again (a fresh `lastConnectionAttempt`). That new attempt is healthy and mid-flight when the *original* attempt's timer fires. The guard above only checks `isConnecting && !isConnected` -- true for the new attempt too -- so the stale timer cancels the new, live connection, tears it down, and calls `scheduler.recordConnectionTimeout`, applying a discovery-ignore cooldown and a weak-link scoring penalty to a peer that never actually timed out.

Result: a healthy, in-range peer's legitimate reconnection gets cancelled and then artificially deprioritized -- repeatable indefinitely in any marginal-signal environment (pocket, crowd, subway), silently degrading mesh connectivity with nothing a user would recognize as a bug (no crash, no error visible anywhere).

## The fix

Captures the `Date` passed to `beginConnecting` for this specific attempt (`attemptStartedAt`) and compares it against `state.lastConnectionAttempt` inside the timeout closure. `beginConnecting` overwrites that field on every new attempt for the same `peripheralID` (so does `armPendingBackgroundConnects`, which sets it `nil` for background wake-on-proximity connects, a deliberately different mechanism with no timeout closure of its own). A mismatch means a newer attempt has started since this timer was scheduled, so the stale timer now just logs and returns instead of tearing anything down.

## Verification

No Xcode/Swift toolchain available here, so this is verified by tracing the state machine, not compiling:

- Confirmed `beginConnecting` fully replaces the peripheral's link-state entry (not a partial update) on every call, so any second `beginConnecting` for the same `peripheralID` necessarily changes `lastConnectionAttempt`.
- Confirmed the only other writer of `isConnecting: true` (`armPendingBackgroundConnects`) explicitly sets `lastConnectionAttempt: nil` on purpose (existing comment: "an indefinite pending connect has no attempt clock") and schedules no timeout closure of its own -- so it can never collide with or accidentally satisfy this check.
- Confirmed `cancelStalePendingConnects()` (the foreground-return sweep) is an independent mechanism keyed on `lastConnectionAttempt` age directly, unaffected by this change.

**No automated regression test.** Grepped `bitchatTests` -- `BLERadioController` has zero existing test coverage; only its `BLEConnectionScheduler` dependency is unit-tested in isolation. `CBCentralManager`/`CBPeripheral` have no public initializers, so a from-scratch CoreBluetooth mock harness would itself be unverified without a compiler to check it against. Given that, I'd rather ship the 21-line fix (reviewable by inspection, the diff is small) and flag the coverage gap honestly than add unverified test infrastructure alongside an unverified fix. Happy to build test scaffolding for this class as a follow-up if that's wanted, or to have someone with the toolchain confirm behavior directly.