### PR TITLE
fix: enable composer autocorrect except on / @ # tokens

### DIFF
--- a/bitchat/Utils/ComposerAutocorrectPolicy.swift
+++ b/bitchat/Utils/ComposerAutocorrectPolicy.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// When the composer should suppress system autocorrect.
+///
+/// `/commands`, `@mentions`, and `#geohash` tokens need the exact typed text
+/// for autocomplete. Prose should still get autocorrect. The token under the
+/// cursor is the substring after the last whitespace before `cursor`.
+enum ComposerAutocorrectPolicy {
+    static func shouldDisable(for text: String, cursor: Int) -> Bool {
+        guard let first = currentToken(in: text, cursor: cursor).first else { return false }
+        return first == "/" || first == "@" || first == "#"
+    }
+
+    static func currentToken(in text: String, cursor: Int) -> String {
+        guard !text.isEmpty else { return "" }
+        let clamped = max(0, min(cursor, text.count))
+        let idx = text.index(text.startIndex, offsetBy: clamped)
+        let before = text[..<idx]
+        if let lastWhitespace = before.lastIndex(where: { $0.isWhitespace }) {
+            return String(before[before.index(after: lastWhitespace)...])
+        }
+        return String(before)
+    }
+}

--- a/bitchat/Views/ContentComposerView.swift
+++ b/bitchat/Views/ContentComposerView.swift
@@ -76,7 +76,12 @@ struct ContentComposerView: View {
                 .bitchatFont(size: 15)
                 .foregroundColor(palette.primary)
                 .focused(isTextFieldFocused)
-                .autocorrectionDisabled(true)
+                .autocorrectionDisabled(
+                    ComposerAutocorrectPolicy.shouldDisable(
+                        for: messageText,
+                        cursor: messageText.count
+                    )
+                )
                 #if os(iOS)
                 .textInputAutocapitalization(.sentences)
                 #endif

--- a/bitchatTests/ComposerAutocorrectPolicyTests.swift
+++ b/bitchatTests/ComposerAutocorrectPolicyTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import bitchat
+
+struct ComposerAutocorrectPolicyTests {
+    @Test func proseLeavesAutocorrectEnabled() {
+        #expect(!ComposerAutocorrectPolicy.shouldDisable(for: "hello there", cursor: 11))
+        #expect(!ComposerAutocorrectPolicy.shouldDisable(for: "", cursor: 0))
+        #expect(!ComposerAutocorrectPolicy.shouldDisable(for: "hello ", cursor: 6))
+    }
+
+    @Test func commandMentionAndGeohashTokensDisableAutocorrect() {
+        #expect(ComposerAutocorrectPolicy.shouldDisable(for: "/msg", cursor: 4))
+        #expect(ComposerAutocorrectPolicy.shouldDisable(for: "hi @al", cursor: 6))
+        #expect(ComposerAutocorrectPolicy.shouldDisable(for: "see #u4pr", cursor: 9))
+    }
+
+    @Test func completedCommandArgumentIsProseAgain() {
+        #expect(!ComposerAutocorrectPolicy.shouldDisable(for: "/msg alice", cursor: 10))
+    }
+
+    @Test func currentTokenIsTheRunBeforeTheCursor() {
+        #expect(ComposerAutocorrectPolicy.currentToken(in: "hello /j", cursor: 8) == "/j")
+        #expect(ComposerAutocorrectPolicy.currentToken(in: "hello ", cursor: 6) == "")
+        #expect(ComposerAutocorrectPolicy.currentToken(in: "/msg", cursor: 2) == "/m")
+    }
+}


### PR DESCRIPTION
## Summary
- The composer kept `.autocorrectionDisabled(true)` for every keystroke so `/commands`, `@mentions`, and `#geohash` tokens would not be rewritten. Prose was paying that cost (#969).
- Disable autocorrect only while the token under the cursor starts with `/`, `@`, or `#`.

## Test plan
- [x] `swiftc` typecheck of `ComposerAutocorrectPolicy.swift` under Swift 5 and 6
- [x] local harness (prose, `/`, `@`, `#`, completed `/msg` argument, token at cursor)
- [ ] `xcodebuild` test suite — this machine has Command Line Tools only, no Xcode; CI covers `ComposerAutocorrectPolicyTests` and the composer wiring
- [ ] type in the composer on a device: a sentence should autocorrect; `/msg`, `@al`, and `#u4pr` should not

Made with [Cursor](https://cursor.com)