### PR TITLE
Enable autocorrection in message composer (#969)

### DIFF
--- a/bitchat/Views/ContentComposerView.swift
+++ b/bitchat/Views/ContentComposerView.swift
@@ -76,7 +76,7 @@ struct ContentComposerView: View {
                 .bitchatFont(size: 15)
                 .foregroundColor(palette.primary)
                 .focused(isTextFieldFocused)
-                .autocorrectionDisabled(true)
+                .autocorrectionDisabled(false)
                 #if os(iOS)
                 .textInputAutocapitalization(.sentences)
                 #endif


### PR DESCRIPTION
## Summary
Fixes #969.

The message input field had autocorrection turned off. This flips it on so autocorrect works while typing a message, matching the behavior users expect from a standard text field.

## Change
- `bitchat/Views/ContentComposerView.swift`: `.autocorrectionDisabled(true)` → `.autocorrectionDisabled(false)` on the message `TextField`.

Only the message composer is affected. Fields where autocorrect should stay off (nickname, URL entry, location/geohash search) are intentionally left unchanged.

## Testing
Single-token change on an existing, valid SwiftUI modifier (`autocorrectionDisabled(Bool)`). I don't have full Xcode in my environment (Command Line Tools only), so I couldn't run a full app build/simulator check — would appreciate a maintainer confirming on a device/simulator.