### PR TITLE
fix: accept Android-aged gift wraps; gate outer timestamps before decrypt

### DIFF
--- a/bitchat/Services/MessageDeduplicationService.swift
+++ b/bitchat/Services/MessageDeduplicationService.swift
@@ -171,10 +171,11 @@ final class MessageDeduplicationService {
     private let nostrAckCache: LRUDeduplicationCache<Bool>
 
     /// Optional cross-launch persistence for the Nostr event cache. BitChat
-    /// randomizes private-envelope timestamps, so DM subscriptions look back 24h and
-    /// relays redeliver the same events on every launch; without this record
-    /// each relaunch reprocesses old PMs and acks. Nil (tests, macOS callers
-    /// that don't opt in) keeps the cache purely in-memory.
+    /// and peer clients randomize private-envelope timestamps (up to ~48h
+    /// into the past on Android), so DM subscriptions look back across that
+    /// window and relays redeliver the same events on every launch; without
+    /// this record each relaunch reprocesses old PMs and acks. Nil (tests,
+    /// macOS callers that don't opt in) keeps the cache purely in-memory.
     private let nostrEventStore: NostrProcessedEventStore?
     private let nostrEventCapacity: Int
     private var persistScheduled = false

--- a/bitchat/Services/NostrProcessedEventStore.swift
+++ b/bitchat/Services/NostrProcessedEventStore.swift
@@ -10,8 +10,9 @@ import BitLogger
 import Foundation
 
 /// Disk persistence for processed private-envelope event IDs. BitChat
-/// randomizes envelope timestamps, so DM subscriptions must look back
-/// generously (24h)
+/// and peer clients randomize envelope timestamps (up to ~48h into the
+/// past on Android), so DM subscriptions must look back across that
+/// window
 /// and relays redeliver the same events on every launch — without a
 /// cross-launch record, each relaunch reprocesses old PMs and acks
 /// (re-sent DELIVERED bursts, "delivered ack for unknown mid" noise).

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -215,11 +215,16 @@ enum TransportConfig {
     static let nostrGeoRelayCount: Int = 5
     static let nostrGeohashSampleLookbackSeconds: TimeInterval = 300
     static let nostrGeohashSampleLimit: Int = 100
+    // Inner-rumor lookback: senders stamp the rumor with real send time.
     static let nostrDMSubscribeLookbackSeconds: TimeInterval = 86400
-    // Tolerated clock skew for the client-side rumor-timestamp window on
-    // inbound Nostr DMs (senders stamp the inner rumor with real time; only
-    // the outer gift wrap is randomized per NIP-17).
+    // Tolerated clock skew for client-side Nostr DM timestamp windows.
     static let nostrDMMaxClockSkewSeconds: TimeInterval = 900
+    // Outer gift-wrap age ceiling. Android (and NIP-17-style clients) may
+    // randomize the wrap's created_at up to 48h into the past; relays that
+    // honor `since` will not deliver those wraps under a 24h filter. The
+    // accept window is 48h plus skew so a wrap at the randomization floor
+    // still clears a mildly slow clock.
+    static let nostrGiftWrapMaxAgeSeconds: TimeInterval = 172_800 + 900
     // A sampled chat message this recent means "a conversation is happening
     // there" for the empty-timeline nearby-activity hint.
     static let uiGeohashChatActivityWindowSeconds: TimeInterval = 900

--- a/bitchat/ViewModels/GeohashSubscriptionManager.swift
+++ b/bitchat/ViewModels/GeohashSubscriptionManager.swift
@@ -164,7 +164,7 @@ final class GeohashSubscriptionManager {
             context.setGeoDmSubscriptionID(dmSub)
             let dmFilter = NostrFilter.giftWrapsFor(
                 pubkey: identity.publicKeyHex,
-                since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+                since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
             )
             NostrRelayManager.shared.subscribe(filter: dmFilter, id: dmSub) { [weak self] giftWrap in
                 Task { @MainActor [weak self] in
@@ -262,7 +262,7 @@ final class GeohashSubscriptionManager {
         }
         let dmFilter = NostrFilter.giftWrapsFor(
             pubkey: identity.publicKeyHex,
-            since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+            since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
         )
         NostrRelayManager.shared.subscribe(filter: dmFilter, id: dmSub) { [weak self] giftWrap in
             Task { @MainActor [weak self] in
@@ -390,7 +390,7 @@ final class GeohashSubscriptionManager {
 
         let filter = NostrFilter.giftWrapsFor(
             pubkey: currentIdentity.publicKeyHex,
-            since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+            since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
         )
 
         context.nostrRelayManager?.subscribe(filter: filter, id: "chat-messages") { [weak self] event in

--- a/bitchat/ViewModels/NostrInboundPipeline.swift
+++ b/bitchat/ViewModels/NostrInboundPipeline.swift
@@ -347,6 +347,16 @@ final class NostrInboundPipeline {
         }
         if alreadyProcessed { return }
 
+        // Cheap outer-wrap gate before the NIP-17 unwrap (two ECDH+ChaCha
+        // rounds). Android may stamp wraps up to 48h into the past; a
+        // future-dated wrap beyond skew is never legitimate for our clients.
+        guard Self.isAcceptableGiftWrapTimestamp(giftWrap.created_at) else {
+            if verbose {
+                SecureLogger.warning("GeoDM: dropping gift-wrap with implausible outer timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+            }
+            return
+        }
+
         guard let (content, senderPubkey, rumorTs) = try? NostrProtocol.decryptPrivateMessage(
             giftWrap: giftWrap,
             recipientIdentity: id
@@ -445,6 +455,11 @@ final class NostrInboundPipeline {
             (context.currentNostrIdentity(), self.wipeGeneration)
         }
         guard let currentIdentity else { return }
+
+        guard Self.isAcceptableGiftWrapTimestamp(giftWrap.created_at) else {
+            SecureLogger.warning("Dropping Nostr DM with implausible outer gift-wrap timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+            return
+        }
 
         do {
             let (content, senderPubkey, rumorTimestamp) = try NostrProtocol.decryptPrivateMessage(
@@ -567,6 +582,16 @@ extension NostrInboundPipeline {
         return age >= -TransportConfig.nostrDMMaxClockSkewSeconds
             && age <= TransportConfig.nostrDMSubscribeLookbackSeconds
                 + TransportConfig.nostrDMMaxClockSkewSeconds
+    }
+
+    /// Accept an outer gift-wrap `created_at` that is not in the far future
+    /// and not older than the 48h randomization ceiling plus skew. Checked
+    /// before decrypt so a hostile relay cannot force ECDH work with
+    /// ancient or far-future wraps.
+    static func isAcceptableGiftWrapTimestamp(_ createdAt: Int, now: Date = Date()) -> Bool {
+        let age = now.timeIntervalSince1970 - TimeInterval(createdAt)
+        return age >= -TransportConfig.nostrDMMaxClockSkewSeconds
+            && age <= TransportConfig.nostrGiftWrapMaxAgeSeconds
     }
 }
 

--- a/bitchatTests/NostrInboundPipelineTimestampTests.swift
+++ b/bitchatTests/NostrInboundPipelineTimestampTests.swift
@@ -15,6 +15,7 @@ struct NostrInboundPipelineTimestampTests {
     private let nowSeconds = 1_700_000_000
     private let skew = Int(TransportConfig.nostrDMMaxClockSkewSeconds)
     private let lookback = Int(TransportConfig.nostrDMSubscribeLookbackSeconds)
+    private let giftWrapMaxAge = Int(TransportConfig.nostrGiftWrapMaxAgeSeconds)
 
     @Test("Rumor timestamps inside the lookback-plus-skew window are accepted")
     func acceptsPlausibleTimestamps() {
@@ -28,5 +29,22 @@ struct NostrInboundPipelineTimestampTests {
     func rejectsImplausibleTimestamps() {
         #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds + skew + 60, now: now))
         #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds - lookback - skew - 60, now: now))
+    }
+
+    @Test("Outer gift wraps inside the 48h-plus-skew window are accepted")
+    func acceptsPlausibleGiftWrapTimestamps() {
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds, now: now))
+        // Android randomizes wraps up to 48h into the past.
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - 172_800 + 60, now: now))
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds + skew - 60, now: now))
+    }
+
+    @Test("Far-future and over-age outer gift wraps are rejected")
+    func rejectsImplausibleGiftWrapTimestamps() {
+        #expect(!NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds + skew + 60, now: now))
+        #expect(!NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - giftWrapMaxAge - 60, now: now))
+        // A wrap older than 24h but inside 48h+skew must still pass — that is
+        // the Android→iOS delivery gap this gate exists to keep open.
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - lookback - 3_600, now: now))
     }
 }


### PR DESCRIPTION
## Summary
- Android stamps outer Nostr gift wraps up to 48h into the past (`randomizeTimestampUpToPast`). iOS subscribed with a 24h `since` filter, so relays that honor `since` never delivered those DMs.
- Add `nostrGiftWrapMaxAgeSeconds` (48h + 15min skew) and use it for gift-wrap subscriptions (geo DM + account mailbox). Keep the inner rumor window at 24h + skew.
- Reject implausible outer `created_at` values *before* decrypt so a hostile relay cannot force ECDH work with ancient or far-future wraps.

## Test plan
- [x] Extended `NostrInboundPipelineTimestampTests` (accept 48h-old outer; reject far-future / over-age; rumor window unchanged)
- [x] Standalone `swiftc` assertions of the same policy math (no Xcode on this machine)
- [ ] CI Swift / iOS simulator suites

