### PR TITLE
Clear a central's partial write buffer when it unsubscribes

### DIFF
--- a/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
+++ b/bitchat/Services/BLE/BLEInboundWriteBuffer.swift
@@ -26,6 +26,16 @@ struct BLEInboundWriteBuffer {
         buffersByCentralID.removeAll()
     }
 
+    /// Discards one central's partial write buffer. Every other exit from
+    /// `.waiting` (decode success, the oversized cap, `removeAll()`) already
+    /// clears its entry; a central that unsubscribes or disconnects mid-write
+    /// leaves the transfer permanently incomplete, so its callers must reach
+    /// for this instead of leaving the entry to accumulate toward a frame
+    /// that can never finish decoding.
+    mutating func removeValue(forCentralID centralID: String) {
+        buffersByCentralID.removeValue(forKey: centralID)
+    }
+
     mutating func append(
         chunks: [BLEInboundWriteChunk],
         for centralID: String,

--- a/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
+++ b/bitchat/Services/BLE/BLEService+LinkLayerPeripheralRole.swift
@@ -176,6 +176,11 @@ extension BLEService: CBPeripheralManagerDelegate {
         // bleQueue: physical retirement now.
         pendingNotifications.removeTarget { $0.identifier.uuidString == centralID }
         linkStateStore.removeSubscribedCentral(central)
+        // A central that disconnects mid-write (walked out of range, backgrounded)
+        // never reaches .decoded or .oversized in BLEInboundWriteBuffer.append, so
+        // its partial buffer would otherwise sit forever -- this is the only
+        // peripheral-role signal CoreBluetooth gives us that a central is gone.
+        pendingWriteBuffers.removeValue(forCentralID: centralID)
 
         // Ensure we're still advertising for other devices to find us
         if !isPanicSuspended, peripheral.isAdvertising == false {

--- a/bitchatTests/Services/BLEInboundWriteBufferTests.swift
+++ b/bitchatTests/Services/BLEInboundWriteBufferTests.swift
@@ -126,6 +126,54 @@ struct BLEInboundWriteBufferTests {
         }
     }
 
+    @Test
+    func removeValueClearsOnlyTheTargetedCentralsPartialWrite() throws {
+        var buffer = BLEInboundWriteBuffer()
+        let packet = makePacket()
+        let frame = try #require(packet.toBinaryData(padding: false))
+        let splitIndex = max(1, frame.count / 2)
+
+        // Two centrals each mid-write, as if both had connected and started
+        // sending a fragmented frame before central-1 disconnected.
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame.prefix(splitIndex))],
+            for: "central-1",
+            capBytes: 1024
+        )
+        _ = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: 0, data: frame.prefix(splitIndex))],
+            for: "central-2",
+            capBytes: 1024
+        )
+
+        buffer.removeValue(forCentralID: "central-1")
+
+        // central-1's abandoned first half must be gone: completing it with
+        // only the second half now must not decode (nothing to decode against).
+        let afterRemoval = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: splitIndex, data: frame.suffix(from: splitIndex))],
+            for: "central-1",
+            capBytes: 1024
+        )
+        if case .waiting = afterRemoval {
+            // Expected: central-1's earlier half was discarded on disconnect.
+        } else {
+            Issue.record("Expected central-1's partial write to be discarded by removeValue")
+        }
+
+        // central-2's own in-flight write must be untouched by central-1's cleanup.
+        let central2Result = buffer.append(
+            chunks: [BLEInboundWriteChunk(offset: splitIndex, data: frame.suffix(from: splitIndex))],
+            for: "central-2",
+            capBytes: 1024
+        )
+        if case let .decoded(decoded, _) = central2Result {
+            #expect(decoded.timestamp == packet.timestamp)
+        } else {
+            Issue.record("Expected central-2's unrelated partial write to still complete normally")
+        }
+    }
+
     private func makePacket(timestamp: UInt64 = 0x0102030405) -> BitchatPacket {
         BitchatPacket(
             type: MessageType.message.rawValue,


### PR DESCRIPTION
## The bug

`BLEInboundWriteBuffer.buffersByCentralID` (`bitchat/Services/BLE/BLEInboundWriteBuffer.swift`) accumulates chunked ATT writes keyed by `centralID`, evicted only on a successful decode (`.decoded`) or on exceeding the oversized cap (`.oversized`). A central that disconnects mid-write -- walked out of range, backgrounded, anything short of finishing the transfer -- lands in `.waiting` and never reaches either exit. Its entry just stays.

`peripheralManager(_:central:didUnsubscribeFrom:)` (`BLEService+LinkLayerPeripheralRole.swift`) is CoreBluetooth's only peripheral-role signal that a central is gone, and already retires that central from `pendingNotifications` and `linkStateStore` there -- just not from `pendingWriteBuffers`.

## Impact

- **Unbounded leak**: every central that disconnects mid-transfer leaves a permanent `Data` entry for the life of the process. Over a day of ordinary background operation with many transient peers (a train, a conference, a crowded room) this adds up for real.
- **Possible corruption on reconnect**: `CBCentral.identifier` is stable per (device, this app). If the same physical peer reconnects and starts a *new*, shorter write at offset 0, `append`'s `combined.replaceSubrange` only overwrites the front of the stale buffer -- leftover trailing bytes from the abandoned transfer stay appended past the new write's end, which can corrupt the new decode attempt in cases where the lengths don't happen to align.

## The fix

Adds `BLEInboundWriteBuffer.removeValue(forCentralID:)` and calls it from `didUnsubscribeFrom`, alongside the cleanup that already happens there for the same central.

## Test

`removeValueClearsOnlyTheTargetedCentralsPartialWrite` mirrors the existing `removeAllClearsPartialWrites` test's pattern: two centrals each mid-write (first half of a frame sent, second half pending), remove one by ID, confirm its abandoned half is actually gone (completing it with only the second half no longer decodes -- there's nothing to decode against) while the other central's unrelated in-flight write is untouched and completes normally.

## Verification

No Xcode/Swift toolchain available here. `BLEInboundWriteBuffer` is a plain struct with no CoreBluetooth dependency, so this test is real and compilable-by-inspection (matches the file's existing test style exactly). Confirmed via `git apply -R` (revert only the source change) that the test then calls a method that doesn't exist -- a genuine fail-without-the-fix state for a new method, since there's no meaningful "runs but returns the wrong thing" state to demonstrate without a compiler for something this small. Reapplied with `git apply` to restore the fix.

The `didUnsubscribeFrom` call site itself has no existing or new test coverage -- it needs a real `CBCentral`, which has no public initializer -- verified by reading only, same limitation noted on #1676 (a separate BLE fix open right now, same toolchain wall).