### PR TITLE
Log oversized compressed payloads before rejection

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -235,7 +235,7 @@ public struct BinaryProtocol {
                 }
             } else {
                 let value = UInt16(originalSize)
-                data.append(UInt8((value >> 8) & 0xFF))
+                data.append(UInt8((value >> 8) & 0xFF)
                 data.append(UInt8(value & 0xFF))
             }
         }
@@ -366,7 +366,14 @@ public struct BinaryProtocol {
                     guard let rawSize = read16() else { return nil }
                     originalSize = Int(rawSize)
                 }
-                guard originalSize >= 0 && originalSize <= FileTransferLimits.maxFramedFileBytes else { return nil }
+                guard originalSize >= 0 else { return nil }
+                guard originalSize <= FileTransferLimits.maxFramedFileBytes else {
+                    SecureLogger.warning(
+                        "🚫 Compressed payload expanded size exceeds limit: \(originalSize) bytes > \(FileTransferLimits.maxFramedFileBytes) bytes",
+                        category: .security
+                    )
+                    return nil
+                }
                 let compressedSize = payloadLength - lengthFieldBytes
                 guard compressedSize > 0, let compressed = readData(compressedSize) else { return nil }
 

--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -235,7 +235,7 @@ public struct BinaryProtocol {
                 }
             } else {
                 let value = UInt16(originalSize)
-                data.append(UInt8((value >> 8) & 0xFF)
+                data.append(UInt8((value >> 8) & 0xFF))
                 data.append(UInt8(value & 0xFF))
             }
         }

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
@@ -349,6 +349,37 @@ struct BinaryProtocolTests {
         let encoded = try #require(BinaryProtocol.encode(packet), "Failed to encode oversized packet")
         #expect(BinaryProtocol.decode(encoded) == nil)
     }
+
+    @Test("Log and reject compressed payloads above the expanded-size limit")
+    func compressedPayloadExpandedSizeAboveLimitIsRejected() {
+        var malformedData = Data()
+        malformedData.append(2) // v2
+        malformedData.append(MessageType.message.rawValue)
+        malformedData.append(1) // ttl
+        malformedData.append(contentsOf: Data(repeating: 0, count: 8)) // timestamp
+        malformedData.append(BinaryProtocol.Flags.isCompressed)
+
+        // The v2 payload length includes the four-byte original-size preamble.
+        let payloadLength: UInt32 = 6
+        malformedData.append(contentsOf: [
+            UInt8((payloadLength >> 24) & 0xFF),
+            UInt8((payloadLength >> 16) & 0xFF),
+            UInt8((payloadLength >> 8) & 0xFF),
+            UInt8(payloadLength & 0xFF)
+        ])
+        malformedData.append(contentsOf: Data(repeating: 0x01, count: BinaryProtocol.senderIDSize))
+
+        let expandedSize = UInt32(FileTransferLimits.maxFramedFileBytes + 1)
+        malformedData.append(contentsOf: [
+            UInt8((expandedSize >> 24) & 0xFF),
+            UInt8((expandedSize >> 16) & 0xFF),
+            UInt8((expandedSize >> 8) & 0xFF),
+            UInt8(expandedSize & 0xFF)
+        ])
+        malformedData.append(contentsOf: [0x78, 0x9C]) // compressed bytes are never reached
+
+        #expect(BinaryProtocol.decode(malformedData) == nil)
+    }
     
     // MARK: - Message Padding Tests
     


### PR DESCRIPTION
Fixes #1628.

## Summary

When a compressed packet declares an expanded size above `FileTransferLimits.maxFramedFileBytes`, the decoder currently rejects it without logging the reason. This makes oversized compressed payloads difficult to diagnose, particularly when platform-specific limits differ.

This change logs the declared expanded size and configured ceiling at the existing security warning level before rejecting the packet. Acceptance behavior is unchanged.

## Tests

Added a v2 regression test that constructs a valid compressed frame whose declared expanded size exceeds the configured limit and verifies that `BinaryProtocol.decode` rejects it before attempting decompression.

The local source and test files pass deterministic source checks and `git diff --check`. The full Swift/Xcode suite could not be run in this Linux environment because `swift` and `xcodebuild` are unavailable.