### PR TITLE
fix: reject a signed byte pair in Data(hexString:)

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/Data+Hex.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/Data+Hex.swift
@@ -45,7 +45,12 @@ public extension Data {
 
         for _ in 0..<len {
             let nextIndex = hex.index(index, offsetBy: 2)
-            guard let byte = UInt8(String(hex[index..<nextIndex]), radix: 16) else {
+            let pair = hex[index..<nextIndex]
+            // UInt8(_:radix:) accepts a leading sign, so "+f" parses as 0x0f.
+            // That gives an identity-bearing hex string a second spelling which
+            // decodes to the same bytes, so require two hex digits first.
+            guard pair.allSatisfy(\.isHexDigit),
+                  let byte = UInt8(pair, radix: 16) else {
                 return nil
             }
             data.append(byte)

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/DataHexTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/DataHexTests.swift
@@ -1,0 +1,62 @@
+//
+// DataHexTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import Testing
+import Foundation
+import BitFoundation
+
+struct DataHexTests {
+    // MARK: - Accepted forms
+
+    @Test func decodes_plain_hex() {
+        #expect(Data(hexString: "0a1b2c")?.hexEncodedString() == "0a1b2c")
+    }
+
+    @Test func decodes_uppercase_hex() {
+        #expect(Data(hexString: "0A1B2C")?.hexEncodedString() == "0a1b2c")
+    }
+
+    @Test func decodes_prefixed_and_padded_hex() {
+        #expect(Data(hexString: "0x0a1b")?.hexEncodedString() == "0a1b")
+        #expect(Data(hexString: "0X0a1b")?.hexEncodedString() == "0a1b")
+        #expect(Data(hexString: "  0a1b  ")?.hexEncodedString() == "0a1b")
+    }
+
+    @Test func round_trips_encoded_bytes() {
+        let bytes = Data((0...255).map { UInt8($0) })
+        #expect(Data(hexString: bytes.hexEncodedString()) == bytes)
+    }
+
+    // MARK: - Rejected forms
+
+    @Test func rejects_odd_length() {
+        #expect(Data(hexString: "0a1") == nil)
+    }
+
+    @Test func rejects_non_hex_characters() {
+        #expect(Data(hexString: "zz") == nil)
+        #expect(Data(hexString: "0a zz") == nil)
+    }
+
+    /// UInt8(_:radix:) accepts a leading sign, so "+f" parses as 0x0f unless the
+    /// digits are checked first. Two spellings of one identity-bearing hex
+    /// string decoding to the same bytes is the whole problem.
+    @Test func rejects_signed_byte_pairs() {
+        #expect(Data(hexString: "+a") == nil)
+        #expect(Data(hexString: "-a") == nil)
+        #expect(Data(hexString: "0a+b") == nil)
+        #expect(Data(hexString: "+a+b") == nil)
+    }
+
+    @Test func a_signed_pair_does_not_alias_a_genuine_key() {
+        let genuine = String(repeating: "0b", count: 32)
+        let signed = String(repeating: "+b", count: 32)
+        #expect(Data(hexString: genuine) != nil)
+        #expect(Data(hexString: signed) == nil)
+    }
+}

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/PeerIDTests.swift
@@ -362,6 +362,10 @@ struct PeerIDTests {
     @Test func rejects_invalid_characters() {
         #expect(!PeerID(str: "peer!@#").isValid)
         #expect(!PeerID(str: "gggggggggggggggg").isValid) // not hex for short form
+        // A 64-character id is only valid because it decodes to a Noise key, so
+        // it has to be rejected on the same grounds a short one is.
+        #expect(!PeerID(str: String(repeating: "+b", count: 32)).isValid)
+        #expect(!PeerID(str: String(repeating: "gg", count: 32)).isValid)
     }
     
     @Test func rejects_too_long() {
@@ -388,6 +392,13 @@ struct PeerIDTests {
         let badPeerID = PeerID(str: bad)
         #expect(!badPeerID.isNoiseKeyHex)
         #expect(badPeerID.noiseKey == nil)
+
+        // isHex and isNoiseKeyHex have to agree: a signed pair is not hex, so it
+        // must not decode to a Noise key either.
+        let signedPeerID = PeerID(str: String(repeating: "+b", count: 32))
+        #expect(!signedPeerID.isHex)
+        #expect(!signedPeerID.isNoiseKeyHex)
+        #expect(signedPeerID.noiseKey == nil)
     }
     
     @Test func prefixes() {


### PR DESCRIPTION
`Data(hexString:)` chunks the string into two-character pairs and hands each to `UInt8(_:radix:)`. That initializer accepts a leading sign, so `"+f"` parses as `0x0f`. Its own doc comment promises nil for a string that "contains invalid hex characters", and `+` is one.

Every identity-bearing hex string in the app goes through this parser — Noise keys, Nostr pubkeys, group member fingerprints, signatures, routing IDs — so each one had a second spelling that decodes to the same bytes.

`PeerID` is where that shows up most sharply. A 64-character id built from `"+b"` pairs:

```
isValid       = true
isHex         = false      <- disagrees with the line below
isNoiseKeyHex = true
noiseKey      = 0b0b0b…0b  <- byte-identical to the genuine peer
toShort()     = f0e38b830ebd8a50  <- same short routing ID
```

`isShort` validates the 16-hex form with `isHexDigit` and rejects `+` correctly; `isNoiseKeyHex` validates the 64-hex form by asking whether `Data(hexString:)` returns non-nil, so the two halves of the same check disagreed. `PeerID` equality and hashing are on the string, so the spoofed id is a distinct key in any dictionary while resolving to the same cryptographic identity.

Fix is to require two hex digits before parsing the pair. Everything the parser is documented to accept still parses: plain, uppercase, `0x`/`0X`-prefixed, whitespace-padded, and every byte value round-trips.

I did not widen this beyond the parser. `PeerID.isValid` needs no change once `Data(hexString:)` keeps its contract, and I would rather not touch the validity rules in the same diff.

### Evidence

No Xcode on this machine, so I could not run `bitchatTests` or build the app. What I did instead: built `BitFoundation` with `swift build` and linked its object files into a standalone harness, so the assertions below ran against the real compiled module rather than a stub.

Before the fix, the harness reproduced the table above — `+b`×32 and `0b`×32 are distinct `PeerID` values that both pass `isValid` and produce the identical 32-byte key and identical `toShort()`. After it, the spoofed id returns nil from `noiseKey`, `isValid` is false, `isHex` and `isNoiseKeyHex` agree, and the genuine id is untouched.

I then ran all 22 assertions from the two test files through that harness; they pass. The tests themselves are swift-testing, and the `Testing` module needs the Xcode toolchain, so **I have not executed `DataHexTests` or `PeerIDTests` as tests** — CI is the first thing that will. The assertions inside them are the ones I ran; the `@Test`/`#expect` scaffolding is copied from the sibling files.

`swift build --package-path localPackages/BitFoundation` is clean.

Related but not a duplicate: #911 hardened the same initializer for odd length, `0x` prefix, whitespace and empty input. Those all landed and are still there; the sign case was not part of it.

This was AI-assisted.