### PR TITLE
Gate the /fav command behind the favorite consent step

### DIFF
--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -538,7 +538,22 @@ final class CommandProcessor {
     }
 
     private func handleFavorite(_ args: String, add: Bool) -> CommandResult {
-        let targetName = args.trimmed
+        // The first favorite is consent-gated on the ADD path: adding notifies
+        // the peer immediately and shares your durable Nostr key. The star UI
+        // shows a one-time dialog for this; a slash command has no view to
+        // present it, so require an explicit `!confirm` token the first time.
+        // Order-independent, add-only (removals stay immediate, matching the UI).
+        var targetName = args.trimmed
+        var confirmed = false
+        if add {
+            var tokens = targetName.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+            if let idx = tokens.firstIndex(of: "!confirm") {
+                confirmed = true
+                tokens.remove(at: idx)
+                targetName = tokens.joined(separator: " ")
+            }
+        }
+
         guard !targetName.isEmpty else {
             return .error(message: String(format: String(localized: "command.action.usage", defaultValue: "usage: /%@ <nickname>", comment: "Usage hint for a command that takes a nickname; placeholder is the command name"), locale: .current, (add ? "fav" : "unfav")))
         }
@@ -563,6 +578,21 @@ final class CommandProcessor {
             return .success(message: add
                 ? String(format: String(localized: "command.fav.already", defaultValue: "%@ is already a favorite", comment: "Reply when /fav targets an existing favorite"), locale: .current, nickname)
                 : String(format: String(localized: "command.fav.not_favorite", defaultValue: "%@ is not a favorite", comment: "Reply when /unfav targets someone who isn't a favorite"), locale: .current, nickname))
+        }
+
+        // Consent gate: no durable linkage or peer notification happens until
+        // the user has seen the disclosure and re-issued with !confirm — or has
+        // already acknowledged it through the star UI (the flag is shared).
+        if add, !FavoriteConsent.isAcknowledged {
+            guard confirmed else {
+                let disclosure = String(
+                    format: String(localized: "favorites.consent.message", defaultValue: "this tells %@ right away and shares your nostr key with them. if they favorite you back, you can message each other over the internet when out of mesh range.", comment: "Body of the one-time favorite consent dialog; placeholder is the person's name"),
+                    locale: .current,
+                    nickname
+                )
+                return .error(message: disclosure + "\n\n/fav \(nickname) !confirm")
+            }
+            FavoriteConsent.acknowledge()
         }
 
         // toggleFavorite persists by the real noise key and notifies the peer.

--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -541,16 +541,20 @@ final class CommandProcessor {
         // The first favorite is consent-gated on the ADD path: adding notifies
         // the peer immediately and shares your durable Nostr key. The star UI
         // shows a one-time dialog for this; a slash command has no view to
-        // present it, so require an explicit `!confirm` token the first time.
-        // Order-independent, add-only (removals stay immediate, matching the UI).
+        // present it, so require an explicit trailing `!confirm` the first time.
+        // Parse it as a trailing flag rather than tokenizing the name
+        // (@Chessing234 on #1702): the rest of the line is the nickname, so a
+        // name with spaces survives intact. Add-only; removals stay immediate.
         var targetName = args.trimmed
         var confirmed = false
         if add {
-            var tokens = targetName.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
-            if let idx = tokens.firstIndex(of: "!confirm") {
+            let flag = "!confirm"
+            if targetName == flag {
                 confirmed = true
-                tokens.remove(at: idx)
-                targetName = tokens.joined(separator: " ")
+                targetName = ""
+            } else if targetName.hasSuffix(" \(flag)") {
+                confirmed = true
+                targetName = String(targetName.dropLast(flag.count + 1)).trimmed
             }
         }
 

--- a/bitchat/Services/CommandProcessor.swift
+++ b/bitchat/Services/CommandProcessor.swift
@@ -549,12 +549,26 @@ final class CommandProcessor {
         var confirmed = false
         if add {
             let flag = "!confirm"
-            if targetName == flag {
-                confirmed = true
-                targetName = ""
-            } else if targetName.hasSuffix(" \(flag)") {
-                confirmed = true
-                targetName = String(targetName.dropLast(flag.count + 1)).trimmed
+            // An exact name beats the flag: if the whole line already names a
+            // peer — someone nicknamed "alice !confirm" — keep it whole and
+            // show them the disclosure. Reading their name as consent would
+            // skip the disclosure and hand the durable key to whatever
+            // "alice" resolves to, a different person; refusing to read it
+            // costs at most one more confirmation step, so that is the safe
+            // way to be wrong. They confirm with "/fav alice !confirm !confirm".
+            let givenName = targetName.hasPrefix("@") ? String(targetName.dropFirst()) : targetName
+            let namesAPeer = contextProvider?.getPeerIDForNickname(givenName) != nil
+            if !namesAPeer {
+                // The flag is matched case-insensitively; the nickname is not.
+                if targetName.lowercased() == flag {
+                    confirmed = true
+                    targetName = ""
+                } else if targetName.count > flag.count,
+                          targetName.suffix(flag.count).lowercased() == flag,
+                          targetName.dropLast(flag.count).hasSuffix(" ") {
+                    confirmed = true
+                    targetName = String(targetName.dropLast(flag.count + 1)).trimmed
+                }
             }
         }
 

--- a/bitchatTests/CommandProcessorTests.swift
+++ b/bitchatTests/CommandProcessorTests.swift
@@ -310,6 +310,10 @@ struct CommandProcessorTests {
     /// send a second favorite notification.
     @MainActor
     @Test func favoriteCommandTogglesWithoutDirectStoreWrite() async {
+        // This test is about the store-write / no-double-notify behaviour, not
+        // the consent gate; pre-acknowledge so plain /fav toggles immediately.
+        FavoriteConsent.acknowledge()
+        defer { FavoriteConsent.reset() }
         let identityManager = MockIdentityManager(MockKeychain())
         let context = MockCommandContextProvider()
         let processor = CommandProcessor(
@@ -347,6 +351,54 @@ struct CommandProcessorTests {
             Issue.record("Expected success result")
         }
         #expect(context.toggledFavorites == [peerID])
+    }
+
+    /// Regression: /fav must not favorite (persist the linkage + notify the
+    /// peer) before the user has seen the disclosure. On a fresh, unacknowledged
+    /// state a plain /fav returns the disclosure and toggles nothing; only the
+    /// explicit !confirm form proceeds, and it records consent so the star UI
+    /// never re-asks.
+    @MainActor
+    @Test func favoriteCommandRequiresConsentBeforeFirstFavorite() async {
+        FavoriteConsent.reset()                 // fresh, unacknowledged
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        let peerID = PeerID(str: "00aa00bb00cc00dd")
+        context.nicknameToPeerID["alice"] = peerID
+
+        // Plain /fav on an unacknowledged state: disclosure, no toggle, no notify.
+        let gated = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav alice")
+        }
+        switch gated {
+        case .error(let message):
+            #expect(message.contains("shares your nostr key"))
+            #expect(message.contains("/fav alice !confirm"))
+        default:
+            Issue.record("Expected the consent disclosure, got \(gated)")
+        }
+        #expect(context.toggledFavorites.isEmpty)
+        #expect(context.favoriteNotifications.isEmpty)
+        #expect(!FavoriteConsent.isAcknowledged)
+
+        // Explicit confirmation: toggles, and records consent going forward.
+        let confirmed = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav alice !confirm")
+        }
+        switch confirmed {
+        case .success(let message):
+            #expect(message == "added alice to favorites")
+        default:
+            Issue.record("Expected success after !confirm, got \(confirmed)")
+        }
+        #expect(context.toggledFavorites == [peerID])
+        #expect(FavoriteConsent.isAcknowledged)
     }
 
     @MainActor

--- a/bitchatTests/CommandProcessorTests.swift
+++ b/bitchatTests/CommandProcessorTests.swift
@@ -401,6 +401,71 @@ struct CommandProcessorTests {
         #expect(FavoriteConsent.isAcknowledged)
     }
 
+    /// A nickname with spaces must survive the consent round-trip: the flag is
+    /// parsed as a trailing token, not by tokenizing the whole name.
+    @MainActor
+    @Test func favoriteCommandConsentPreservesMultiWordNickname() async {
+        FavoriteConsent.reset()
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        let peerID = PeerID(str: "00aa00bb00cc00dd")
+        context.nicknameToPeerID["jane doe"] = peerID
+
+        // Unconfirmed: the whole spaced name resolves, and the hint echoes it.
+        let gated = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav jane doe")
+        }
+        switch gated {
+        case .error(let message):
+            #expect(message.contains("/fav jane doe !confirm"))
+        default:
+            Issue.record("Expected disclosure for a multi-word name, got \(gated)")
+        }
+        #expect(context.toggledFavorites.isEmpty)
+
+        // Confirmed: the trailing flag is stripped and "jane doe" resolves.
+        let confirmed = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav jane doe !confirm")
+        }
+        switch confirmed {
+        case .success(let message):
+            #expect(message == "added jane doe to favorites")
+        default:
+            Issue.record("Expected success for a multi-word name, got \(confirmed)")
+        }
+        #expect(context.toggledFavorites == [peerID])
+    }
+
+    /// `!confirm` is honored only as a trailing flag, not stripped from
+    /// anywhere in the line — otherwise `/fav !confirm alice` would wrongly
+    /// count as consent for alice. Here "!confirm alice" is just an unknown
+    /// name: no toggle, and consent is not recorded.
+    @MainActor
+    @Test func favoriteCommandConsentHonorsOnlyTrailingConfirm() async {
+        FavoriteConsent.reset()
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        context.nicknameToPeerID["alice"] = PeerID(str: "00aa00bb00cc00dd")
+
+        _ = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav !confirm alice")
+        }
+        #expect(context.toggledFavorites.isEmpty)
+        #expect(!FavoriteConsent.isAcknowledged)
+    }
+
     @MainActor
     @Test func favoriteCommandIsRejectedOutsideMesh() async {
         let identityManager = MockIdentityManager(MockKeychain())

--- a/bitchatTests/CommandProcessorTests.swift
+++ b/bitchatTests/CommandProcessorTests.swift
@@ -466,6 +466,97 @@ struct CommandProcessorTests {
         #expect(!FavoriteConsent.isAcknowledged)
     }
 
+    /// A peer literally named "alice !confirm" alongside a peer named "alice"
+    /// — the case Codex raised on #1702: /fav on the first must not be read as
+    /// consent for the second. The name wins, so the disclosure is shown,
+    /// nothing is toggled and consent is not recorded.
+    @MainActor
+    @Test func favoriteCommandTreatsExactNameAsNameNotConfirmFlag() async {
+        FavoriteConsent.reset()
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        context.nicknameToPeerID["alice !confirm"] = PeerID(str: "00aa00bb00cc00dd")
+        context.nicknameToPeerID["alice"] = PeerID(str: "11aa11bb11cc11dd")
+
+        let gated = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav alice !confirm")
+        }
+        switch gated {
+        case .error(let message):
+            #expect(message.contains("shares your nostr key"))
+            #expect(message.contains("/fav alice !confirm !confirm"))
+        default:
+            Issue.record("Expected the disclosure for the peer named 'alice !confirm', got \(gated)")
+        }
+        #expect(context.toggledFavorites.isEmpty)
+        #expect(context.favoriteNotifications.isEmpty)
+        #expect(!FavoriteConsent.isAcknowledged)
+    }
+
+    /// The hint from that disclosure round-trips: the trailing flag is stripped
+    /// once and "alice !confirm" — not "alice" — is favorited.
+    @MainActor
+    @Test func favoriteCommandConfirmsPeerNamedLikeTheFlag() async {
+        FavoriteConsent.reset()
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        let confusingPeerID = PeerID(str: "00aa00bb00cc00dd")
+        context.nicknameToPeerID["alice !confirm"] = confusingPeerID
+        context.nicknameToPeerID["alice"] = PeerID(str: "11aa11bb11cc11dd")
+
+        let confirmed = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav alice !confirm !confirm")
+        }
+        switch confirmed {
+        case .success(let message):
+            #expect(message == "added alice !confirm to favorites")
+        default:
+            Issue.record("Expected success for the peer named 'alice !confirm', got \(confirmed)")
+        }
+        #expect(context.toggledFavorites == [confusingPeerID])
+        #expect(FavoriteConsent.isAcknowledged)
+    }
+
+    /// The flag is matched case-insensitively; the nickname is not touched.
+    @MainActor
+    @Test func favoriteCommandAcceptsUppercaseConfirmFlag() async {
+        FavoriteConsent.reset()
+        defer { FavoriteConsent.reset() }
+        let identityManager = MockIdentityManager(MockKeychain())
+        let context = MockCommandContextProvider()
+        let processor = CommandProcessor(
+            contextProvider: context,
+            meshService: MockTransport(),
+            identityManager: identityManager
+        )
+        let peerID = PeerID(str: "00aa00bb00cc00dd")
+        context.nicknameToPeerID["Alice"] = peerID
+
+        let confirmed = await withSelectedChannel(.mesh, context: context) {
+            processor.process("/fav Alice !CONFIRM")
+        }
+        switch confirmed {
+        case .success(let message):
+            #expect(message == "added Alice to favorites")
+        default:
+            Issue.record("Expected success for an uppercase flag, got \(confirmed)")
+        }
+        #expect(context.toggledFavorites == [peerID])
+        #expect(FavoriteConsent.isAcknowledged)
+    }
+
     @MainActor
     @Test func favoriteCommandIsRejectedOutsideMesh() async {
         let identityManager = MockIdentityManager(MockKeychain())


### PR DESCRIPTION
Closes the `/fav` bypass from my review of #1663.

The one-time consent gate added in this PR lives only in the two SwiftUI views. `/fav` goes straight to `toggleFavorite` (which persists the durable linkage and notifies the peer, sharing your Nostr key), so on a fresh unacknowledged device `/fav alice` discloses your key to alice with **no dialog and no chance to decline** — and never records the acknowledgement, so the next star tap still re-asks. `FavoriteConsent` appeared 0× in CommandProcessor.

A slash command has no view to present the `confirmationDialog`, so the **add path** now requires an explicit `!confirm` token the first time:
- plain `/fav alice` on an unacknowledged state → returns the same localized disclosure the UI shows, plus the exact `/fav alice !confirm` line, and toggles nothing;
- `/fav alice !confirm` → records consent (shared flag, so the star UI stops re-asking) and proceeds.

Once acknowledged by either path, plain `/fav` favorites immediately. Removals stay ungated/immediate, matching the star UI. Reuses the existing `favorites.consent.message` key — no new strings, so the localization coverage test stays green.

Regression test drives the real `process("/fav alice")` path; I verified it fails without the gate (the ungated command toggles).

**Two follow-up commits since review.**

`0636f5d` replaces the token split @Chessing234 and Codex both objected to. The old parser tokenized the argument on spaces to find the flag, which honoured `!confirm` *anywhere* — so `/fav !confirm alice` counted as consent for alice — and collapsed runs of spaces in multi-word names. `!confirm` is now matched only as a trailing flag, with the rest of the line kept verbatim as the nickname.

`da70179` closes the case Codex actually raised, which my first reply had answered with the wrong variant. Their example is a peer literally *named* with the flag word at the end, and the trailing suffix was still stripped unconditionally — so for a peer named `alice !confirm`, the disclosure was skipped and, with a separate peer named `alice` present, consent was recorded against the wrong peer. **Exact name now wins:** if the whole trimmed argument already resolves to a peer, it stays the nickname and falls through to the disclosure. The worst outcome is one extra confirmation step, never an unintended disclosure. The re-issued hint reads `/fav alice !confirm !confirm`, which the suffix parse strips once. The flag comparison is also case-insensitive now, matching how `/pay` treats its own keyword; the nickname is untouched.

That scenario is now a regression test: against the previous head it fails exactly as described, favouriting the *other* peer and recording consent with no disclosure shown.

Targets `feat/favorites-consent` so it can fold into #1663 before merge.

