### PR TITLE
Consolidate base64url encoding into Base64URLCoding (#642)

### DIFF
--- a/bitchat/Nostr/NostrEmbeddedBitChat.swift
+++ b/bitchat/Nostr/NostrEmbeddedBitChat.swift
@@ -28,7 +28,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` base64url-encoded BitChat packet carrying a delivery/read ack for Nostr DMs.
@@ -51,7 +51,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` ACK (delivered/read) without an embedded recipient peer ID (geohash DMs).
@@ -72,7 +72,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     /// Build a `bitchat1:` payload without an embedded recipient peer ID (used for geohash DMs).
@@ -94,7 +94,7 @@ struct NostrEmbeddedBitChat {
         )
 
         guard let data = packet.toBinaryData() else { return nil }
-        return "bitchat1:" + base64URLEncode(data)
+        return "bitchat1:" + Base64URLCoding.encode(data)
     }
 
     private static func normalizeRecipientPeerID(_ recipientPeerID: PeerID) -> PeerID {
@@ -109,14 +109,5 @@ struct NostrEmbeddedBitChat {
         }
         // Fallback: return as-is (expecting 16 hex chars) – caller should pass a valid peer ID
         return recipientPeerID
-    }
-
-    /// Base64url encode without padding
-    private static func base64URLEncode(_ data: Data) -> String {
-        let b64 = data.base64EncodedString()
-        return b64
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/bitchat/Services/VerificationService.swift
+++ b/bitchat/Services/VerificationService.swift
@@ -86,7 +86,7 @@ final class VerificationService {
         var nonce = Data(count: 16)
         let status = nonce.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, 16, $0.baseAddress!) }
         guard status == errSecSuccess else { return nil }
-        let nonceB64 = nonce.base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+        let nonceB64 = Base64URLCoding.encode(nonce)
         let payload = VerificationQR(v: 1, noiseKeyHex: noiseKey, signKeyHex: signKey, npub: npub, nickname: nickname, ts: ts, nonceB64: nonceB64, sigHex: "")
         let msg = payload.canonicalBytes()
         guard let sig = transport.noiseSignData(msg) else { return nil }


### PR DESCRIPTION
## Summary
Works toward #642 by removing duplicate base64url **encode** implementations and routing them through the existing shared `Base64URLCoding` utility (`bitchat/Nostr/Base64URLCoding.swift`).

Since the issue was filed, a shared `Base64URLCoding` enum already landed and `NostrProtocol` + `NostrInboundPipeline` were migrated to it. `ChatViewModel` no longer contains any base64url helper. This PR cleans up the remaining source-level encode duplicates.

## Changes
- `bitchat/Nostr/NostrEmbeddedBitChat.swift`: dropped the private `base64URLEncode(_:)` helper; its 4 call sites now use `Base64URLCoding.encode(_:)`.
- `bitchat/Services/VerificationService.swift`: replaced the inline `base64EncodedString() + replacingOccurrences(...)` chain with `Base64URLCoding.encode(_:)`.

Both removed implementations were byte-for-byte identical to `Base64URLCoding.encode` (`+`→`-`, `/`→`_`, strip `=`), so behavior is unchanged.

## Intentionally left alone
- `CashuTokenDecoder.base64URLDecode(_:)` is **not** migrated. It parses attacker-controlled token payloads and has deliberately stricter padding handling (strips existing `=`, rejects a length-remainder of 1) that differs from the shared decoder. Changing a security-sensitive parser's behavior doesn't belong in a consolidation chore — happy to align it in a separate, focused change if maintainers want that.

## Testing
The shared utility is already covered by `bitchatTests/Nostr/Base64URLCodingTests.swift`.

I compiled locally with `swift build`; both modified files (`NostrEmbeddedBitChat.swift`, `VerificationService.swift`) compile cleanly. The build only fails on unrelated `#Preview` macros (the `PreviewsMacros` plugin ships with full Xcode and isn't available in a Command Line Tools-only `swift build`) — that reproduces on a clean checkout and is unrelated to this change. A CI/Xcode run would give a full green build.