### PR TITLE
fix: stop unattributable prekey bundles from wedging the pending stash

### DIFF
--- a/bitchat/Services/BLE/BLEPendingPrekeyBundleStore.swift
+++ b/bitchat/Services/BLE/BLEPendingPrekeyBundleStore.swift
@@ -1,0 +1,79 @@
+//
+// BLEPendingPrekeyBundleStore.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import BitFoundation
+import Foundation
+
+/// Holds prekey bundles that arrived before their owner's announce bound a
+/// signing key, so attribution can be retried when that announce lands.
+///
+/// Nothing about a stashed bundle has been verified — that is precisely why it
+/// is stashed — so every entry has to be treated as attacker-controlled. A
+/// bundle only needs a `senderID` matching the short ID derived from the
+/// `noiseStaticPublicKey` it carries to reach the stash, and both of those are
+/// public, so anyone in radio range can mint entries for owners that will never
+/// announce. The store therefore bounds itself two ways: oldest-by-insertion
+/// eviction at the cap, and an age sweep that drops entries whose owner never
+/// showed up. Announces repeat every few seconds, so a genuine entry is drained
+/// long before the TTL; an unattributable one is garbage by then.
+///
+/// Both bounds matter. Refusing new entries at a full cap — with no expiry —
+/// lets a single burst of unattributable bundles wedge the stash for the rest
+/// of the process, after which no bundle that races its owner's announce is
+/// ever retried again.
+struct BLEPendingPrekeyBundleStore {
+    struct Config {
+        /// Distinct owners that may hold a stashed bundle at once.
+        var capacity: Int = TransportConfig.prekeyBundlePendingCap
+        /// How long a stashed bundle waits for its owner's announce.
+        var ttlSeconds: TimeInterval = TransportConfig.prekeyBundlePendingTTLSeconds
+    }
+
+    private struct Entry {
+        let packet: BitchatPacket
+        let stashedAt: Date
+    }
+
+    private let config: Config
+    private var entries: [PeerID: Entry] = [:]
+
+    init(config: Config = Config()) {
+        self.config = config
+    }
+
+    var count: Int { entries.count }
+
+    /// Retains the latest bundle seen for `owner`. Replacing an owner's entry
+    /// never counts against the cap: a re-gossiped bundle must not be treated
+    /// as a new claimant.
+    mutating func stash(_ packet: BitchatPacket, for owner: PeerID, now: Date = Date()) {
+        sweepExpired(now: now)
+        let capacity = max(1, config.capacity)
+        if entries[owner] == nil {
+            while entries.count >= capacity {
+                guard let oldest = entries.min(by: { $0.value.stashedAt < $1.value.stashedAt })?.key else { break }
+                entries.removeValue(forKey: oldest)
+            }
+        }
+        entries[owner] = Entry(packet: packet, stashedAt: now)
+    }
+
+    /// Removes and returns `owner`'s stashed bundle, if one is still live. The
+    /// entry is dropped either way — a bundle that outlived its TTL is not
+    /// worth re-verifying, and the owner will gossip a fresh one.
+    mutating func take(for owner: PeerID, now: Date = Date()) -> BitchatPacket? {
+        guard let entry = entries.removeValue(forKey: owner) else { return nil }
+        guard now.timeIntervalSince(entry.stashedAt) <= config.ttlSeconds else { return nil }
+        return entry.packet
+    }
+
+    private mutating func sweepExpired(now: Date) {
+        guard !entries.isEmpty else { return }
+        entries = entries.filter { now.timeIntervalSince($0.value.stashedAt) <= config.ttlSeconds }
+    }
+}

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -274,10 +274,9 @@ final class BLEService: NSObject {
     // Prekey bundles that arrived before their owner's verified announce bound
     // a signing key. Over the air a bundle can still arrive before the
     // announce it depends on; we retain the latest such bundle per owner
-    // (bounded) and re-attempt attribution when the announce lands.
-    // Engine-confined.
-    private var pendingPrekeyBundles: [PeerID: BitchatPacket] = [:]
-    private static let pendingPrekeyBundleCap = 64
+    // (bounded, with an age sweep) and re-attempt attribution when the announce
+    // lands. Engine-confined.
+    private var pendingPrekeyBundles = BLEPendingPrekeyBundleStore()
     // Gateway mode: sink for received nostrCarrier packets (set by app
     // wiring, called on the main actor after transport-level checks) and the
     // runtime-toggled capability bits ORed into `PeerCapabilities.localSupported`
@@ -4900,12 +4899,11 @@ extension BLEService {
             where candidate.publicKey == bundle.noiseStaticPublicKey {
                 if let key = candidate.signingPublicKey { return key }
             }
-            // No binding yet: retain the latest bundle per owner, bounded, and
-            // retry once the verified announce lands.
-            if pendingPrekeyBundles[owner] != nil
-                || pendingPrekeyBundles.count < Self.pendingPrekeyBundleCap {
-                pendingPrekeyBundles[owner] = packet
-            }
+            // No binding yet: retain the latest bundle per owner and retry
+            // once the verified announce lands. The stash evicts its oldest
+            // entry at the cap and sweeps expired ones, so a burst of bundles
+            // from owners that never announce cannot wedge it shut.
+            pendingPrekeyBundles.stash(packet, for: owner)
             return nil
         }
         guard let signingKey else {
@@ -4932,10 +4930,12 @@ extension BLEService {
     /// Re-attempt any prekey bundle that arrived before this owner's announce
     /// bound a signing key. Called from handleAnnounce after a verified
     /// announce, in a barrier ordered after the registry write, so a bundle
-    /// stashed before the write is always observed here.
+    /// stashed before the write is always observed here. A bundle whose owner
+    /// took longer than the stash TTL to announce is dropped instead — the
+    /// owner re-gossips bundles, so waiting on a stale one buys nothing.
     private func drainPendingPrekeyBundles(for owner: PeerID) {
         let pending: BitchatPacket? = onEngine {
-            pendingPrekeyBundles.removeValue(forKey: owner)
+            pendingPrekeyBundles.take(for: owner)
         }
         guard let packet = pending,
               let bundle = PrekeyBundle.decode(packet.payload),

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -410,4 +410,13 @@ enum TransportConfig {
     // announces, keep it alive in peers' gossip stores; changed bundles are
     // sent immediately.
     static let prekeyBundleRebroadcastSeconds: TimeInterval = 60 * 60
+    // A bundle that arrives before its owner's announce is stashed until that
+    // announce binds a signing key. Nothing about a stashed bundle is verified
+    // yet and anyone can mint one for an owner that never announces, so the
+    // stash is bounded both ways: oldest-by-insertion eviction at the cap, plus
+    // an age sweep. The TTL is many announce intervals
+    // (bleAnnounceIntervalSeconds), so a genuine bundle is always drained well
+    // inside it.
+    static let prekeyBundlePendingCap: Int = 64
+    static let prekeyBundlePendingTTLSeconds: TimeInterval = 120.0
 }

--- a/bitchatTests/Services/BLEPendingPrekeyBundleStoreTests.swift
+++ b/bitchatTests/Services/BLEPendingPrekeyBundleStoreTests.swift
@@ -1,0 +1,122 @@
+//
+// BLEPendingPrekeyBundleStoreTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import BitFoundation
+import Foundation
+import Testing
+@testable import bitchat
+
+struct BLEPendingPrekeyBundleStoreTests {
+    private let config = BLEPendingPrekeyBundleStore.Config(capacity: 4, ttlSeconds: 60)
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    private func owner(_ index: Int) -> PeerID {
+        PeerID(hexData: Data([0, 0, 0, 0, 0, 0, UInt8(index >> 8), UInt8(index & 0xFF)]))
+    }
+
+    private func packet(_ marker: UInt8) -> BitchatPacket {
+        BitchatPacket(
+            type: MessageType.prekeyBundle.rawValue,
+            senderID: Data(repeating: marker, count: 8),
+            recipientID: nil,
+            timestamp: 1_000_000_000,
+            payload: Data([marker]),
+            signature: nil,
+            ttl: TransportConfig.messageTTLDefault
+        )
+    }
+
+    @Test
+    func stashedBundleIsReturnedOnce() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        store.stash(packet(1), for: owner(1), now: t0)
+
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(1))?.payload == Data([1]))
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(1)) == nil)
+        #expect(store.count == 0)
+    }
+
+    @Test
+    func latestBundleForAnOwnerReplacesTheEarlierOne() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        store.stash(packet(1), for: owner(1), now: t0)
+        store.stash(packet(2), for: owner(1), now: t0.addingTimeInterval(1))
+
+        #expect(store.count == 1)
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(2))?.payload == Data([2]))
+    }
+
+    @Test
+    func expiredBundleIsNotReturned() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        store.stash(packet(1), for: owner(1), now: t0)
+
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(61)) == nil)
+    }
+
+    /// The regression this store exists for: unattributable bundles used to
+    /// occupy the cap forever, so a later genuine bundle was never stashed and
+    /// never retried.
+    @Test
+    func burstOfUnattributableBundlesDoesNotWedgeTheStash() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        for index in 0..<config.capacity {
+            store.stash(packet(0xFF), for: owner(index), now: t0)
+        }
+        #expect(store.count == config.capacity)
+
+        let genuineOwner = owner(500)
+        store.stash(packet(7), for: genuineOwner, now: t0.addingTimeInterval(1))
+
+        #expect(store.count == config.capacity)
+        #expect(store.take(for: genuineOwner, now: t0.addingTimeInterval(2))?.payload == Data([7]))
+    }
+
+    @Test
+    func evictionAtCapacityDropsTheOldestEntry() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        for index in 0..<config.capacity {
+            store.stash(packet(UInt8(index)), for: owner(index), now: t0.addingTimeInterval(Double(index)))
+        }
+
+        store.stash(packet(9), for: owner(99), now: t0.addingTimeInterval(10))
+
+        // Oldest (index 0) is gone; the newer ones and the new arrival survive.
+        #expect(store.take(for: owner(0), now: t0.addingTimeInterval(11)) == nil)
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(11)) != nil)
+        #expect(store.take(for: owner(99), now: t0.addingTimeInterval(11))?.payload == Data([9]))
+    }
+
+    @Test
+    func expiredEntriesAreSweptSoTheyDoNotCostCapacity() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        for index in 0..<config.capacity {
+            store.stash(packet(0xFF), for: owner(index), now: t0)
+        }
+
+        // Every stale entry goes on the next stash, leaving only the newcomer.
+        store.stash(packet(3), for: owner(500), now: t0.addingTimeInterval(61))
+
+        #expect(store.count == 1)
+        #expect(store.take(for: owner(500), now: t0.addingTimeInterval(62))?.payload == Data([3]))
+    }
+
+    @Test
+    func replacingAnOwnerAtCapacityEvictsNobody() {
+        var store = BLEPendingPrekeyBundleStore(config: config)
+        for index in 0..<config.capacity {
+            store.stash(packet(UInt8(index)), for: owner(index), now: t0.addingTimeInterval(Double(index)))
+        }
+
+        store.stash(packet(8), for: owner(0), now: t0.addingTimeInterval(10))
+
+        #expect(store.count == config.capacity)
+        #expect(store.take(for: owner(1), now: t0.addingTimeInterval(11)) != nil)
+        #expect(store.take(for: owner(0), now: t0.addingTimeInterval(11))?.payload == Data([8]))
+    }
+}


### PR DESCRIPTION
### The bug

`handlePrekeyBundle` (`BLEService.swift`) has to cope with a bundle arriving before the announce that binds its owner's signing key, so when no key is bound yet it stashes the packet in `pendingPrekeyBundles` and `drainPendingPrekeyBundles` retries once a verified announce lands.

Nothing about a stashed packet has been verified at that point — deferring the signature check is the whole reason the stash exists. The only gate in front of it is:

```swift
guard PeerID(hexData: packet.senderID) == owner else { return }   // owner = PeerID(publicKey: bundle.noiseStaticPublicKey)
```

Both halves of that are public and attacker-choosable: pick any 32 bytes as `noiseStaticPublicKey`, set `senderID` to its derived short ID, attach a garbage signature. No handshake, no announce, no session needed.

The stash then did this:

```swift
if pendingPrekeyBundles[owner] != nil
    || pendingPrekeyBundles.count < Self.pendingPrekeyBundleCap {   // 64
    pendingPrekeyBundles[owner] = packet
}
```

New owners are refused once the dictionary holds 64 entries, and entries only ever leave via `drainPendingPrekeyBundles(for:)` — which is called from `handleAnnounce` for that specific owner. An entry whose owner never announces is never removed. So 64 packets from fabricated owners pin the stash for the rest of the process, and from then on every genuine bundle that races its owner's announce is dropped and never retried.

The consequence is quiet rather than loud: courier mail to that peer falls back to a v1 static-key seal instead of a one-time prekey, i.e. no forward secrecy for async first contact — the thing #1381 added.

### The fix

Move the bookkeeping into `BLEPendingPrekeyBundleStore`, bounded the same way `nostrPendingSubscriptions*` already is in this repo: **oldest-by-insertion eviction at the cap, plus an age sweep**. Replacing an owner's own entry still never counts as a new claimant, so a re-gossiped bundle can't evict anyone. `take(for:)` refuses an entry that outlived the TTL, since the owner re-gossips bundles anyway.

TTL is 120s against a 4s announce interval, so a genuine entry is drained many intervals inside it.

**What this does not fix, stated plainly:** an attacker sustaining a flood of distinct fabricated owners can still crowd out a genuine entry for as long as the flood lasts — any per-identity stash loses that race. What changes is recovery: the wedge is no longer permanent, and each 60s bundle gossip round gets a fresh chance. Making the stash unfloodable needs attribution that doesn't exist yet at that point in the pipeline.

### Verification

Xcode is not installed on my machine, so **I could not run `swift test` or build the app target** — CI is the first thing that will compile the `@Test` scaffolding in `BLEPendingPrekeyBundleStoreTests.swift`.

What I did run:

- Compiled and executed `BLEPendingPrekeyBundleStore.swift` against the real built `BitFoundation` module (`swift build --package-path localPackages/BitFoundation`, then linking its object files), with every assertion from the test file ported into a `main.swift` harness. **17/17 passed.**
- Re-ran the same harness against the old policy (refuse-at-cap, no expiry) pasted back in, to confirm the tests have teeth: **6 failed**, including `burst/genuineStashed` — the wedge itself — plus the eviction and sweep assertions.
- Typechecked the store under both `-swift-version 5` and `-swift-version 6` alongside a stub mimicking `BLEService`'s shape at both call sites (mutating the struct inside the non-escaping `onEngine` closure).

The three-line `BLEService.swift` change is verified by reading and by that stub typecheck, not by execution.
