### PR TITLE
fix: cap the dedup set when IDs arrive through markProcessed

### DIFF
--- a/bitchat/Utils/MessageDeduplicator.swift
+++ b/bitchat/Utils/MessageDeduplicator.swift
@@ -59,11 +59,15 @@ final class MessageDeduplicator {
 
         if lookup[id] == nil {
             let now = Date()
+            // Expire first, then cap, in that order and for the same reason as
+            // isDuplicate: trimming by count alone would drop still-valid IDs
+            // to make room while an already-expired prefix sat in front of them.
+            cleanupOldEntries(before: now.addingTimeInterval(-maxAge))
             entries.append(Entry(id: id, timestamp: now))
             lookup[id] = now
-            // Same cap as isDuplicate: a node that only sends (self-broadcasts,
-            // announce-backs) never reaches the eviction in isDuplicate, so
-            // without this its dedup set grows for the whole maxAge window.
+            // A node that only sends (self-broadcasts, announce-backs) never
+            // reaches the eviction in isDuplicate, so without this its dedup
+            // set grows for the whole maxAge window.
             trimIfNeeded()
         }
     }

--- a/bitchat/Utils/MessageDeduplicator.swift
+++ b/bitchat/Utils/MessageDeduplicator.swift
@@ -61,6 +61,10 @@ final class MessageDeduplicator {
             let now = Date()
             entries.append(Entry(id: id, timestamp: now))
             lookup[id] = now
+            // Same cap as isDuplicate: a node that only sends (self-broadcasts,
+            // announce-backs) never reaches the eviction in isDuplicate, so
+            // without this its dedup set grows for the whole maxAge window.
+            trimIfNeeded()
         }
     }
 

--- a/bitchatTests/MessageDeduplicatorTests.swift
+++ b/bitchatTests/MessageDeduplicatorTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import bitchat
+
+/// The deduplicator promises a bounded working set: at most `maxCount` live
+/// IDs, evicting oldest-first. Both entry points have to honour that, since a
+/// node that mostly sends (self-broadcasts, announce-backs) adds IDs through
+/// `markProcessed` and may never call `isDuplicate` at all.
+struct MessageDeduplicatorTests {
+    private static let maxCount = 1_000
+    private static let load = 10 * maxCount
+
+    @Test
+    func markProcessedStaysUnderTheCap() {
+        let dedup = MessageDeduplicator(maxAge: 300, maxCount: Self.maxCount)
+        for i in 0..<Self.load {
+            dedup.markProcessed("marked-\(i)")
+        }
+
+        // The most recent ID is still known, the oldest have been evicted.
+        #expect(dedup.contains("marked-\(Self.load - 1)"))
+        #expect(!dedup.contains("marked-0"))
+    }
+
+    @Test
+    func isDuplicateStaysUnderTheCap() {
+        let dedup = MessageDeduplicator(maxAge: 300, maxCount: Self.maxCount)
+        for i in 0..<Self.load {
+            #expect(!dedup.isDuplicate("checked-\(i)"))
+        }
+
+        #expect(dedup.isDuplicate("checked-\(Self.load - 1)"))
+        #expect(!dedup.isDuplicate("checked-0"))
+    }
+
+    @Test
+    func markProcessedKeepsTheMostRecentIDsAfterEviction() {
+        let dedup = MessageDeduplicator(maxAge: 300, maxCount: Self.maxCount)
+        for i in 0..<Self.load {
+            dedup.markProcessed("marked-\(i)")
+        }
+
+        // Eviction trims to 75% of the cap, so the last 750 IDs must survive.
+        let keptWindow = (Self.load - (Self.maxCount * 3) / 4)..<Self.load
+        for i in keptWindow {
+            #expect(dedup.contains("marked-\(i)"), "evicted a recent ID: marked-\(i)")
+        }
+    }
+
+    @Test
+    func markProcessedDoesNotResurrectAnEvictedID() {
+        let dedup = MessageDeduplicator(maxAge: 300, maxCount: Self.maxCount)
+        for i in 0..<Self.load {
+            dedup.markProcessed("marked-\(i)")
+        }
+
+        // An evicted ID is unknown again, so a late relay of it is not filtered.
+        #expect(!dedup.isDuplicate("marked-0"))
+    }
+}


### PR DESCRIPTION
`MessageDeduplicator` documents a bounded working set — at most `maxCount` live IDs, oldest evicted first — and `isDuplicate` enforces it by calling `trimIfNeeded()`. `markProcessed` doesn't, so IDs added that way just accumulate until something ages them out at `maxAge` (300 s).

that is the send path. every self-broadcast pre-marks its own dedup ID (`BLEService.swift:885`), so does announce-back tracking (`:1532`, `:2851`, `:2918`, `:6532`, `:6616`), and a node that mostly sends can go a long time without an inbound packet to hit the eviction in `isDuplicate`.

measured on the real class, `maxCount` 1000:

```
before:  10000 markProcessed -> live entries: 10000   (isDuplicate: 964)
after:   10000 markProcessed -> live entries:   964   (isDuplicate: 964)
```

second commit adds four tests: both entry points stay under the cap, eviction keeps the most recent 75%, and an evicted ID is genuinely forgotten rather than stranded in the lookup table.

no xcode on this machine, so i compiled `MessageDeduplicator.swift` standalone with swiftc and ran the new tests against it through a small harness (`#expect` replaced by a counting stub): 4/4 pass with the fix, and 2 expectations fail without it. the real `Testing` suite i could not run here — CI covers that.