### PR TITLE
Sync the manager's read-receipt set, closing a re-enable leak

### DIFF
--- a/bitchat/Services/PrivateChatManager.swift
+++ b/bitchat/Services/PrivateChatManager.swift
@@ -28,7 +28,11 @@ final class PrivateChatManager: ObservableObject {
     @Published private(set) var selectedPeer: PeerID? = nil
     private var selectedPeerMirrorCancellable: AnyCancellable? = nil
 
-    var sentReadReceipts: Set<String> = []  // Made accessible for ChatViewModel
+    // Readable by ChatViewModel; mutated only here or through the record/
+    // forget/clear API below. Direct external writes are how the view-model
+    // and this manager's sets fell out of lockstep in the first place, so the
+    // setter is closed off.
+    private(set) var sentReadReceipts: Set<String> = []
 
     weak var meshService: Transport?
     // Route acks/receipts via MessageRouter (chooses mesh or Nostr)
@@ -257,6 +261,27 @@ final class PrivateChatManager: ObservableObject {
     /// not this manager's set, so claiming only locally would let a receipt
     /// for a message read while the setting was OFF fire after re-enabling.
     var markReceiptHandled: ((String) -> Void)?
+
+    // MARK: - Read-receipt sent-set (shared with ChatViewModel)
+
+    /// Record a read receipt as sent/handled. ChatViewModel mirrors its own
+    /// records here so `markAsRead`'s chat-open re-scan (which dedups against
+    /// this set) sees receipts withheld or sent on the coordinator path.
+    func recordReadReceiptSent(_ messageID: String) {
+        sentReadReceipts.insert(messageID)
+    }
+
+    /// Forget sent receipts so they can be re-sent after the peer reconnects.
+    /// `markAsRead` guards on this set, so the view-model's `unmark` must reach
+    /// it or the reconnect re-send never fires.
+    func forgetReadReceiptsSent(_ ids: [String]) {
+        sentReadReceipts.subtract(ids)
+    }
+
+    /// Drop all sent-receipt tracking (panic/wipe).
+    func clearReadReceiptsSent() {
+        sentReadReceipts.removeAll()
+    }
 
     private func sendReadReceipt(for message: BitchatMessage) {
         guard !sentReadReceipts.contains(message.id),

--- a/bitchat/Services/PrivateChatManager.swift
+++ b/bitchat/Services/PrivateChatManager.swift
@@ -256,11 +256,18 @@ final class PrivateChatManager: ObservableObject {
     /// suites through the shared UserDefaults-backed setting.
     var sendsReadReceipts: () -> Bool = { ReadReceiptSettings.sendReadReceipts }
 
-    /// Records a withheld receipt in the owner's persisted set too: the
-    /// lifecycle read pass dedups against ChatViewModel.sentReadReceipts,
-    /// not this manager's set, so claiming only locally would let a receipt
-    /// for a message read while the setting was OFF fire after re-enabling.
+    /// Records EVERY claim this manager makes — sent and withheld alike — in
+    /// the owner's persisted set too. The lifecycle read pass dedups against
+    /// ChatViewModel.sentReadReceipts, not this manager's set, so a claim
+    /// kept only here is invisible to it: a withheld receipt would fire after
+    /// re-enabling the setting, and a sent one would go out a second time on
+    /// the very same chat open.
     var markReceiptHandled: ((String) -> Void)?
+
+    /// Releases a claim from BOTH sets when the route fails. Dropping it only
+    /// here would leave the owner's set still claiming the receipt, so the
+    /// lifecycle pass would skip it forever and it would never be retried.
+    var releaseReceiptClaim: ((String) -> Void)?
 
     // MARK: - Read-receipt sent-set (shared with ChatViewModel)
 
@@ -272,8 +279,9 @@ final class PrivateChatManager: ObservableObject {
     }
 
     /// Forget sent receipts so they can be re-sent after the peer reconnects.
-    /// `markAsRead` guards on this set, so the view-model's `unmark` must reach
-    /// it or the reconnect re-send never fires.
+    /// `markAsRead` guards on this set while the lifecycle pass guards on the
+    /// view model's, so the view-model's `unmark` must reach both or the two
+    /// sets drift apart and each path decides differently about the same id.
     func forgetReadReceiptsSent(_ ids: [String]) {
         sentReadReceipts.subtract(ids)
     }
@@ -308,20 +316,24 @@ final class PrivateChatManager: ObservableObject {
         if let router = messageRouter {
             SecureLogger.debug("PrivateChatManager: sending READ ack for \(message.id.prefix(8))… to \(senderPeerID.id.prefix(8))… via router", category: .session)
             let messageID = message.id
-            // Claim the receipt synchronously so a second read scan in the
-            // same runloop pass (chat open triggers two) can't route a
-            // duplicate; release the claim on a failed route (no reachable
-            // transport) so a later read scan retries instead of permanently
-            // losing the receipt.
+            // Claim the receipt synchronously, in BOTH sets, before the
+            // routing task can run. A chat open fires three read scans: this
+            // manager's two (deduped here) and the lifecycle pass, which
+            // dedups against the owner's set — so a claim kept only here
+            // would still let that third scan route a second copy of it.
+            // Release both claims on a failed route (no reachable transport)
+            // so a later scan retries instead of losing the receipt for good.
             sentReadReceipts.insert(messageID)
+            markReceiptHandled?(messageID)
             Task { @MainActor [weak self] in
                 if !router.sendReadReceipt(receipt, to: senderPeerID) {
-                    self?.sentReadReceipts.remove(messageID)
+                    self?.releaseReceiptClaim?(messageID)
                 }
             }
         } else {
             // Fallback: preserve previous behavior (best-effort mesh send).
             sentReadReceipts.insert(message.id)
+            markReceiptHandled?(message.id)
             meshService?.sendReadReceipt(receipt, to: senderPeerID)
         }
     }

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -541,7 +541,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
         // fire after the read-receipt setting is toggled back on. Keep both
         // sets in lockstep; the existing markReceiptHandled bridge covers the
         // reverse (manager -> here) direction.
-        privateChatManager.sentReadReceipts.insert(messageID)
+        privateChatManager.recordReadReceiptSent(messageID)
         return sentReadReceipts.insert(messageID).inserted
     }
 
@@ -561,7 +561,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
         // Must reach the manager set too: markAsRead's re-send-after-reconnect
         // path guards on the manager set, so leaving ids stuck there would
         // silently defeat the reconnect re-send this method exists to enable.
-        privateChatManager.sentReadReceipts.subtract(ids)
+        privateChatManager.forgetReadReceiptsSent(ids)
     }
 
     /// Marks read receipts as sent for own messages already delivered/read in
@@ -1705,7 +1705,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
 
         // Clear read receipt tracking
         sentReadReceipts.removeAll()
-        privateChatManager.sentReadReceipts.removeAll()
+        privateChatManager.clearReadReceiptsSent()
         deduplicationService.clearAll()
 
         // IMPORTANT: Clear Nostr-related state

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -534,7 +534,15 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
     @MainActor
     @discardableResult
     func markReadReceiptSent(_ messageID: String) -> Bool {
-        sentReadReceipts.insert(messageID).inserted
+        // Mirror into the manager's set too. PrivateChatManager.markAsRead
+        // re-scans on every chat open and dedups against ITS own set, so a
+        // receipt withheld (or sent) on the coordinator path — which records
+        // only here — would otherwise be invisible to that re-scan and could
+        // fire after the read-receipt setting is toggled back on. Keep both
+        // sets in lockstep; the existing markReceiptHandled bridge covers the
+        // reverse (manager -> here) direction.
+        privateChatManager.sentReadReceipts.insert(messageID)
+        return sentReadReceipts.insert(messageID).inserted
     }
 
     /// Records that a GeoDM delivery ACK is being sent for `messageID`.
@@ -550,6 +558,10 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
     @MainActor
     func unmarkReadReceiptsSent(_ ids: [String]) {
         sentReadReceipts.subtract(ids)
+        // Must reach the manager set too: markAsRead's re-send-after-reconnect
+        // path guards on the manager set, so leaving ids stuck there would
+        // silently defeat the reconnect re-send this method exists to enable.
+        privateChatManager.sentReadReceipts.subtract(ids)
     }
 
     /// Marks read receipts as sent for own messages already delivered/read in
@@ -1693,6 +1705,7 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
 
         // Clear read receipt tracking
         sentReadReceipts.removeAll()
+        privateChatManager.sentReadReceipts.removeAll()
         deduplicationService.clearAll()
 
         // IMPORTANT: Clear Nostr-related state

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -558,9 +558,10 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
     @MainActor
     func unmarkReadReceiptsSent(_ ids: [String]) {
         sentReadReceipts.subtract(ids)
-        // Must reach the manager set too: markAsRead's re-send-after-reconnect
-        // path guards on the manager set, so leaving ids stuck there would
-        // silently defeat the reconnect re-send this method exists to enable.
+        // Must reach the manager set too: markAsRead guards on that set while
+        // the lifecycle pass guards on this one, so leaving ids stuck there
+        // would let the two sets disagree about the same receipt — one path
+        // re-sending it, the other still treating it as handled.
         privateChatManager.forgetReadReceiptsSent(ids)
     }
 

--- a/bitchat/ViewModels/ChatViewModelBootstrapper.swift
+++ b/bitchat/ViewModels/ChatViewModelBootstrapper.swift
@@ -93,6 +93,9 @@ private extension ChatViewModelBootstrapper {
         viewModel.privateChatManager.markReceiptHandled = { [weak viewModel] messageID in
             viewModel?.markReadReceiptSent(messageID)
         }
+        viewModel.privateChatManager.releaseReceiptClaim = { [weak viewModel] messageID in
+            viewModel?.unmarkReadReceiptsSent([messageID])
+        }
         viewModel.unifiedPeerService.messageRouter = viewModel.messageRouter
         // Surface silent outbox drops (attempt cap, TTL expiry, overflow
         // eviction) as a visible failure. The store's no-downgrade rule does

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -471,6 +471,74 @@ struct ChatViewModelServiceLifecycleTests {
         #expect(viewModel.privateChatManager.sentReadReceipts.contains("read-2"))
     }
 
+    /// Regression for the two-set asymmetry: a message read while viewing a
+    /// chat with receipts OFF is withheld on the *coordinator* path (which
+    /// records only the view-model set). `PrivateChatManager.markAsRead`
+    /// re-scans on every chat open and dedups against its OWN set, so before
+    /// the fix, re-enabling the setting and reopening the chat fired a receipt
+    /// for that already-read message — a delayed disclosure of reading done
+    /// while the setting was off. Drives the real inbound delegate path, not
+    /// the manager-withhold path the test above covers.
+    @Test @MainActor
+    func readReceiptNotResentWhenReenablingAfterMessageReadWhileViewing() async {
+        let (viewModel, transport) = makeTestableViewModel()
+        viewModel.sendsReadReceipts = { false }
+        viewModel.privateChatManager.sendsReadReceipts = { false }
+        let peerID = PeerID(str: "0000000000000042")
+        transport.simulateConnect(peerID, nickname: "Alice")
+        viewModel.selectedPrivateChatPeer = peerID   // viewing
+
+        let message = BitchatMessage(
+            id: "read-viewing",
+            sender: "Alice",
+            content: "read while receipts were off",
+            timestamp: Date(),
+            isRelay: false,
+            originalSender: nil,
+            isPrivate: true,
+            recipientNickname: viewModel.nickname,
+            senderPeerID: peerID,
+            mentions: nil
+        )
+        // Real inbound path -> didReceiveMessage -> handlePrivateMessage
+        // (isViewing branch): withholds the mesh receipt and records the id.
+        transport.simulateIncomingMessage(message)
+
+        // Confirm the coordinator path actually ran (id recorded) and nothing
+        // left the device while the setting was OFF.
+        #expect(await TestHelpers.waitUntil({
+            viewModel.sentReadReceipts.contains("read-viewing")
+        }, timeout: TestConstants.settleTimeout))
+        #expect(!transport.sentReadReceipts.contains { $0.receipt.originalMessageID == "read-viewing" })
+
+        // Re-enable, leave, and reopen the chat: startChat -> markAsRead
+        // re-scans. The message must NOT be resent.
+        viewModel.selectedPrivateChatPeer = nil
+        viewModel.sendsReadReceipts = { true }
+        viewModel.privateChatManager.sendsReadReceipts = { true }
+        viewModel.selectedPrivateChatPeer = peerID   // reopen
+
+        let leaked = await TestHelpers.waitUntil({
+            transport.sentReadReceipts.contains { $0.receipt.originalMessageID == "read-viewing" }
+        }, timeout: TestConstants.negativeWaitWindow)
+        #expect(!leaked)
+    }
+
+    /// Guards the second half of the fix: `unmarkReadReceiptsSent` must clear
+    /// BOTH sets, or the reconnect re-send it exists to enable would be
+    /// silently defeated (markAsRead guards on the manager set).
+    @Test @MainActor
+    func unmarkReadReceiptsSentClearsBothSets() {
+        let (viewModel, _) = makeTestableViewModel()
+        viewModel.markReadReceiptSent("m-1")
+        #expect(viewModel.sentReadReceipts.contains("m-1"))
+        #expect(viewModel.privateChatManager.sentReadReceipts.contains("m-1"))
+
+        viewModel.unmarkReadReceiptsSent(["m-1"])
+        #expect(!viewModel.sentReadReceipts.contains("m-1"))
+        #expect(!viewModel.privateChatManager.sentReadReceipts.contains("m-1"))
+    }
+
     @Test @MainActor
     func readReceiptSettingDefaultsToOnAndResets() {
         let suite = "ReadReceiptSettingsTests.\(UUID().uuidString)"

--- a/bitchatTests/ChatViewModelTests.swift
+++ b/bitchatTests/ChatViewModelTests.swift
@@ -525,8 +525,8 @@ struct ChatViewModelServiceLifecycleTests {
     }
 
     /// Guards the second half of the fix: `unmarkReadReceiptsSent` must clear
-    /// BOTH sets, or the reconnect re-send it exists to enable would be
-    /// silently defeated (markAsRead guards on the manager set).
+    /// BOTH sets, or they drift apart — markAsRead guards on the manager set,
+    /// the lifecycle pass on the view model's.
     @Test @MainActor
     func unmarkReadReceiptsSentClearsBothSets() {
         let (viewModel, _) = makeTestableViewModel()
@@ -537,6 +537,68 @@ struct ChatViewModelServiceLifecycleTests {
         viewModel.unmarkReadReceiptsSent(["m-1"])
         #expect(!viewModel.sentReadReceipts.contains("m-1"))
         #expect(!viewModel.privateChatManager.sentReadReceipts.contains("m-1"))
+    }
+
+    /// Regression for the duplicate a reopen used to emit: opening a chat
+    /// runs the manager's read scan (claims in the manager set, routes
+    /// asynchronously) and then the lifecycle pass, which dedups against the
+    /// view model's set. Until the manager bridged its successful claims back,
+    /// that second scan saw an unclaimed id and routed the receipt again —
+    /// twice per open, and twice more after a reconnect cleared both sets.
+    @Test @MainActor
+    func readReceiptSentOnceOnOpenAndOnceMoreAfterReconnect() async {
+        let (viewModel, transport) = makeTestableViewModel()
+        let peerID = PeerID(str: "0000000000000043")
+        transport.simulateConnect(peerID, nickname: "Alice")
+
+        let message = BitchatMessage(
+            id: "read-reopen",
+            sender: "Alice",
+            content: "Hello from Alice",
+            timestamp: Date(),
+            isRelay: false,
+            originalSender: nil,
+            isPrivate: true,
+            recipientNickname: viewModel.nickname,
+            senderPeerID: peerID,
+            mentions: nil
+        )
+
+        viewModel.seedPrivateChat([message], for: peerID)
+        viewModel.markPrivateChatUnread(peerID)
+
+        func receiptCount() -> Int {
+            transport.sentReadReceipts.filter { $0.receipt.originalMessageID == "read-reopen" }.count
+        }
+
+        // Open through startPrivateChat, not the selection setter: only this
+        // path runs the lifecycle read pass after the manager's own scan, so
+        // only this path can produce the duplicate.
+        viewModel.startPrivateChat(with: peerID)
+
+        #expect(await TestHelpers.waitUntil({ receiptCount() >= 1 }, timeout: TestConstants.settleTimeout))
+        // Negative wait: a duplicate lands in the same runloop turn as the
+        // first, so nothing more may arrive in this window.
+        _ = await TestHelpers.waitUntil({ receiptCount() > 1 }, timeout: TestConstants.negativeWaitWindow)
+        #expect(receiptCount() == 1)
+
+        // A disconnect clears both claims so the receipt can be re-sent — but
+        // it runs inside a Task, so drain before reopening or the reopen would
+        // still see both sets claiming the id.
+        viewModel.endPrivateChat()
+        transport.simulateDisconnect(peerID)
+        #expect(await TestHelpers.waitUntil({
+            !viewModel.sentReadReceipts.contains("read-reopen")
+                && !viewModel.privateChatManager.sentReadReceipts.contains("read-reopen")
+        }, timeout: TestConstants.settleTimeout))
+
+        transport.simulateConnect(peerID, nickname: "Alice")
+        viewModel.startPrivateChat(with: peerID)
+
+        #expect(await TestHelpers.waitUntil({ receiptCount() >= 2 }, timeout: TestConstants.settleTimeout))
+        _ = await TestHelpers.waitUntil({ receiptCount() > 2 }, timeout: TestConstants.negativeWaitWindow)
+        // The one original plus a single retry — not a pair per open.
+        #expect(receiptCount() == 2)
     }
 
     @Test @MainActor

--- a/bitchatTests/Services/PrivateChatManagerTests.swift
+++ b/bitchatTests/Services/PrivateChatManagerTests.swift
@@ -148,11 +148,16 @@ struct PrivateChatManagerTests {
     @Test @MainActor
     func markAsRead_failedRouteReleasesClaimForRetry() async {
         // No reachable transport: the receipt is not sent, and the eager
-        // claim must be released so a later read scan retries.
+        // claim must be released so a later read scan retries. The release
+        // goes through the owner's bridge (it holds the other set), so stand
+        // in for the bootstrapper's wiring here.
         let transport = MockTransport()
         let router = MessageRouter(transports: [transport])
         let (manager, store) = Self.makeManager(transport: transport)
         manager.messageRouter = router
+        manager.releaseReceiptClaim = { [weak manager] messageID in
+            manager?.forgetReadReceiptsSent([messageID])
+        }
 
         let peerID = PeerID(str: "00000000000000DF")
 


### PR DESCRIPTION
Fixes the retroactive read-receipt leak from my review of #1659 — the concrete repro, and a test that fails on the current branch.

**The gap:** `markReadReceiptSent` recorded a handled receipt only in `ChatViewModel.sentReadReceipts`. But `PrivateChatManager.markAsRead` re-scans on every chat open and dedups against the manager's **own** in-memory set. So a receipt withheld on the coordinator path — an inbound message read *while viewing the chat* with receipts off — was invisible to that re-scan. Re-enable the setting, reopen the chat, and a read receipt fired for a message read while receipts were off. Within-session (the in-memory store is wiped on relaunch), but exactly the retroactive disclosure the feature's own comment says can't happen.

**The fix:** the existing `markReceiptHandled` callback already bridges manager → view-model; this adds the missing reverse direction, mirroring both mutations of the view-model set into the manager set (insert in `markReadReceiptSent`, subtract in `unmarkReadReceiptsSent`, plus the wipe path). The subtract mirror keeps the two sets consistent: `markAsRead` guards on the manager set while the lifecycle read pass guards on the view-model set, so leaving ids stuck in one of them lets the two paths disagree about the same receipt. (An earlier version of this description called that mirror load-bearing for the reconnect re-send. That was wrong — the lifecycle pass already re-sent from the cleared view-model set — and the same wrong sentence was in two doc comments, now corrected.) A second test pins the behaviour so an insert-only regression can't slip in.

The regression test drives the **real inbound delegate path** (`simulateIncomingMessage` → `didReceiveMessage` → `handlePrivateMessage`), not the manager-withhold path the existing test covers. I verified it fails on the current branch tip and passes after the fix; full suite green (2022 tests).

**Two follow-up commits since review.**

`8c6fb92` closes the encapsulation gap @Chessing234 raised: `PrivateChatManager.sentReadReceipts` is now `private(set)`, mutated only inside the manager or through `recordReadReceiptSent` / `forgetReadReceiptsSent` / `clearReadReceiptsSent`, so nothing can rebuild it out from under the lockstep.

`1f36888` fixes a duplicate Codex found, which the mirror above had introduced: clearing both sets on disconnect removed the manager's dedup claim as well, so reopening a chat after a reconnect emitted **two** READ receipts to the peer. `sendReadReceipt` now calls `markReceiptHandled` immediately after its synchronous claim, so the lifecycle pass that runs next in `startPrivateChat` sees the claim and skips; a failed route releases both claims through a new `releaseReceiptClaim` callback, since releasing only the manager's would leave the view model claiming a receipt that never went out.

Reading the base branch and main, the same missing bridge appears to double-send on an ordinary chat open with unread messages too — no disconnect needed. I traced that by reading rather than reproducing it, but the fix here covers it either way.

The new regression test opens through `startPrivateChat`, not by assigning `selectedPrivateChatPeer`: that setter runs only the manager's scan, so it cannot reproduce the duplicate. It drains around the disconnect, since the unmark runs inside a Task.

Targets `feat/read-receipt-toggle` so it can fold into #1659 before merge.

