### PR TITLE
feat: show received file transfers as tappable attachments

### DIFF
--- a/bitchat/Models/BitchatMessage+Media.swift
+++ b/bitchat/Models/BitchatMessage+Media.swift
@@ -13,6 +13,7 @@ extension BitchatMessage {
     enum Media {
         case voice(URL)
         case image(URL)
+        case file(URL)
     }
 
     // Cache the directory lookup to avoid repeated FileManager calls during view rendering
@@ -56,6 +57,9 @@ extension BitchatMessage {
         }
         if let url = url(for: .image) {
             return .image(url)
+        }
+        if let url = url(for: .file) {
+            return .file(url)
         }
         return nil
     }

--- a/bitchat/Models/BitchatMessage+Media.swift
+++ b/bitchat/Models/BitchatMessage+Media.swift
@@ -37,19 +37,28 @@ extension BitchatMessage {
         guard let baseDirectory = Cache.shared.filesDir else { return nil }
 
         func url(for category: MimeType.Category) -> URL? {
+            // Real transfers write `messagePrefix + lastPathComponent`. A
+            // spoofed text bubble can still carry `[file] ../prekeys/…`;
+            // ShareLink would then export whatever that path resolves to.
             guard content.hasPrefix(category.messagePrefix),
-                  let filename = String(content.dropFirst(category.messagePrefix.count)).trimmedOrNilIfEmpty
+                  let rawFilename = String(content.dropFirst(category.messagePrefix.count)).trimmedOrNilIfEmpty,
+                  let filename = (rawFilename as NSString).lastPathComponent.nilIfEmpty,
+                  filename == rawFilename,
+                  filename != ".",
+                  filename != ".."
             else {
                 return nil
             }
 
-            // Check outgoing first for sent messages, incoming for received
             let subdir = sender == nickname ? "\(category.mediaDir)/outgoing" : "\(category.mediaDir)/incoming"
-
-            // Construct URL directly without fileExists check (avoids blocking disk I/O in view body)
-            // Files are checked during playback/display, so missing files fail gracefully
-            let directory = baseDirectory.appendingPathComponent(subdir, isDirectory: true)
-            return directory.appendingPathComponent(filename)
+            let directory = baseDirectory
+                .appendingPathComponent(subdir, isDirectory: true)
+                .standardizedFileURL
+            let candidate = directory.appendingPathComponent(filename).standardizedFileURL
+            guard candidate.deletingLastPathComponent().path == directory.path else {
+                return nil
+            }
+            return candidate
         }
 
         if let url = url(for: .audio) {

--- a/bitchat/Views/Media/FileAttachmentView.swift
+++ b/bitchat/Views/Media/FileAttachmentView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Row for a received or sent `[file]` transfer. The payload is already on
+/// disk (`files/incoming` or `files/outgoing`); the timeline used to render
+/// it as ordinary chat text, so there was no way to open it.
+struct FileAttachmentView: View {
+    @ThemedPalette private var palette
+
+    let url: URL
+    let isSending: Bool
+    let sendProgress: Double?
+    let onCancel: (() -> Void)?
+    let onDelete: (() -> Void)?
+
+    @State private var showDeleteConfirmation = false
+
+    private enum Strings {
+        static let delete = String(localized: "media.image.action.delete", comment: "Context menu action that deletes a received image")
+        static let deleteConfirmTitle = String(localized: "media.image.delete_confirm_title", comment: "Title of the confirmation dialog before deleting a received image")
+        static let deleteConfirmMessage = String(localized: "media.image.delete_confirm_message", comment: "Body of the confirmation dialog before deleting a received image")
+        static let cancelSend = String(localized: "media.accessibility.cancel_send", comment: "Accessibility label for the cancel button on an in-flight media send")
+        static let sending = String(localized: "media.image.accessibility.sending", comment: "Accessibility label for an image that is still sending")
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "doc.fill")
+                .font(.bitchatSystem(size: 22, weight: .semibold))
+                .foregroundColor(palette.primary)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: url.lastPathComponent)
+                    .bitchatFont(size: 13, weight: .medium)
+                    .foregroundColor(palette.primary)
+                    .lineLimit(2)
+                if fileByteCount > 0 {
+                    Text(verbatim: byteCountLabel)
+                        .bitchatFont(size: 11)
+                        .foregroundColor(palette.secondary)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if isSending {
+                if let onCancel {
+                    Button(action: onCancel) {
+                        Image(systemName: "xmark")
+                            .font(.bitchatSystem(size: 12, weight: .bold))
+                            .padding(8)
+                            .background(Circle().fill(Color.black.opacity(0.7)))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(Strings.cancelSend)
+                }
+            } else {
+                ShareLink(item: url) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.bitchatSystem(size: 14, weight: .semibold))
+                        .foregroundColor(palette.secondary)
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(palette.secondary.opacity(0.12))
+        )
+        .overlay(alignment: .bottom) {
+            if let sendProgress, isSending {
+                GeometryReader { geo in
+                    Rectangle()
+                        .fill(palette.primary.opacity(0.35))
+                        .frame(width: geo.size.width * CGFloat(max(0, min(1, sendProgress))))
+                }
+                .frame(height: 3)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+        }
+        .contextMenu {
+            if isSending {
+                if let onCancel {
+                    Button(Strings.cancelSend, action: onCancel)
+                }
+            } else if onDelete != nil {
+                Button(Strings.delete, role: .destructive) {
+                    showDeleteConfirmation = true
+                }
+            }
+        }
+        .confirmationDialog(
+            Strings.deleteConfirmTitle,
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(Strings.delete, role: .destructive) {
+                onDelete?()
+            }
+            Button("common.cancel", role: .cancel) {}
+        } message: {
+            Text(verbatim: Strings.deleteConfirmMessage)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(isSending ? Strings.sending : url.lastPathComponent)
+        .frame(maxWidth: 280)
+    }
+
+    private var fileByteCount: Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
+    }
+
+    private var byteCountLabel: String {
+        ByteCountFormatter.string(fromByteCount: Int64(fileByteCount), countStyle: .file)
+    }
+}

--- a/bitchat/Views/Media/MediaMessageView.swift
+++ b/bitchat/Views/Media/MediaMessageView.swift
@@ -123,6 +123,14 @@ struct MediaMessageView: View {
                             onDelete: !isFromMe ? { conversationUIModel.deleteMediaMessage(messageID: message.id) } : nil
                         )
                         .frame(maxWidth: 280)
+                    case .file(let url):
+                        FileAttachmentView(
+                            url: url,
+                            isSending: state.isSending,
+                            sendProgress: state.progress,
+                            onCancel: cancelAction,
+                            onDelete: !isFromMe ? { conversationUIModel.deleteMediaMessage(messageID: message.id) } : nil
+                        )
                     }
                 }
             }

--- a/bitchatTests/BitchatMessageMediaTests.swift
+++ b/bitchatTests/BitchatMessageMediaTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+import BitFoundation
+@testable import bitchat
+
+struct BitchatMessageMediaTests {
+    @Test func mediaAttachment_resolvesIncomingFileTransfers() {
+        let message = BitchatMessage(
+            sender: "alice",
+            content: "[file] notes.pdf",
+            timestamp: Date(),
+            isRelay: false
+        )
+
+        guard case .file(let url) = message.mediaAttachment(for: "bob") else {
+            Issue.record("expected a file attachment")
+            return
+        }
+        #expect(url.lastPathComponent == "notes.pdf")
+        #expect(url.path.contains("files/incoming"))
+    }
+
+    @Test func mediaAttachment_resolvesOutgoingFileTransfers() {
+        let message = BitchatMessage(
+            sender: "bob",
+            content: "[file] notes.pdf",
+            timestamp: Date(),
+            isRelay: false
+        )
+
+        guard case .file(let url) = message.mediaAttachment(for: "bob") else {
+            Issue.record("expected a file attachment")
+            return
+        }
+        #expect(url.path.contains("files/outgoing"))
+    }
+
+    @Test func mediaAttachment_doesNotTreatFilePrefixAsImage() {
+        let message = BitchatMessage(
+            sender: "alice",
+            content: "[file] notes.pdf",
+            timestamp: Date(),
+            isRelay: false
+        )
+        if case .image = message.mediaAttachment(for: "bob") {
+            Issue.record("file transfers must not render as images")
+        }
+    }
+}

--- a/bitchatTests/BitchatMessageMediaTests.swift
+++ b/bitchatTests/BitchatMessageMediaTests.swift
@@ -46,4 +46,26 @@ struct BitchatMessageMediaTests {
             Issue.record("file transfers must not render as images")
         }
     }
+
+    @Test func mediaAttachment_rejectsPathTraversalInFileName() {
+        let traversal = BitchatMessage(
+            sender: "alice",
+            content: "[file] ../../../prekeys/bundles.json",
+            timestamp: Date(),
+            isRelay: false
+        )
+        if traversal.mediaAttachment(for: "bob") != nil {
+            Issue.record("traversal names must not become file attachments")
+        }
+
+        let parent = BitchatMessage(
+            sender: "alice",
+            content: "[file] ..",
+            timestamp: Date(),
+            isRelay: false
+        )
+        if parent.mediaAttachment(for: "bob") != nil {
+            Issue.record("parent directory names must not become file attachments")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- The transfer path already accepts PDFs and other files and stores them under `files/incoming`, but `mediaAttachment` only returned `.voice` / `.image`, so `[file] notes.pdf` rendered as ordinary chat text with no way to open it.
- Resolve the `[file]` prefix the same way as the others and render a share / cancel / delete row. Reuses existing `media.image.*` strings — no new catalog keys.

## Test plan
- [x] `swiftc` typecheck of `BitchatMessage+Media.swift` under Swift 5
- [x] `swiftc` typecheck of `FileAttachmentView.swift` under Swift 5 and 6
- [ ] `xcodebuild` test suite — this machine has Command Line Tools only, no Xcode; CI covers `BitchatMessageMediaTests` and the view wiring
- [ ] receive a PDF over mesh and share it from the timeline