### PR TITLE
Refuse to encode payloads above the framed file cap

### DIFF
--- a/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
+++ b/localPackages/BitFoundation/Sources/BitFoundation/BinaryProtocol.swift
@@ -137,6 +137,12 @@ public struct BinaryProtocol {
         var payload = packet.payload
         var isCompressed = false
         var originalPayloadSize: Int?
+        // Refuse to emit a frame whose expanded (or plain) payload we would reject on decode.
+        // Decode enforces FileTransferLimits.maxFramedFileBytes; encode previously only checked
+        // the on-wire length field width, so v2 could compress up to UInt32.max and produce
+        // frames peers (including ourselves) silently drop.
+        guard payload.count <= FileTransferLimits.maxFramedFileBytes else { return nil }
+
         if CompressionUtil.shouldCompress(payload) {
             // Only compress when we can represent the original length in the outbound frame
             let maxRepresentable = version == 2 ? Int(UInt32.max) : Int(UInt16.max)

--- a/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
+++ b/localPackages/BitFoundation/Tests/BitFoundationTests/BinaryProtocolTests.swift
@@ -346,8 +346,29 @@ struct BinaryProtocolTests {
             ttl: 1,
             version: 2
         )
-        let encoded = try #require(BinaryProtocol.encode(packet), "Failed to encode oversized packet")
-        #expect(BinaryProtocol.decode(encoded) == nil)
+        // Encode must refuse the same ceiling decode enforces — otherwise we emit
+        // frames that every honest peer (including ourselves) silently drops.
+        #expect(BinaryProtocol.encode(packet) == nil)
+    }
+
+    @Test("Round-trip a payload exactly at the framed file cap")
+    func framedFileCapRoundTrip() throws {
+        let targetSize = FileTransferLimits.maxFramedFileBytes
+        var payload = Data(repeating: 0x41, count: targetSize)
+        // Highly compressible so the frame stays wire-friendly after compression.
+        let packet = BitchatPacket(
+            type: MessageType.message.rawValue,
+            senderID: Data(hexString: "0011223344556677") ?? Data(),
+            recipientID: nil,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
+            payload: payload,
+            signature: nil,
+            ttl: 1,
+            version: 2
+        )
+        let encoded = try #require(BinaryProtocol.encode(packet), "cap-sized payload should encode")
+        let decoded = try #require(BinaryProtocol.decode(encoded), "cap-sized payload should decode")
+        #expect(decoded.payload == payload)
     }
     
     // MARK: - Message Padding Tests


### PR DESCRIPTION
## Summary
- `BinaryProtocol.encode` only checked that a compressed size fit in the v1/v2 length field (`UInt16`/`UInt32`), so it could emit frames whose declared `originalSize` exceeds `FileTransferLimits.maxFramedFileBytes`.
- Decode already rejects those frames (often silently), which is the Android→iOS drop mode in #1618/#1629.
- Refuse to encode above the same ceiling the decoder enforces; update the oversized-payload test and add a round-trip at the cap.

## Test plan
- [ ] `BinaryProtocolTests` oversized + framed-cap round-trip
- [ ] Confirm encode returns `nil` for `maxFramedFileBytes + 1`

Refs #1618 #1629