### PR TITLE
Radio-metadata: whitepaper consistency + honest topology map

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -52,7 +52,7 @@ Only `noiseEncrypted` and `noiseHandshake` packets are padded, toward 256/512/10
 
 Relaying is a deterministic controlled flood tuned by local connection degree:
 
-* **TTL:** packets originate with TTL 7. Relays clamp: dense graphs (≥ 6 links) cap broadcast TTL at 5; thin chains (≤ 2 links) relay at full incoming depth.
+* **TTL:** packets originate with TTL 7, except public broadcasts carrying authored content — public and group messages, broadcast files, board posts, live voice, and leave — which draw uniformly from 5–7 so that a maximum TTL is not a reliable authorship marker (§8). Live voice draws once per talk burst rather than per frame. Relays clamp: dense graphs (≥ 6 links) cap broadcast TTL at 5; thin chains (≤ 2 links) relay at full incoming depth.
 * **Deduplication:** an LRU seen-set (1000 entries, 5-minute expiry) keyed by sender, timestamp, type, and a payload digest drops duplicates. A scheduled relay is cancelled when a duplicate arrives first from another relay.
 * **Jitter:** relays wait a random 10–220 ms (wider when dense) so duplicate suppression wins often.
 * **Fanout subsetting:** broadcast messages are re-sent to a deterministic, message-ID-seeded subset of links (~log₂ of degree) rather than all of them; announces, fragments, and sync packets use full fanout. The ingress link is always excluded (split horizon).
@@ -60,7 +60,9 @@ Relaying is a deterministic controlled flood tuned by local connection degree:
 
 ### 4.3 Routing
 
-Announcements carry up to 10 direct-neighbor IDs, giving each node a shallow topology map (60 s freshness). When a bidirectionally-confirmed path exists, packets are source-routed along it; otherwise — and whenever a route fails — delivery falls back to flooding.
+Announcements no longer carry direct-neighbor IDs. The list gave each node a shallow topology map, but it also handed any single passive receiver the local adjacency graph (§8), so it is suppressed by default. Lists from peers still sending them are parsed, so a mixed network behaves sensibly and a node keeps a shallow topology map (60 s freshness) of whatever it hears.
+
+When a bidirectionally-confirmed path exists, packets are source-routed along it; otherwise — and whenever a route fails — delivery falls back to flooding. Confirmation requires both endpoints to claim the edge, so once neighbor lists are suppressed network-wide no path is confirmable and directed traffic floods. That is the documented fallback rather than a new failure mode: it costs airtime in dense meshes and changes no delivery semantics.
 
 ### 4.4 Fragmentation
 
@@ -132,7 +134,11 @@ Bare local counters (deposits, handovers, sprays, opens, outbox flushes and drop
 * **Couriers** are quota-bounded mailbags. A malicious courier can drop mail (redundant copies and deposit retry mitigate this) but cannot read it, link it across days, or amplify it — copy budgets are capped and every envelope is validated against size and lifetime policy on deposit.
 * **Flooding abuse** is bounded by TTL clamps, deduplication, per-depositor quotas, connect-rate limits, and announce-rate limiting.
 * **Replay** of public broadcasts is bounded by the 6-hour acceptance window plus deduplication; private payloads are protected by Noise nonces.
-* **Metadata is the weakest part of this design, and the peer ID does not help.** The 8-byte sender ID in every packet header is derived from a never-rotating key (§3), and announcements publish the static keys and nickname in cleartext, so a passive listener can enumerate participants and follow a device between places. Announcements also carry up to ten direct-neighbor IDs (§4.3), which hands a single sniffer the local adjacency graph. Origin packets leave at the default TTL, so hop distance identifies the originator. Daily-rotating courier tags do limit correlation of carried mail, and Nostr traffic can ride Tor. Addressing the radio-layer exposure is future work (§9).
+* **Metadata is the weakest part of this design, and the peer ID does not help.** The 8-byte sender ID in every packet header is derived from a never-rotating key (§3), and announcements publish the static keys and nickname in cleartext, so a passive listener can enumerate participants and follow a device between places. Two narrower leaks are now closed. Announcements no longer carry neighbor IDs (§4.3), so a single sniffer no longer reconstructs the local adjacency graph. And authored public broadcasts draw their origin TTL from a range (§4.2) instead of always leaving at the maximum.
+
+  The TTL change **reduces an authorship marker rather than removing it**, and the distinction matters. Relays strictly decrement, so the top of the range can still only have come from an origin: with three values that is one message in three, and `1 − (2/3)ᵏ` — roughly 87% of senders self-identified within five messages. It protects an occasional sender considerably and a chatty one little. Eliminating the marker requires relays to sometimes *not* decrement, which trades directly against TTL's role as the loop bound, so it is named as future work (§9) rather than implied to be solved.
+
+  Daily-rotating courier tags do limit correlation of carried mail, and Nostr traffic can ride Tor. Addressing the remaining radio-layer exposure — the non-rotating identity above all — is future work (§9).
 * **No forward secrecy for sealed mail or Nostr private envelopes** (§5.2–5.3) means compromise of a recipient's static key can expose retained ciphertext addressed to that key.
 
 ## 9. Future Work
@@ -143,7 +149,8 @@ Bare local counters (deposits, handovers, sprays, opens, outbox flushes and drop
 * Multi-hop courier routing informed by encounter history.
 * **Rotating on-air identity.** Epoch-rotating peer IDs, with static-key disclosure moved inside the encrypted handshake and mutual favorites recognising each other through a tag derived from their shared secret, so presence stops being linkable across sessions (§3, §8).
 * **Padding for non-Noise packet types**, and closing the gap where a frame needing more than 255 bytes of padding is emitted unpadded (§4.1).
-* Making the neighbor list in announcements optional, or restricted to authenticated links (§4.3).
+* **Removing the origin-TTL authorship marker outright** (§4.2, §8). Drawing from a range leaves the top of that range origin-only; suppressing it entirely needs relays to sometimes forward without decrementing, which trades against TTL's role as the loop bound and so needs the relay behaviour in scope.
+* **Restoring source routing without publishing adjacency** (§4.3) — for example deriving confirmable paths from authenticated links only, so suppressing the neighbor list does not permanently cost directed-traffic efficiency.
 
 ---
 

--- a/bitchat/App/AppChromeModel.swift
+++ b/bitchat/App/AppChromeModel.swift
@@ -80,9 +80,12 @@ final class AppChromeModel: ObservableObject {
         isNoticesSheetPresented = true
     }
 
-    /// Builds the mesh topology map model from the transport's gossiped
-    /// graph plus the live nickname table. Unknown nodes (heard about via a
-    /// neighbor claim but never announced to us) fall back to a short ID.
+    /// Builds the mesh topology map model from the transport's graph plus the
+    /// live nickname table. Unknown nodes (heard about via a neighbor claim but
+    /// never announced to us) fall back to a short ID.
+    ///
+    /// That graph is mostly this device's own direct links now that neighbour
+    /// lists are no longer announced; see `BLEService.currentMeshTopology()`.
     func meshTopologyDisplayModel() -> MeshTopologyDisplayModel {
         let mesh = chatViewModel.meshService
         guard let diagnostics = mesh as? MeshDiagnosing,

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -72718,181 +72718,181 @@
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "مُقدَّرة من قوائم الجيران المتناقلة (حتى 10 لكل قرين) — جهازك مميَّز"
+            "value" : "روابطك المباشرة فقط — لم تعد قوائم الجيران تُبَث، لذلك لا تُرسم الروابط بين الأقران الآخرين"
           }
         },
         "bn" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "গসিপ করা প্রতিবেশী তালিকা থেকে অনুমান করা (প্রতি পিয়ারে সর্বোচ্চ ১০) — আপনার ডিভাইস হাইলাইট করা"
+            "value" : "শুধু আপনার নিজের সরাসরি সংযোগ — প্রতিবেশী তালিকা আর সম্প্রচার করা হয় না, তাই অন্য পিয়ারদের মধ্যেকার সংযোগ দেখানো হয় না"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "geschätzt aus verbreiteten nachbarlisten (bis zu 10 pro peer) — dein gerät ist hervorgehoben"
+            "value" : "nur deine direkten verbindungen — nachbarlisten werden nicht mehr gesendet, daher werden verbindungen zwischen anderen peers nicht dargestellt"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "estimated from gossiped neighbor lists (up to 10 per peer) — your device is highlighted"
+            "value" : "your own direct links — neighbor lists are no longer broadcast, so links between other peers aren't mapped"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "estimado a partir de listas de vecinos difundidas (hasta 10 por peer) — tu dispositivo está resaltado"
+            "state" : "needs_review",
+            "value" : "solo tus enlaces directos — las listas de vecinos ya no se difunden, así que los enlaces entre otros peers no se muestran"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "برآورد از فهرست همسایه‌های منتشرشده (تا ۱۰ مورد برای هر همتا) — دستگاه شما پررنگ شده است"
+            "state" : "needs_review",
+            "value" : "فقط پیوندهای مستقیم شما — فهرست همسایه‌ها دیگر منتشر نمی‌شود، بنابراین پیوند میان همتاهای دیگر نمایش داده نمی‌شود"
           }
         },
         "fil" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "tinantiya mula sa mga ibinahaging listahan ng kapitbahay (hanggang 10 bawat peer) — naka-highlight ang iyong device"
+            "value" : "ang sarili mong direktang koneksyon lang — hindi na ibinabrodkast ang listahan ng kapitbahay, kaya hindi ipinapakita ang koneksyon sa pagitan ng ibang peer"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "estimé à partir des listes de voisins diffusées (jusqu'à 10 par pair) — ton appareil est mis en évidence"
+            "value" : "uniquement tes liens directs — les listes de voisins ne sont plus diffusées, donc les liens entre les autres pairs ne sont pas affichés"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "מוערך מרשימות שכנים שהופצו (עד 10 לכל עמית) — המכשיר שלך מודגש"
+            "value" : "רק הקישורים הישירים שלך — רשימות שכנים כבר לא משודרות, ולכן קישורים בין עמיתים אחרים אינם מוצגים"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "गॉसिप की गई पड़ोसी सूचियों से अनुमानित (प्रति पीयर 10 तक) — आपका डिवाइस हाइलाइट किया गया है"
+            "value" : "केवल आपके सीधे लिंक — पड़ोसी सूचियाँ अब प्रसारित नहीं होतीं, इसलिए अन्य पीयर के बीच के लिंक नहीं दिखाए जाते"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "diperkirakan dari daftar tetangga yang di-gossip (hingga 10 per peer) — perangkatmu disorot"
+            "value" : "hanya tautan langsungmu — daftar tetangga tidak lagi disiarkan, jadi tautan antar peer lain tidak ditampilkan"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "stimato dalle liste di vicini diffuse (fino a 10 per peer) — il tuo dispositivo è evidenziato"
+            "value" : "solo i tuoi collegamenti diretti — le liste di vicini non vengono più diffuse, quindi i collegamenti tra altri peer non sono mostrati"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ゴシップされた近隣リスト（ピアあたり最大10件）から推定 — お使いのデバイスをハイライト"
+            "value" : "自分の直接リンクのみ — 近隣リストは配信されなくなったため、他のピア同士のリンクは表示されません"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "가십으로 전파된 이웃 목록(피어당 최대 10개)에서 추정 — 사용 중인 기기가 강조 표시됨"
+            "value" : "내 직접 연결만 — 이웃 목록은 더 이상 브로드캐스트되지 않아 다른 피어 간 연결은 표시되지 않음"
           }
         },
         "ms" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "dianggarkan dari senarai jiran yang di-gossip (sehingga 10 setiap peer) — perantimu diserlahkan"
+            "value" : "hanya pautan langsungmu — senarai jiran tidak lagi disiarkan, jadi pautan antara peer lain tidak dipaparkan"
           }
         },
         "ne" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "गसिप गरिएका छिमेकी सूचीबाट अनुमानित (प्रति सहकर्मी बढीमा १०) — तिम्रो यन्त्र हाइलाइट गरिएको छ"
+            "value" : "तपाईंका प्रत्यक्ष लिंकहरू मात्र — छिमेकी सूची अब प्रसारण गरिँदैन, त्यसैले अन्य सहकर्मीहरूबीचका लिंक देखाइँदैन"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "geschat op basis van verspreide buurlijsten (tot 10 per peer) — je apparaat is gemarkeerd"
+            "value" : "alleen je directe verbindingen — buurlijsten worden niet meer uitgezonden, dus verbindingen tussen andere peers worden niet getoond"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "oszacowane na podstawie rozgłaszanych list sąsiadów (do 10 na peera) — twoje urządzenie jest wyróżnione"
+            "value" : "tylko twoje bezpośrednie połączenia — listy sąsiadów nie są już rozgłaszane, więc połączenia między innymi peerami nie są pokazywane"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "estimado a partir de listas de vizinhos difundidas (até 10 por par) — o teu dispositivo está destacado"
+            "value" : "apenas as tuas ligações diretas — as listas de vizinhos já não são difundidas, por isso as ligações entre outros pares não são mostradas"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "estimado a partir das listas de vizinhos divulgadas (até 10 por par) — seu dispositivo está destacado"
+            "value" : "apenas seus links diretos — as listas de vizinhos não são mais divulgadas, então os links entre outros pares não são mostrados"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "оценено по gossip-спискам соседей (до 10 на пира) — твоё устройство выделено"
+            "value" : "только твои прямые связи — списки соседей больше не рассылаются, поэтому связи между другими пирами не отображаются"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "uppskattat från skvallrade grannlistor (upp till 10 per peer) — din enhet är markerad"
+            "value" : "endast dina direkta länkar — grannlistor sänds inte längre ut, så länkar mellan andra peers visas inte"
           }
         },
         "ta" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "வதந்தியாகப் பகிரப்பட்ட அண்டை பட்டியல்களிலிருந்து மதிப்பிடப்பட்டது (ஒரு peer க்கு 10 வரை) — உங்கள் சாதனம் தனிப்படுத்தப்பட்டுள்ளது"
+            "value" : "உங்கள் நேரடி இணைப்புகள் மட்டும் — அண்டை பட்டியல்கள் இனி ஒளிபரப்பப்படுவதில்லை, எனவே பிற peer-களுக்கு இடையேயான இணைப்புகள் காட்டப்படுவதில்லை"
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ประมาณจากรายชื่อเพื่อนบ้านที่ส่งต่อแบบ gossip (สูงสุด 10 รายต่อเพียร์) — อุปกรณ์ของคุณถูกไฮไลต์"
+            "value" : "เฉพาะลิงก์โดยตรงของคุณ — ไม่มีการกระจายรายชื่อเพื่อนบ้านอีกต่อไป จึงไม่แสดงลิงก์ระหว่างเพียร์อื่น"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "yayılan komşu listelerinden tahmin edildi (eş başına en fazla 10) — cihazın vurgulanmış"
+            "value" : "yalnızca kendi doğrudan bağlantıların — komşu listeleri artık yayınlanmıyor, bu yüzden diğer eşler arasındaki bağlantılar gösterilmiyor"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "оцінено на основі поширюваних списків сусідів (до 10 на піра) — твій пристрій виділено"
+            "value" : "лише твої прямі з'єднання — списки сусідів більше не розсилаються, тому з'єднання між іншими пірами не показуються"
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "گپ شپ کی گئی پڑوسیوں کی فہرستوں سے اندازہ (فی ہم منصب 10 تک) — آپ کی ڈیوائس نمایاں ہے"
+            "value" : "صرف آپ کے براہِ راست روابط — پڑوسیوں کی فہرستیں اب نشر نہیں ہوتیں، اس لیے دیگر ہم منصبوں کے درمیان روابط نہیں دکھائے جاتے"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ước tính từ danh sách hàng xóm được gossip (tối đa 10 mỗi nút) — thiết bị của bạn được làm nổi bật"
+            "value" : "chỉ các liên kết trực tiếp của bạn — danh sách hàng xóm không còn được phát nữa, nên liên kết giữa các nút khác không được hiển thị"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "根据传播的邻居列表估算（每个同伴最多 10 个）— 你的设备已高亮显示"
+            "value" : "仅显示你的直接连接 — 邻居列表不再广播，因此其他同伴之间的连接不会显示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "根據同伴間流傳的鄰居列表估算（每位同伴最多 10 個）— 你的裝置已高亮顯示"
+            "value" : "僅顯示你的直接連線 — 鄰居列表不再廣播，因此其他同伴之間的連線不會顯示"
           }
         }
       }

--- a/bitchat/Localizable.xcstrings
+++ b/bitchat/Localizable.xcstrings
@@ -72718,181 +72718,181 @@
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "روابطك المباشرة فقط — لم تعد قوائم الجيران تُبَث، لذلك لا تُرسم الروابط بين الأقران الآخرين"
+            "value" : "في الغالب روابطك المباشرة — لم تعد قوائم الجيران تُبَث، لذلك لا تظهر الروابط بين الأقران الآخرين إلا لمن لا يزال يرسلها"
           }
         },
         "bn" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "শুধু আপনার নিজের সরাসরি সংযোগ — প্রতিবেশী তালিকা আর সম্প্রচার করা হয় না, তাই অন্য পিয়ারদের মধ্যেকার সংযোগ দেখানো হয় না"
+            "value" : "বেশিরভাগই আপনার নিজের সরাসরি সংযোগ — প্রতিবেশী তালিকা আর সম্প্রচার করা হয় না, তাই অন্য পিয়ারদের মধ্যেকার সংযোগ কেবল সেই পিয়ারদের জন্যই দেখা যায় যারা এখনও তা পাঠাচ্ছে"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "nur deine direkten verbindungen — nachbarlisten werden nicht mehr gesendet, daher werden verbindungen zwischen anderen peers nicht dargestellt"
+            "value" : "meist deine eigenen direkten verbindungen — nachbarlisten werden nicht mehr gesendet, verbindungen zwischen anderen peers erscheinen nur bei peers, die sie noch senden"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "your own direct links — neighbor lists are no longer broadcast, so links between other peers aren't mapped"
+            "value" : "mostly your own direct links — neighbor lists are no longer broadcast, so links between other peers only appear for peers still sending them"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "solo tus enlaces directos — las listas de vecinos ya no se difunden, así que los enlaces entre otros peers no se muestran"
+            "value" : "en su mayoría tus enlaces directos — las listas de vecinos ya no se difunden, así que los enlaces entre otros peers solo aparecen para los peers que todavía las envían"
           }
         },
         "fa" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "فقط پیوندهای مستقیم شما — فهرست همسایه‌ها دیگر منتشر نمی‌شود، بنابراین پیوند میان همتاهای دیگر نمایش داده نمی‌شود"
+            "value" : "بیشتر پیوندهای مستقیم خودتان — فهرست همسایه‌ها دیگر منتشر نمی‌شود، پس پیوند میان همتاهای دیگر فقط برای همتاهایی نمایش داده می‌شود که هنوز آن را می‌فرستند"
           }
         },
         "fil" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ang sarili mong direktang koneksyon lang — hindi na ibinabrodkast ang listahan ng kapitbahay, kaya hindi ipinapakita ang koneksyon sa pagitan ng ibang peer"
+            "value" : "kadalasan ang sarili mong direktang koneksyon — hindi na ibinabrodkast ang listahan ng kapitbahay, kaya ang koneksyon sa pagitan ng ibang peer ay lumalabas lang para sa mga peer na nagpapadala pa nito"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "uniquement tes liens directs — les listes de voisins ne sont plus diffusées, donc les liens entre les autres pairs ne sont pas affichés"
+            "value" : "surtout tes liens directs — les listes de voisins ne sont plus diffusées, donc les liens entre les autres pairs n'apparaissent que pour les pairs qui les envoient encore"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "רק הקישורים הישירים שלך — רשימות שכנים כבר לא משודרות, ולכן קישורים בין עמיתים אחרים אינם מוצגים"
+            "value" : "בעיקר הקישורים הישירים שלך — רשימות שכנים כבר לא משודרות, ולכן קישורים בין עמיתים אחרים מופיעים רק אצל עמיתים שעדיין שולחים אותן"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "केवल आपके सीधे लिंक — पड़ोसी सूचियाँ अब प्रसारित नहीं होतीं, इसलिए अन्य पीयर के बीच के लिंक नहीं दिखाए जाते"
+            "value" : "ज़्यादातर आपके अपने सीधे लिंक — पड़ोसी सूचियाँ अब प्रसारित नहीं होतीं, इसलिए अन्य पीयर के बीच के लिंक केवल उन पीयर के लिए दिखते हैं जो अब भी उन्हें भेज रहे हैं"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "hanya tautan langsungmu — daftar tetangga tidak lagi disiarkan, jadi tautan antar peer lain tidak ditampilkan"
+            "value" : "sebagian besar tautan langsungmu sendiri — daftar tetangga tidak lagi disiarkan, jadi tautan antar peer lain hanya muncul untuk peer yang masih mengirimkannya"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "solo i tuoi collegamenti diretti — le liste di vicini non vengono più diffuse, quindi i collegamenti tra altri peer non sono mostrati"
+            "value" : "per lo più i tuoi collegamenti diretti — le liste di vicini non vengono più diffuse, quindi i collegamenti tra altri peer compaiono solo per i peer che le inviano ancora"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "自分の直接リンクのみ — 近隣リストは配信されなくなったため、他のピア同士のリンクは表示されません"
+            "value" : "ほとんどは自分の直接リンク — 近隣リストはもう配信されないため、他のピア同士のリンクはまだ送っているピアの分だけ表示されます"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "내 직접 연결만 — 이웃 목록은 더 이상 브로드캐스트되지 않아 다른 피어 간 연결은 표시되지 않음"
+            "value" : "대부분 내 직접 연결 — 이웃 목록은 더 이상 브로드캐스트되지 않아 다른 피어 간 연결은 아직 목록을 보내는 피어에 대해서만 표시됨"
           }
         },
         "ms" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "hanya pautan langsungmu — senarai jiran tidak lagi disiarkan, jadi pautan antara peer lain tidak dipaparkan"
+            "value" : "kebanyakannya pautan langsungmu sendiri — senarai jiran tidak lagi disiarkan, jadi pautan antara peer lain hanya muncul bagi peer yang masih menghantarnya"
           }
         },
         "ne" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "तपाईंका प्रत्यक्ष लिंकहरू मात्र — छिमेकी सूची अब प्रसारण गरिँदैन, त्यसैले अन्य सहकर्मीहरूबीचका लिंक देखाइँदैन"
+            "value" : "प्रायः तपाईंका आफ्नै प्रत्यक्ष लिंक — छिमेकी सूची अब प्रसारण गरिँदैन, त्यसैले अन्य सहकर्मीहरूबीचका लिंक अझै सूची पठाइरहेका सहकर्मीहरूका लागि मात्र देखिन्छ"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "alleen je directe verbindingen — buurlijsten worden niet meer uitgezonden, dus verbindingen tussen andere peers worden niet getoond"
+            "value" : "meestal je eigen directe verbindingen — buurlijsten worden niet meer uitgezonden, dus verbindingen tussen andere peers verschijnen alleen bij peers die ze nog versturen"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "tylko twoje bezpośrednie połączenia — listy sąsiadów nie są już rozgłaszane, więc połączenia między innymi peerami nie są pokazywane"
+            "value" : "przeważnie twoje własne bezpośrednie połączenia — listy sąsiadów nie są już rozgłaszane, więc połączenia między innymi peerami pojawiają się tylko przy peerach, które wciąż je wysyłają"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "apenas as tuas ligações diretas — as listas de vizinhos já não são difundidas, por isso as ligações entre outros pares não são mostradas"
+            "value" : "sobretudo as tuas ligações diretas — as listas de vizinhos já não são difundidas, por isso as ligações entre outros pares só aparecem para os pares que ainda as enviam"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "apenas seus links diretos — as listas de vizinhos não são mais divulgadas, então os links entre outros pares não são mostrados"
+            "value" : "na maior parte, seus links diretos — as listas de vizinhos não são mais divulgadas, então os links entre outros pares só aparecem para os pares que ainda as enviam"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "только твои прямые связи — списки соседей больше не рассылаются, поэтому связи между другими пирами не отображаются"
+            "value" : "в основном твои прямые связи — списки соседей больше не рассылаются, поэтому связи между другими пирами видны только для пиров, которые их всё ещё отправляют"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "endast dina direkta länkar — grannlistor sänds inte längre ut, så länkar mellan andra peers visas inte"
+            "value" : "mest dina egna direkta länkar — grannlistor sänds inte längre ut, så länkar mellan andra peers visas bara för peers som fortfarande skickar dem"
           }
         },
         "ta" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "உங்கள் நேரடி இணைப்புகள் மட்டும் — அண்டை பட்டியல்கள் இனி ஒளிபரப்பப்படுவதில்லை, எனவே பிற peer-களுக்கு இடையேயான இணைப்புகள் காட்டப்படுவதில்லை"
+            "value" : "பெரும்பாலும் உங்கள் நேரடி இணைப்புகள் — அண்டை பட்டியல்கள் இனி ஒளிபரப்பப்படுவதில்லை, எனவே பிற peer-களுக்கு இடையேயான இணைப்புகள் இன்னும் அவற்றை அனுப்பும் peer-களுக்கு மட்டுமே தெரியும்"
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "เฉพาะลิงก์โดยตรงของคุณ — ไม่มีการกระจายรายชื่อเพื่อนบ้านอีกต่อไป จึงไม่แสดงลิงก์ระหว่างเพียร์อื่น"
+            "value" : "ส่วนใหญ่เป็นลิงก์โดยตรงของคุณ — ไม่มีการกระจายรายชื่อเพื่อนบ้านอีกต่อไป ลิงก์ระหว่างเพียร์อื่นจึงปรากฏเฉพาะเพียร์ที่ยังส่งรายชื่ออยู่"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "yalnızca kendi doğrudan bağlantıların — komşu listeleri artık yayınlanmıyor, bu yüzden diğer eşler arasındaki bağlantılar gösterilmiyor"
+            "value" : "çoğunlukla kendi doğrudan bağlantıların — komşu listeleri artık yayınlanmıyor, bu yüzden diğer eşler arasındaki bağlantılar yalnızca hâlâ liste gönderen eşler için görünüyor"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "лише твої прямі з'єднання — списки сусідів більше не розсилаються, тому з'єднання між іншими пірами не показуються"
+            "value" : "переважно твої прямі з'єднання — списки сусідів більше не розсилаються, тому з'єднання між іншими пірами видно лише для пірів, які їх ще надсилають"
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "صرف آپ کے براہِ راست روابط — پڑوسیوں کی فہرستیں اب نشر نہیں ہوتیں، اس لیے دیگر ہم منصبوں کے درمیان روابط نہیں دکھائے جاتے"
+            "value" : "زیادہ تر آپ کے اپنے براہِ راست روابط — پڑوسیوں کی فہرستیں اب نشر نہیں ہوتیں، اس لیے دیگر ہم منصبوں کے درمیان روابط صرف اُن ہم منصبوں کے لیے دکھائے جاتے ہیں جو اب بھی یہ فہرستیں بھیج رہے ہیں"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "chỉ các liên kết trực tiếp của bạn — danh sách hàng xóm không còn được phát nữa, nên liên kết giữa các nút khác không được hiển thị"
+            "value" : "chủ yếu là các liên kết trực tiếp của bạn — danh sách hàng xóm không còn được phát nữa, nên liên kết giữa các nút khác chỉ hiện với những nút vẫn còn gửi danh sách"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "仅显示你的直接连接 — 邻居列表不再广播，因此其他同伴之间的连接不会显示"
+            "value" : "多为你自己的直接连接 — 邻居列表不再广播，因此其他同伴之间的连接只对仍在发送列表的同伴显示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "僅顯示你的直接連線 — 鄰居列表不再廣播，因此其他同伴之間的連線不會顯示"
+            "value" : "多為你自己的直接連線 — 鄰居列表不再廣播，因此其他同伴之間的連線只會對仍在傳送列表的同伴顯示"
           }
         }
       }

--- a/bitchat/Services/BLE/BLEService.swift
+++ b/bitchat/Services/BLE/BLEService.swift
@@ -3921,8 +3921,17 @@ extension BLEService {
         return isPeerConnected(peerID) ? [] : nil
     }
 
-    /// Mesh graph for the topology map. Edges are advisory: announces cap
-    /// neighbor lists at 10, so an edge claimed by either endpoint counts.
+    /// Mesh graph for the topology map. Edges are advisory: an edge claimed by
+    /// either endpoint counts.
+    ///
+    /// Since announces stopped carrying neighbour lists
+    /// (`TransportConfig.announceIncludesDirectNeighbors`) the only claims a
+    /// device reliably holds are its own, refreshed from live connections just
+    /// below. So this degrades to a star centred on self rather than going
+    /// empty, and peer-to-peer edges appear only for peers still advertising a
+    /// list. The caption in the topology sheet says so, because a star that
+    /// silently stands in for the whole graph reads as "the mesh is a star"
+    /// rather than "this is all we can see".
     func currentMeshTopology() -> MeshTopologySnapshot? {
         refreshLocalTopology()
         let claims = meshTopology.adjacencySnapshot()

--- a/bitchat/Views/MeshTopologyView.swift
+++ b/bitchat/Views/MeshTopologyView.swift
@@ -8,9 +8,10 @@
 
 import SwiftUI
 
-/// Display model for the mesh topology map: nodes are known mesh peers,
-/// edges are gossiped `directNeighbors` claims. Built on the main actor from
-/// a `MeshTopologySnapshot` plus the current nickname table.
+/// Display model for the mesh topology map: nodes are known mesh peers, edges
+/// are neighbour claims — in practice this device's own, since announces no
+/// longer carry a neighbour list. Built on the main actor from a
+/// `MeshTopologySnapshot` plus the current nickname table.
 struct MeshTopologyDisplayModel {
     struct Node: Identifiable, Equatable {
         let id: String


### PR DESCRIPTION
Two follow-ups to #1492, so the change doesn't ship inconsistent with itself. Both sit directly on this branch's tip (`4a2e06ba`); net diff is just these two commits.

**1. Bring `WHITEPAPER.md` in line.** `docs/privacy-assessment.md` was updated on this branch, but the whitepaper wasn't: §4.2 still says packets "originate with TTL 7", §4.3 still says announcements "carry up to 10 direct-neighbor IDs", §8 lists both as live leaks, §9 lists the neighbour-list one as future work. Corrected all four — and deliberately **not** written up as a win, matching how `TransportConfig` and the privacy assessment already frame it: relays strictly decrement, so the top of the range is still origin-only (~1 message in 3, ~87% of senders self-identified within five). A whitepaper that overstates a mitigation is worse than one that omits it.

**2. Stop the topology map implying it can still see the whole mesh.** I expected it to go blank; it doesn't. `currentMeshTopology()` calls `refreshLocalTopology()` first, which records *this device's own* links from live connections, so those survive while remote peers contribute nothing — the map degrades to a **star centred on self**, which reads as "a mesh where nobody else is connected to anybody" rather than "this is all we can see." The caption made it worse ("estimated from gossiped neighbor lists" — now false twice over). Reworded the caption across all 30 locales and fixed the three doc comments that still describe edges as gossiped claims. No behaviour change.

Worth a maintainer decision, not buried in a doc: with neighbour lists suppressed network-wide, **no source route is ever confirmable** (confirmation needs both endpoints to claim the edge), so directed traffic always floods. That's the documented fallback, not a regression — but source routing becomes effectively dead code in a fully-upgraded mesh. Noted in §9 as follow-up ("restore source routing without publishing adjacency").

Full suite green (2013 tests) on this branch + these commits. `fa` topology.caption dropped to `needs_review` since its meaning changed and I'm not a native reviewer of the new wording.
