### PR TITLE
fix: randomize seal/gift-wrap timestamps up to 48h into the past

### DIFF
--- a/bitchat/Nostr/NostrProtocol.swift
+++ b/bitchat/Nostr/NostrProtocol.swift
@@ -745,25 +745,23 @@ struct NostrProtocol {
         return sharedSecretData
     }
     
+    /// Randomized `created_at` for seals and gift wraps. Samples uniformly
+    /// from `[now − maxPast, now]` (never future) so relays cannot correlate
+    /// envelope timing with the true send time carried on the inner rumor.
+    /// Matches Android `NostrCrypto.randomizeTimestampUpToPast`. Internal so
+    /// tests can pin `now` / `maxPast`.
+    static func randomizedEnvelopeTimestamp(
+        now: Date = Date(),
+        maxPast: TimeInterval = TransportConfig.nostrGiftWrapTimestampRandomizationSeconds
+    ) -> Date {
+        let clampedPast = max(0, maxPast)
+        // Inclusive of both endpoints, matching Android's nextInt(maxPast+1).
+        let offsetSeconds = Int.random(in: 0...Int(clampedPast))
+        return now.addingTimeInterval(-TimeInterval(offsetSeconds))
+    }
+
     private static func randomizedTimestamp() -> Date {
-        // Add random offset to current time for privacy
-        // This prevents timing correlation attacks while the actual message timestamp
-        // is preserved in the encrypted rumor
-        let offset = TimeInterval.random(in: -900...900) // +/- 15 minutes
-        let now = Date()
-        let randomized = now.addingTimeInterval(offset)
-        
-        // Log with explicit UTC and local time for debugging
-        let formatter = DateFormatter()
-        //
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        formatter.timeZone = TimeZone(abbreviation: "UTC")
-        
-        formatter.timeZone = TimeZone.current
-        
-        // Timestamp randomized for privacy
-        
-        return randomized
+        randomizedEnvelopeTimestamp()
     }
 }
 

--- a/bitchat/Services/MessageDeduplicationService.swift
+++ b/bitchat/Services/MessageDeduplicationService.swift
@@ -171,10 +171,11 @@ final class MessageDeduplicationService {
     private let nostrAckCache: LRUDeduplicationCache<Bool>
 
     /// Optional cross-launch persistence for the Nostr event cache. BitChat
-    /// randomizes private-envelope timestamps, so DM subscriptions look back 24h and
-    /// relays redeliver the same events on every launch; without this record
-    /// each relaunch reprocesses old PMs and acks. Nil (tests, macOS callers
-    /// that don't opt in) keeps the cache purely in-memory.
+    /// and peer clients randomize private-envelope timestamps (up to ~48h
+    /// into the past on Android), so DM subscriptions look back across that
+    /// window and relays redeliver the same events on every launch; without
+    /// this record each relaunch reprocesses old PMs and acks. Nil (tests,
+    /// macOS callers that don't opt in) keeps the cache purely in-memory.
     private let nostrEventStore: NostrProcessedEventStore?
     private let nostrEventCapacity: Int
     private var persistScheduled = false

--- a/bitchat/Services/NostrProcessedEventStore.swift
+++ b/bitchat/Services/NostrProcessedEventStore.swift
@@ -10,8 +10,9 @@ import BitLogger
 import Foundation
 
 /// Disk persistence for processed private-envelope event IDs. BitChat
-/// randomizes envelope timestamps, so DM subscriptions must look back
-/// generously (24h)
+/// and peer clients randomize envelope timestamps (up to ~48h into the
+/// past on Android), so DM subscriptions must look back across that
+/// window
 /// and relays redeliver the same events on every launch — without a
 /// cross-launch record, each relaunch reprocesses old PMs and acks
 /// (re-sent DELIVERED bursts, "delivered ack for unknown mid" noise).

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -215,11 +215,16 @@ enum TransportConfig {
     static let nostrGeoRelayCount: Int = 5
     static let nostrGeohashSampleLookbackSeconds: TimeInterval = 300
     static let nostrGeohashSampleLimit: Int = 100
+    // Inner-rumor lookback: senders stamp the rumor with real send time.
     static let nostrDMSubscribeLookbackSeconds: TimeInterval = 86400
-    // Tolerated clock skew for the client-side rumor-timestamp window on
-    // inbound Nostr DMs (senders stamp the inner rumor with real time; only
-    // the outer gift wrap is randomized per NIP-17).
+    // Tolerated clock skew for client-side Nostr DM timestamp windows.
     static let nostrDMMaxClockSkewSeconds: TimeInterval = 900
+    // Outer gift-wrap age ceiling. Android (and NIP-17-style clients) may
+    // randomize the wrap's created_at up to 48h into the past; relays that
+    // honor `since` will not deliver those wraps under a 24h filter. The
+    // accept window is 48h plus skew so a wrap at the randomization floor
+    // still clears a mildly slow clock.
+    static let nostrGiftWrapMaxAgeSeconds: TimeInterval = 172_800 + 900
     // A sampled chat message this recent means "a conversation is happening
     // there" for the empty-timeline nearby-activity hint.
     static let uiGeohashChatActivityWindowSeconds: TimeInterval = 900

--- a/bitchat/Services/TransportConfig.swift
+++ b/bitchat/Services/TransportConfig.swift
@@ -219,12 +219,18 @@ enum TransportConfig {
     static let nostrDMSubscribeLookbackSeconds: TimeInterval = 86400
     // Tolerated clock skew for client-side Nostr DM timestamp windows.
     static let nostrDMMaxClockSkewSeconds: TimeInterval = 900
+    /// Outer gift-wrap / seal `created_at` randomization floor. Matches
+    /// Android `NostrCrypto.randomizeTimestampUpToPast` (up to 48h into the
+    /// past). The actual message time lives on the inner rumor.
+    static let nostrGiftWrapTimestampRandomizationSeconds: TimeInterval = 172_800
+
     // Outer gift-wrap age ceiling. Android (and NIP-17-style clients) may
     // randomize the wrap's created_at up to 48h into the past; relays that
     // honor `since` will not deliver those wraps under a 24h filter. The
     // accept window is 48h plus skew so a wrap at the randomization floor
     // still clears a mildly slow clock.
-    static let nostrGiftWrapMaxAgeSeconds: TimeInterval = 172_800 + 900
+    static let nostrGiftWrapMaxAgeSeconds: TimeInterval =
+        nostrGiftWrapTimestampRandomizationSeconds + nostrDMMaxClockSkewSeconds
     // A sampled chat message this recent means "a conversation is happening
     // there" for the empty-timeline nearby-activity hint.
     static let uiGeohashChatActivityWindowSeconds: TimeInterval = 900

--- a/bitchat/ViewModels/GeohashSubscriptionManager.swift
+++ b/bitchat/ViewModels/GeohashSubscriptionManager.swift
@@ -164,7 +164,7 @@ final class GeohashSubscriptionManager {
             context.setGeoDmSubscriptionID(dmSub)
             let dmFilter = NostrFilter.giftWrapsFor(
                 pubkey: identity.publicKeyHex,
-                since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+                since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
             )
             NostrRelayManager.shared.subscribe(filter: dmFilter, id: dmSub) { [weak self] giftWrap in
                 Task { @MainActor [weak self] in
@@ -262,7 +262,7 @@ final class GeohashSubscriptionManager {
         }
         let dmFilter = NostrFilter.giftWrapsFor(
             pubkey: identity.publicKeyHex,
-            since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+            since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
         )
         NostrRelayManager.shared.subscribe(filter: dmFilter, id: dmSub) { [weak self] giftWrap in
             Task { @MainActor [weak self] in
@@ -390,7 +390,7 @@ final class GeohashSubscriptionManager {
 
         let filter = NostrFilter.giftWrapsFor(
             pubkey: currentIdentity.publicKeyHex,
-            since: Date().addingTimeInterval(-TransportConfig.nostrDMSubscribeLookbackSeconds)
+            since: Date().addingTimeInterval(-TransportConfig.nostrGiftWrapMaxAgeSeconds)
         )
 
         context.nostrRelayManager?.subscribe(filter: filter, id: "chat-messages") { [weak self] event in

--- a/bitchat/ViewModels/NostrInboundPipeline.swift
+++ b/bitchat/ViewModels/NostrInboundPipeline.swift
@@ -347,6 +347,16 @@ final class NostrInboundPipeline {
         }
         if alreadyProcessed { return }
 
+        // Cheap outer-wrap gate before the NIP-17 unwrap (two ECDH+ChaCha
+        // rounds). Android may stamp wraps up to 48h into the past; a
+        // future-dated wrap beyond skew is never legitimate for our clients.
+        guard Self.isAcceptableGiftWrapTimestamp(giftWrap.created_at) else {
+            if verbose {
+                SecureLogger.warning("GeoDM: dropping gift-wrap with implausible outer timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+            }
+            return
+        }
+
         guard let (content, senderPubkey, rumorTs) = try? NostrProtocol.decryptPrivateMessage(
             giftWrap: giftWrap,
             recipientIdentity: id
@@ -445,6 +455,11 @@ final class NostrInboundPipeline {
             (context.currentNostrIdentity(), self.wipeGeneration)
         }
         guard let currentIdentity else { return }
+
+        guard Self.isAcceptableGiftWrapTimestamp(giftWrap.created_at) else {
+            SecureLogger.warning("Dropping Nostr DM with implausible outer gift-wrap timestamp id=\(giftWrap.id.prefix(8))…", category: .session)
+            return
+        }
 
         do {
             let (content, senderPubkey, rumorTimestamp) = try NostrProtocol.decryptPrivateMessage(
@@ -567,6 +582,16 @@ extension NostrInboundPipeline {
         return age >= -TransportConfig.nostrDMMaxClockSkewSeconds
             && age <= TransportConfig.nostrDMSubscribeLookbackSeconds
                 + TransportConfig.nostrDMMaxClockSkewSeconds
+    }
+
+    /// Accept an outer gift-wrap `created_at` that is not in the far future
+    /// and not older than the 48h randomization ceiling plus skew. Checked
+    /// before decrypt so a hostile relay cannot force ECDH work with
+    /// ancient or far-future wraps.
+    static func isAcceptableGiftWrapTimestamp(_ createdAt: Int, now: Date = Date()) -> Bool {
+        let age = now.timeIntervalSince1970 - TimeInterval(createdAt)
+        return age >= -TransportConfig.nostrDMMaxClockSkewSeconds
+            && age <= TransportConfig.nostrGiftWrapMaxAgeSeconds
     }
 }
 

--- a/bitchatTests/NostrInboundPipelineTimestampTests.swift
+++ b/bitchatTests/NostrInboundPipelineTimestampTests.swift
@@ -15,6 +15,7 @@ struct NostrInboundPipelineTimestampTests {
     private let nowSeconds = 1_700_000_000
     private let skew = Int(TransportConfig.nostrDMMaxClockSkewSeconds)
     private let lookback = Int(TransportConfig.nostrDMSubscribeLookbackSeconds)
+    private let giftWrapMaxAge = Int(TransportConfig.nostrGiftWrapMaxAgeSeconds)
 
     @Test("Rumor timestamps inside the lookback-plus-skew window are accepted")
     func acceptsPlausibleTimestamps() {
@@ -28,5 +29,22 @@ struct NostrInboundPipelineTimestampTests {
     func rejectsImplausibleTimestamps() {
         #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds + skew + 60, now: now))
         #expect(!NostrInboundPipeline.isPlausibleRumorTimestamp(nowSeconds - lookback - skew - 60, now: now))
+    }
+
+    @Test("Outer gift wraps inside the 48h-plus-skew window are accepted")
+    func acceptsPlausibleGiftWrapTimestamps() {
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds, now: now))
+        // Android randomizes wraps up to 48h into the past.
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - 172_800 + 60, now: now))
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds + skew - 60, now: now))
+    }
+
+    @Test("Far-future and over-age outer gift wraps are rejected")
+    func rejectsImplausibleGiftWrapTimestamps() {
+        #expect(!NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds + skew + 60, now: now))
+        #expect(!NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - giftWrapMaxAge - 60, now: now))
+        // A wrap older than 24h but inside 48h+skew must still pass — that is
+        // the Android→iOS delivery gap this gate exists to keep open.
+        #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - lookback - 3_600, now: now))
     }
 }

--- a/bitchatTests/NostrInboundPipelineTimestampTests.swift
+++ b/bitchatTests/NostrInboundPipelineTimestampTests.swift
@@ -48,3 +48,20 @@ struct NostrInboundPipelineTimestampTests {
         #expect(NostrInboundPipeline.isAcceptableGiftWrapTimestamp(nowSeconds - lookback - 3_600, now: now))
     }
 }
+
+struct NostrEnvelopeTimestampRandomizationTests {
+    @Test("Envelope timestamps stay in [now-maxPast, now] and never go future")
+    func samplesPastOnlyWindow() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let maxPast: TimeInterval = 172_800
+        for _ in 0..<200 {
+            let ts = NostrProtocol.randomizedEnvelopeTimestamp(now: now, maxPast: maxPast)
+            #expect(ts <= now)
+            #expect(ts >= now.addingTimeInterval(-maxPast))
+        }
+        // Zero past collapses to exactly now.
+        #expect(NostrProtocol.randomizedEnvelopeTimestamp(now: now, maxPast: 0) == now)
+        // Negative past is treated as zero.
+        #expect(NostrProtocol.randomizedEnvelopeTimestamp(now: now, maxPast: -10) == now)
+    }
+}


### PR DESCRIPTION
## Summary
- iOS stamped seal and gift-wrap `created_at` with a ±15 minute jitter around now.
- Android samples uniformly from the past 48 hours (`randomizeTimestampUpToPast`), which is what the wider gift-wrap subscription window exists for.
- Match that past-only distribution so iOS envelopes get the same timing-correlation resistance.

Stacked on #1706 (receive-path lookback + outer timestamp gate). That lookback is required once iOS starts emitting wraps older than 24h; if #1706 merges first, rebase drops the shared commit cleanly.

## Test plan
- [x] `NostrEnvelopeTimestampRandomizationTests` — 200 samples stay in `[now−48h, now]`; zero/negative maxPast collapse to `now`
- [x] Standalone `swiftc` assertions of the same sampler
- [ ] CI Swift / iOS simulator suites

