### PR TITLE
Cover the modal layer with a dedicated app-lock window (iOS)

### DIFF
--- a/bitchat/App/AppLockWindow.swift
+++ b/bitchat/App/AppLockWindow.swift
@@ -1,0 +1,69 @@
+//
+// AppLockWindow.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Hosts the app-lock gate in a dedicated `UIWindow` above the main window's
+/// entire presentation stack.
+///
+/// The gate is also rendered as a ZStack sibling of `ContentView` (see
+/// `BitchatApp`), which covers the cold-launch case with no flash. But a
+/// `.sheet` / `.fullScreenCover` presented from `ContentView` is a UIKit modal
+/// above the SwiftUI root, so the sibling cannot cover a modal that was open
+/// when the app went to the background and re-locked — settings (relay names,
+/// the panic-wipe button), the QR sheet, location channels, etc. would sit on
+/// top of the lock on return. A separate window at `.alert + 1` is the only
+/// surface guaranteed to sit above that modal layer.
+///
+/// Driven from SwiftUI by `AppLockModel.isLocked` so the model stays UIKit-free
+/// and testable; the window is created on the false→true transition (the
+/// background re-lock, the only time a modal can already be open) and torn down
+/// on unlock. Mirrors the window-lifecycle approach of `PrivacyScreen`.
+@MainActor
+final class AppLockWindow {
+    static let shared = AppLockWindow()
+
+    private var window: UIWindow?
+
+    private init() {}
+
+    /// Show or hide the lock window. `model` and `appTheme` are only read when
+    /// a window is created.
+    func setLocked(_ isLocked: Bool, model: AppLockModel, appTheme: AppTheme) {
+        if isLocked {
+            guard window == nil, let scene = Self.activeWindowScene() else { return }
+            let host = UIHostingController(
+                rootView: AppLockScreen(model: model)
+                    .environment(\.appTheme, appTheme)
+            )
+            let window = UIWindow(windowScene: scene)
+            // Above the main window's presented sheets/covers (which live at
+            // the normal level) and above system alerts.
+            window.windowLevel = UIWindow.Level(rawValue: UIWindow.Level.alert.rawValue + 1)
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+            self.window = window
+        } else {
+            window?.isHidden = true
+            window?.rootViewController = nil
+            window = nil
+        }
+    }
+
+    private static func activeWindowScene() -> UIWindowScene? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        ?? UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+    }
+}
+#endif

--- a/bitchat/App/AppLockWindow.swift
+++ b/bitchat/App/AppLockWindow.swift
@@ -11,21 +11,21 @@ import SwiftUI
 import UIKit
 
 /// Hosts the app-lock gate in a dedicated `UIWindow` above the main window's
-/// entire presentation stack.
+/// entire presentation stack. On iOS this is the gate's only host — macOS,
+/// which has no `UIWindow` path, keeps the ZStack sibling in `BitchatApp`.
 ///
-/// The gate is also rendered as a ZStack sibling of `ContentView` (see
-/// `BitchatApp`), which covers the cold-launch case with no flash. But a
-/// `.sheet` / `.fullScreenCover` presented from `ContentView` is a UIKit modal
-/// above the SwiftUI root, so the sibling cannot cover a modal that was open
-/// when the app went to the background and re-locked — settings (relay names,
-/// the panic-wipe button), the QR sheet, location channels, etc. would sit on
-/// top of the lock on return. A separate window at `.alert + 1` is the only
-/// surface guaranteed to sit above that modal layer.
+/// A `.sheet` / `.fullScreenCover` presented from `ContentView` is a UIKit
+/// modal above the SwiftUI root, so a gate drawn inside the SwiftUI tree
+/// cannot cover one — settings (relay names, the panic-wipe button), the QR
+/// sheet, location channels, etc. would sit on top of the lock. A separate
+/// window at `.alert + 1` is the only surface guaranteed to sit above that
+/// modal layer.
 ///
 /// Driven from SwiftUI by `AppLockModel.isLocked` so the model stays UIKit-free
-/// and testable; the window is created on the false→true transition (the
-/// background re-lock, the only time a modal can already be open) and torn down
-/// on unlock. Mirrors the window-lifecycle approach of `PrivacyScreen`.
+/// and testable; the window is created whenever the app is locked — including
+/// at launch, since tapping a private-message notification selects the
+/// conversation and presents the people sheet over the launch lock — and torn
+/// down on unlock. Mirrors the window-lifecycle approach of `PrivacyScreen`.
 @MainActor
 final class AppLockWindow {
     static let shared = AppLockWindow()

--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -65,11 +65,14 @@ struct BitchatApp: App {
                 }
                 #endif
 
-                // The gate renders above everything: with the lock engaged
-                // the timelines below must be neither readable nor tappable.
-                // iOS re-locks on background (below); macOS locks at launch
-                // only — its windows resign focus constantly, and the
-                // existing PrivacyScreen already covers window snapshots.
+                // Launch/underlay cover, drawn in the SwiftUI tree with no
+                // flash at cold launch (where no modal is ever open) and the
+                // sole lock surface on macOS. On iOS it does NOT cover a
+                // .sheet/.fullScreenCover that was open when the app
+                // backgrounded and re-locked — those are UIKit modals above
+                // the SwiftUI root — so a dedicated window handles that case
+                // (below). iOS re-locks on background; macOS locks at launch
+                // only, and PrivacyScreen already covers window snapshots.
                 if appLock.isLocked {
                     AppLockScreen(model: appLock)
                         .environment(\.appTheme, AppTheme(rawValue: appThemeRawValue) ?? .matrix)
@@ -80,6 +83,17 @@ struct BitchatApp: App {
                 if newPhase == .background {
                     appLock.lockIfEnabled()
                 }
+            }
+            // A dedicated window above the modal layer covers a sheet/cover
+            // that was open at background time. Fires on the false→true
+            // background re-lock (cold launch keeps the true value, so no
+            // window there — the sibling above suffices with no modal open).
+            .onChange(of: appLock.isLocked) { locked in
+                AppLockWindow.shared.setLocked(
+                    locked,
+                    model: appLock,
+                    appTheme: AppTheme(rawValue: appThemeRawValue) ?? .matrix
+                )
             }
             #endif
         }

--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -65,35 +65,41 @@ struct BitchatApp: App {
                 }
                 #endif
 
-                // Launch/underlay cover, drawn in the SwiftUI tree with no
-                // flash at cold launch (where no modal is ever open) and the
-                // sole lock surface on macOS. On iOS it does NOT cover a
-                // .sheet/.fullScreenCover that was open when the app
-                // backgrounded and re-locked — those are UIKit modals above
-                // the SwiftUI root — so a dedicated window handles that case
-                // (below). iOS re-locks on background; macOS locks at launch
-                // only, and PrivacyScreen already covers window snapshots.
+                // The macOS lock surface, and the only one there: no
+                // UIWindow path, and macOS locks at launch only, so no
+                // AppKit sheet is ever already open over it. On iOS the
+                // gate is hosted solely by AppLockWindow (below): a cover
+                // drawn here sits under the UIKit modal layer, so a
+                // .sheet/.fullScreenCover would show through it.
+                #if os(macOS)
                 if appLock.isLocked {
                     AppLockScreen(model: appLock)
                         .environment(\.appTheme, AppTheme(rawValue: appThemeRawValue) ?? .matrix)
                 }
+                #endif
             }
             #if os(iOS)
             .onChange(of: scenePhase) { newPhase in
                 if newPhase == .background {
                     appLock.lockIfEnabled()
                 }
+                // Retry: `setLocked` gives up when no window scene is
+                // connected yet, and since iOS no longer draws an in-tree
+                // cover, a creation missed at subscription time would leave
+                // the app ungated with nothing to trigger a second attempt.
+                // A scene is certainly connected by the time a phase change
+                // arrives. Reading the property is correct here — @Published
+                // fires in willSet, so only the closure below sees the new
+                // value early.
+                syncAppLockWindow(appLock.isLocked)
             }
-            // A dedicated window above the modal layer covers a sheet/cover
-            // that was open at background time. Fires on the false→true
-            // background re-lock (cold launch keeps the true value, so no
-            // window there — the sibling above suffices with no modal open).
-            .onChange(of: appLock.isLocked) { locked in
-                AppLockWindow.shared.setLocked(
-                    locked,
-                    model: appLock,
-                    appTheme: AppTheme(rawValue: appThemeRawValue) ?? .matrix
-                )
+            // The lock's only host on iOS: a dedicated window above the
+            // modal layer. Subscribed rather than .onChange so the launch
+            // value arrives too — a cold launch is already locked and never
+            // transitions, yet a notification tap can select a conversation
+            // and present a sheet over the lock.
+            .onReceive(appLock.$isLocked) { locked in
+                syncAppLockWindow(locked)
             }
             #endif
         }
@@ -102,6 +108,20 @@ struct BitchatApp: App {
         .windowResizability(.contentSize)
         #endif
     }
+
+    #if os(iOS)
+    /// Brings the lock window in line with `locked`. Idempotent: `setLocked`
+    /// no-ops when a window already exists, so the several places that call
+    /// this can overlap freely.
+    @MainActor
+    private func syncAppLockWindow(_ locked: Bool) {
+        AppLockWindow.shared.setLocked(
+            locked,
+            model: appLock,
+            appTheme: AppTheme(rawValue: appThemeRawValue) ?? .matrix
+        )
+    }
+    #endif
 }
 
 #if os(iOS)


### PR DESCRIPTION
Closes the sheet-over-lock gap from my review of #1664.

**The gap:** `AppLockScreen` renders as a ZStack sibling of `ContentView`, but the six `.sheet`/`.fullScreenCover` presentations are UIKit modals above the SwiftUI root. `lockIfEnabled()` only flips `isLocked` and dismisses nothing, and iOS doesn't dismiss modals on background — so a sheet open when the app backgrounds and re-locks sits **on top of the lock** on return. With settings open (`ContentView.swift:341`), that exposes hand-added relay hostnames and the panic-wipe button over a "locked" screen. The chat timelines (in `ContentView`) are covered; only the modal layer escapes.

**The fix (approach c from the review discussion):** a dedicated `UIWindow` at `.alert + 1` hosting `AppLockScreen`, above the main window's entire presentation stack. I rejected the two alternatives on evidence already in the tree:
- *dismiss-all in `lockIfEnabled()`* would have to reset `@State` local to `ContentView` and `ContentPeopleSheetView` that the `@MainActor` model can't reach, and destroys the user's in-progress modal on unlock;
- *a scene-root `.fullScreenCover`* conflicts with an already-presented child sheet — the exact "already presenting" collision the existing `ContentRootModalPresentationState` deferral machinery exists to avoid.

The window is driven from SwiftUI by `AppLockModel.isLocked` (model stays UIKit-free) and torn down on unlock. Mirrors `PrivacyScreen`'s window lifecycle.

**Follow-up commit `2fd1730` — the first version of this was wrong in two ways, both now fixed.**

It created the window only on the false→true background re-lock, on the stated assumption that no modal is ever open at a cold launch. That assumption is false, and Codex was right to flag it: `AppLockModel` starts locked from its initializer, so `onChange` never fires at launch, and nothing on the notification path consults the lock — a tapped private-message notification runs `handleNotificationResponse` → `startPrivateChat` and presents the people sheet *over* the launch lock. No termination is needed to reach it: enable the lock, cancel Face ID at launch, tap a message banner. The window is now driven from the published value, which delivers the launch state too.

It also hosted `AppLockScreen` in both the window and the ZStack, which @Chessing234 correctly called the wrong shape. On iOS the window is now the only host; macOS keeps the in-tree gate, having no `UIWindow` path and locking at launch only, so no AppKit sheet is ever already open over it. (The double *prompt* they worried about could not actually happen — `requestUnlock()` returns early while `isAuthenticating` — but the shared-model duplication was real and was the same root cause as the Codex finding.)

Dropping the in-tree cover made one previously harmless gap load-bearing: `setLocked` gives up when no window scene is connected, and with nothing to retry that would have left the app **ungated** rather than briefly flashing. It is now also re-synced on every scene-phase change, by which point a scene certainly exists. Both call sites are idempotent.

**Verification:** the z-order is not unit-testable — `bitchatTests` has no `UIWindowScene`, and the existing `AppLockModel` tests already show the model isn't where the bug was (`isLocked` flips fine; the view layer leaked). It **builds for the iOS simulator**. Two device checks that matter, neither of which I can automate: enable the lock, open Settings, background, foreground — the lock must be on top of the sheet; and at a cold launch with the lock on, the window must be up before the first frame rather than one frame after it.

The one red check here is `GossipSyncManagerTests.concurrentPacketIntakeAndSyncRequest`, which is an upstream timing flake unrelated to this diff — the interleaving and a one-line fix are written up in a comment below.

Targets `feat/app-lock` so it can fold into #1664 before merge.

