### PR TITLE
Bind a trust seal to the nickname it was earned under

### DIFF
--- a/bitchat/App/ConversationUIModel.swift
+++ b/bitchat/App/ConversationUIModel.swift
@@ -164,10 +164,12 @@ final class ConversationUIModel: ObservableObject {
               !isSentByCurrentUser(message),
               let peerID = message.senderPeerID else { return false }
         guard let fingerprint = chatViewModel.getFingerprint(for: peerID) else { return false }
-        guard chatViewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
-        // A verified key that renamed itself onto a name the user trusts must
-        // not carry the seal beside the new one.
-        return !chatViewModel.trustedNicknameMismatch(fingerprint)
+        // The row renders `message.sender`, frozen at receipt, so the question
+        // is whether THAT name is the one this key was verified under — not
+        // whether its current name is. Checking the current name would let a
+        // rename away, a post, and a rename back put a seal beside a name the
+        // key was never trusted under. One call, one lock.
+        return chatViewModel.sealAppliesToRow(fingerprint, renderedSender: message.sender)
     }
 
     func senderDisplayName(for peerID: PeerID, fallbackMessages: [BitchatMessage]) -> String? {

--- a/bitchat/App/ConversationUIModel.swift
+++ b/bitchat/App/ConversationUIModel.swift
@@ -164,7 +164,11 @@ final class ConversationUIModel: ObservableObject {
               !isSentByCurrentUser(message),
               let peerID = message.senderPeerID else { return false }
         guard let fingerprint = chatViewModel.getFingerprint(for: peerID) else { return false }
-        return chatViewModel.peerIdentityStore.isVerified(fingerprint)
+        guard chatViewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
+        // The seal is read next to `message.sender`, so it has to be bound to
+        // that name: a verified key that renamed itself onto a name the user
+        // trusts must not carry the seal beside the new one.
+        return !chatViewModel.trustedNicknameMismatch(fingerprint, displayedSender: message.sender)
     }
 
     func senderDisplayName(for peerID: PeerID, fallbackMessages: [BitchatMessage]) -> String? {

--- a/bitchat/App/ConversationUIModel.swift
+++ b/bitchat/App/ConversationUIModel.swift
@@ -165,10 +165,9 @@ final class ConversationUIModel: ObservableObject {
               let peerID = message.senderPeerID else { return false }
         guard let fingerprint = chatViewModel.getFingerprint(for: peerID) else { return false }
         guard chatViewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
-        // The seal is read next to `message.sender`, so it has to be bound to
-        // that name: a verified key that renamed itself onto a name the user
-        // trusts must not carry the seal beside the new one.
-        return !chatViewModel.trustedNicknameMismatch(fingerprint, displayedSender: message.sender)
+        // A verified key that renamed itself onto a name the user trusts must
+        // not carry the seal beside the new one.
+        return !chatViewModel.trustedNicknameMismatch(fingerprint)
     }
 
     func senderDisplayName(for peerID: PeerID, fallbackMessages: [BitchatMessage]) -> String? {

--- a/bitchat/App/PeerListModel.swift
+++ b/bitchat/App/PeerListModel.swift
@@ -232,9 +232,18 @@ final class PeerListModel: ObservableObject {
             let isMe = peer.peerID == myPeerID
             let fingerprint = isMe ? nil : chatViewModel.getFingerprint(for: peer.peerID)
             let isVerifiedFingerprint = fingerprint.map { peerIdentityStore.isVerified($0) } ?? false
-            let verifiedBadge = !peer.isConnected && isVerifiedFingerprint
+            // A seal is bound to the name it was earned under. Without that,
+            // a key that earned one vouch as "ravi" can rename itself to
+            // "medic" and keep rendering the seal beside the new name. A local
+            // petname already outranks the claimed nickname for display, so
+            // there is nothing to spoof and the seal stands.
+            let hasPetname = !(peer.localPetname ?? "").isEmpty
+            let renamedSinceTrust = !hasPetname && (fingerprint.map {
+                chatViewModel.trustedNicknameMismatch($0, claimedNickname: peer.nickname)
+            } ?? false)
+            let verifiedBadge = !peer.isConnected && isVerifiedFingerprint && !renamedSinceTrust
             // Vouched is subordinate to verified: never show both seals.
-            let vouchedBadge = !isVerifiedFingerprint
+            let vouchedBadge = !isVerifiedFingerprint && !renamedSinceTrust
                 && (fingerprint.map { chatViewModel.isVouchedFingerprint($0) } ?? false)
 
             return MeshPeerRow(

--- a/bitchat/App/PeerListModel.swift
+++ b/bitchat/App/PeerListModel.swift
@@ -234,13 +234,15 @@ final class PeerListModel: ObservableObject {
             let isVerifiedFingerprint = fingerprint.map { peerIdentityStore.isVerified($0) } ?? false
             // A seal is bound to the name it was earned under. Without that,
             // a key that earned one vouch as "ravi" can rename itself to
-            // "medic" and keep rendering the seal beside the new name. A local
-            // petname already outranks the claimed nickname for display, so
-            // there is nothing to spoof and the seal stands.
-            let hasPetname = !(peer.localPetname ?? "").isEmpty
-            let renamedSinceTrust = !hasPetname && (fingerprint.map {
-                chatViewModel.trustedNicknameMismatch($0, claimedNickname: peer.nickname)
-            } ?? false)
+            // "medic" and keep rendering the seal beside the new name. The
+            // check compares announced names, NOT `peer.nickname`, which is
+            // already collision-resolved: two connected peers both claiming
+            // "medic" are rendered "medic#a1b2" and "medic#c3d4", so comparing
+            // the displayed string would drop the real medic's seal during the
+            // very attack this defends against. Petnames are handled there too.
+            let renamedSinceTrust = fingerprint.map {
+                chatViewModel.trustedNicknameMismatch($0)
+            } ?? false
             let verifiedBadge = !peer.isConnected && isVerifiedFingerprint && !renamedSinceTrust
             // Vouched is subordinate to verified: never show both seals.
             let vouchedBadge = !isVerifiedFingerprint && !renamedSinceTrust

--- a/bitchat/App/VerificationModel.swift
+++ b/bitchat/App/VerificationModel.swift
@@ -16,6 +16,15 @@ struct FingerprintPresentationState: Equatable {
     let voucherCount: Int
     /// Display names of the (verified) vouchers, where known.
     let voucherNames: [String]
+    /// The nickname this key was announcing when it was verified or first
+    /// vouched, if anything was bound. Non-nil and different from the name on
+    /// screen is what `nameChangedSinceVerification` reports.
+    let verifiedAsNickname: String?
+    /// The key is trusted, but it now announces a different name than when
+    /// that trust was established. The sheet is the one place this should be
+    /// explained rather than collapsed into a glyph, so it is surfaced here
+    /// instead of silently suppressing the badge.
+    let nameChangedSinceVerification: Bool
 
     /// Vouched for by ≥1 peer the user verified (and not explicitly verified).
     var isVouched: Bool { voucherCount > 0 }
@@ -136,6 +145,13 @@ final class VerificationModel: ObservableObject {
         let isVerified = theirFingerprint.map { peerIdentityStore.isVerified($0) } ?? false
         let localPetname = theirFingerprint
             .flatMap { chatViewModel.identityManager.getSocialIdentity(for: $0)?.localPetname }
+        // A vouched seal is bound to the name it was earned under, exactly like
+        // the verified one. Missing baseline means nothing was bound, so this
+        // fails open like every other site.
+        let nameBound = theirFingerprint
+            .map { !chatViewModel.identityManager.trustedNicknameMismatch(fingerprint: $0) } ?? true
+        let verifiedAsNickname = theirFingerprint
+            .flatMap { chatViewModel.identityManager.trustedNickname(fingerprint: $0) }
 
         // Vouch state is recomputed on read: only vouchers still in the
         // verified set count, so removing a verification silently retires the
@@ -161,8 +177,12 @@ final class VerificationModel: ObservableObject {
             myFingerprint: chatViewModel.getMyFingerprint(),
             isVerified: isVerified,
             localPetname: localPetname,
-            voucherCount: vouchers.count,
-            voucherNames: voucherNames
+            // Suppressed together: a voucher list beside a name nobody
+            // vouched for is the same claim as the seal itself.
+            voucherCount: nameBound ? vouchers.count : 0,
+            voucherNames: nameBound ? voucherNames : [],
+            verifiedAsNickname: verifiedAsNickname,
+            nameChangedSinceVerification: !nameBound
         )
     }
 

--- a/bitchat/Identity/IdentityModels.swift
+++ b/bitchat/Identity/IdentityModels.swift
@@ -202,6 +202,15 @@ struct IdentityCache: Codable {
     // entries verified before this field exists sort as oldest)
     var verifiedAt: [String: Date]? = nil
 
+    /// The self-claimed nickname each fingerprint was presenting at the moment
+    /// trust in it was established here — set on verification and on a first
+    /// accepted vouch. A trust badge means "this key was the Medic I checked",
+    /// so it has to be pinned to the name it was earned under; without this
+    /// baseline a vouched key can rename itself onto a name the user trusts and
+    /// keep rendering the seal beside it. Absent for peers trusted by older
+    /// builds, which is why a missing entry never suppresses a badge.
+    var trustedNicknames: [String: String]? = nil
+
     // Stable Noise fingerprints that proved encrypted private-media support
     // inside an authenticated Noise session. Optional for decoding caches
     // written before this migration. Entries are monotonic until a panic wipe
@@ -240,6 +249,7 @@ struct IdentityCache: Codable {
         vouchesByVouchee = try container.decodeIfPresent([String: [VouchRecord]].self, forKey: .vouchesByVouchee)
         vouchBatchSentAt = try container.decodeIfPresent([String: Date].self, forKey: .vouchBatchSentAt)
         verifiedAt = try container.decodeIfPresent([String: Date].self, forKey: .verifiedAt)
+        trustedNicknames = try container.decodeIfPresent([String: String].self, forKey: .trustedNicknames)
         privateMediaCapableFingerprints = try container.decodeIfPresent(Set<String>.self, forKey: .privateMediaCapableFingerprints)
         authenticatedSigningKeysByFingerprint = try container.decodeIfPresent([String: Data].self, forKey: .authenticatedSigningKeysByFingerprint)
         cryptographicIdentities = try container.decodeIfPresent([String: CryptographicIdentity].self, forKey: .cryptographicIdentities) ?? [:]

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -130,6 +130,9 @@ protocol SecureIdentityStateManagerProtocol {
     func setVerified(fingerprint: String, verified: Bool)
     func isVerified(fingerprint: String) -> Bool
     func getVerifiedFingerprints() -> Set<String>
+    /// Whether this peer is now claiming a different nickname than the one its
+    /// trust was earned under.
+    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool
 
     // MARK: Vouching (transitive verification)
     @discardableResult
@@ -148,6 +151,17 @@ protocol SecureIdentityStateManagerProtocol {
     // MARK: Private-media downgrade protection
     func markPrivateMediaCapable(fingerprint: String)
     func hasObservedPrivateMediaCapability(fingerprint: String) -> Bool
+}
+
+extension SecureIdentityStateManagerProtocol {
+    /// `trustedNicknameMismatch` for a name as *rendered* in a message row,
+    /// which may carry a `#abcd` disambiguation suffix that an announced
+    /// nickname never has. Comparing the displayed string verbatim would read
+    /// every suffixed sender as a mismatch.
+    func trustedNicknameMismatch(fingerprint: String, displayedSender: String) -> Bool {
+        trustedNicknameMismatch(fingerprint: fingerprint,
+                                claimedNickname: displayedSender.splitSuffix().0)
+    }
 }
 
 /// Singleton manager for secure identity state persistence and retrieval.
@@ -428,6 +442,15 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                 } else if self.cache.socialIdentities[fingerprint] == nil {
                     self.cache.socialIdentities[fingerprint] = identity
                 }
+                // A vouch usually arrives for a peer we have not seen announce
+                // — it comes over Noise from someone else, and the vouchee may
+                // be several hops away. There was no name to bind to then, so
+                // bind on the first announce we see while the trust stands.
+                self.pinTrustedNicknameLocked(
+                    fingerprint: fingerprint,
+                    overwrite: false,
+                    requireExistingTrust: true
+                )
             }
 
             self.saveIdentityCache()
@@ -678,9 +701,15 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
                 var verifiedAt = self.cache.verifiedAt ?? [:]
                 verifiedAt[fingerprint] = Date()
                 self.cache.verifiedAt = verifiedAt
+                // Re-verifying overwrites the baseline: the user just checked
+                // this key again, under whatever name it presents now.
+                self.pinTrustedNicknameLocked(fingerprint: fingerprint, overwrite: true)
             } else {
                 self.cache.verifiedFingerprints.remove(fingerprint)
                 self.cache.verifiedAt?.removeValue(forKey: fingerprint)
+                if self.cache.vouchesByVouchee?[fingerprint]?.isEmpty ?? true {
+                    self.cache.trustedNicknames?.removeValue(forKey: fingerprint)
+                }
             }
 
             // Update trust level if social identity exists
@@ -696,6 +725,52 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     func isVerified(fingerprint: String) -> Bool {
         queue.sync {
             return cache.verifiedFingerprints.contains(fingerprint)
+        }
+    }
+
+    // MARK: - Nickname binding
+    //
+    // A vouch signs `voucheeFingerprint | voucheeSigningKey | timestampMs` and
+    // deliberately says nothing about a name — the attestation is right to stay
+    // name-free. But the badge is *rendered* next to a self-claimed nickname,
+    // so the binding has to exist somewhere, and the receiver is the only party
+    // that can hold it: it is the one that decided to trust this key while it
+    // was presenting a particular name.
+
+    /// Requires `queue`. Records the peer's currently claimed nickname as the
+    /// name its trust is bound to. Empty nicknames are not pinned — a key
+    /// verified before its first announce has no name to bind to, and pinning
+    /// "" would then read as a mismatch against every later announce.
+    ///
+    /// `requireExistingTrust` is for the announce path, which runs for every
+    /// peer: pinning a name before there is any trust would bind the badge to
+    /// whatever name we happened to see first, so a peer who renamed *before*
+    /// being vouched would have its legitimate badge suppressed.
+    private func pinTrustedNicknameLocked(fingerprint: String,
+                                          overwrite: Bool,
+                                          requireExistingTrust: Bool = false) {
+        if requireExistingTrust {
+            let trusted = cache.verifiedFingerprints.contains(fingerprint)
+                || !(cache.vouchesByVouchee?[fingerprint] ?? []).isEmpty
+            guard trusted else { return }
+        }
+        guard let claimed = cache.socialIdentities[fingerprint]?.claimedNickname,
+              !claimed.isEmpty else { return }
+        var pinned = cache.trustedNicknames ?? [:]
+        if !overwrite, pinned[fingerprint] != nil { return }
+        pinned[fingerprint] = claimed
+        cache.trustedNicknames = pinned
+    }
+
+    /// True only when a baseline exists AND the peer now claims something else.
+    /// Fails OPEN on a missing baseline on purpose: peers trusted by builds
+    /// before this existed have none, and dropping their badges on upgrade
+    /// would train users to ignore the signal.
+    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool {
+        queue.sync {
+            guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty,
+                  !claimedNickname.isEmpty else { return false }
+            return pinned != claimedNickname
         }
     }
     
@@ -760,6 +835,10 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
             var vouches = self.cache.vouchesByVouchee ?? [:]
             vouches[voucheeFingerprint] = capped
             self.cache.vouchesByVouchee = vouches
+            // Pin on the FIRST vouch only. A later vouch for the same key must
+            // not move the baseline, or an attacker could rename and then have
+            // a second voucher silently re-anchor the badge to the new name.
+            self.pinTrustedNicknameLocked(fingerprint: voucheeFingerprint, overwrite: false)
             self.saveIdentityCache()
             return true
         }

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -179,7 +179,7 @@ extension SecureIdentityStateManagerProtocol {
         else { return true }
         let shown = renderedSender.withoutCollisionSuffix
         guard !shown.isEmpty else { return true }
-        return pinned.normalizedNickname == shown.normalizedNickname
+        return pinned.nicknameBindingKey == shown.nicknameBindingKey
     }
 }
 
@@ -826,7 +826,7 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
             // stand between the reader and a spoofed name on this row.
             let shown = renderedSender.withoutCollisionSuffix
             guard !shown.isEmpty else { return true }
-            return pinned.normalizedNickname == shown.normalizedNickname
+            return pinned.nicknameBindingKey == shown.nicknameBindingKey
         }
     }
 
@@ -839,9 +839,9 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
         // is displayed, so there is nothing to spoof and the seal stands.
         if let petname = social?.localPetname, !petname.isEmpty { return false }
         guard let claimed = social?.claimedNickname, !claimed.isEmpty else { return false }
-        // NFC, matching `normalizedNickname` everywhere else nicknames are
-        // compared: a decomposed and a precomposed "café" are one name.
-        return pinned.normalizedNickname != claimed.normalizedNickname
+        // See `nicknameBindingKey`: NFC plus case, so a decomposed and a
+        // precomposed "café" are one name and recasing is not a rename.
+        return pinned.nicknameBindingKey != claimed.nicknameBindingKey
     }
     
     func getVerifiedFingerprints() -> Set<String> {

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -130,9 +130,19 @@ protocol SecureIdentityStateManagerProtocol {
     func setVerified(fingerprint: String, verified: Bool)
     func isVerified(fingerprint: String) -> Bool
     func getVerifiedFingerprints() -> Set<String>
+    /// The nickname `fingerprint` was announcing when trust in it was
+    /// established, or nil if nothing was bound. Shown to the user, so a sheet
+    /// can say *which* name was verified rather than only that one changed.
+    func trustedNickname(fingerprint: String) -> String?
     /// Whether this peer now announces a different nickname than the one its
     /// trust was earned under.
     func trustedNicknameMismatch(fingerprint: String) -> Bool
+    /// Verified AND still presenting the name it was verified under — what a
+    /// seal beside a LIVE name is actually asserting. One lock, not two.
+    func isVerifiedAndNameBound(fingerprint: String) -> Bool
+    /// Verified AND `renderedSender` is the name it was verified under — what
+    /// a seal beside a name frozen on a message row is asserting.
+    func sealAppliesToRow(fingerprint: String, renderedSender: String) -> Bool
 
     // MARK: Vouching (transitive verification)
     @discardableResult
@@ -151,6 +161,26 @@ protocol SecureIdentityStateManagerProtocol {
     // MARK: Private-media downgrade protection
     func markPrivateMediaCapable(fingerprint: String)
     func hasObservedPrivateMediaCapability(fingerprint: String) -> Bool
+}
+
+extension SecureIdentityStateManagerProtocol {
+    // Default implementations so a conformance only has to provide the two
+    // primitives. `SecureIdentityStateManager` overrides both to answer in a
+    // single lock acquisition — these seal checks run per row, per render, and
+    // the format cache does not shield the one in ChatMessageFormatter because
+    // the answer is part of its cache key.
+    func isVerifiedAndNameBound(fingerprint: String) -> Bool {
+        isVerified(fingerprint: fingerprint) && !trustedNicknameMismatch(fingerprint: fingerprint)
+    }
+
+    func sealAppliesToRow(fingerprint: String, renderedSender: String) -> Bool {
+        guard isVerified(fingerprint: fingerprint) else { return false }
+        guard let pinned = trustedNickname(fingerprint: fingerprint), !pinned.isEmpty
+        else { return true }
+        let shown = renderedSender.withoutCollisionSuffix
+        guard !shown.isEmpty else { return true }
+        return pinned.normalizedNickname == shown.normalizedNickname
+    }
 }
 
 /// Singleton manager for secure identity state persistence and retrieval.
@@ -765,18 +795,53 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
     /// before this existed have none, and dropping their seals on upgrade would
     /// train users to ignore the signal.
     func trustedNicknameMismatch(fingerprint: String) -> Bool {
+        queue.sync { liveNameMismatchLocked(fingerprint) }
+    }
+
+    func trustedNickname(fingerprint: String) -> String? {
+        queue.sync { cache.trustedNicknames?[fingerprint] }
+    }
+
+    func isVerifiedAndNameBound(fingerprint: String) -> Bool {
         queue.sync {
-            guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty
-            else { return false }
-            let social = cache.socialIdentities[fingerprint]
-            // A local petname outranks the claimed nickname everywhere it is
-            // displayed, so there is nothing to spoof and the seal stands.
-            if let petname = social?.localPetname, !petname.isEmpty { return false }
-            guard let claimed = social?.claimedNickname, !claimed.isEmpty else { return false }
-            // NFC, matching `normalizedNickname` everywhere else nicknames are
-            // compared: a decomposed and a precomposed "café" are one name.
-            return pinned.normalizedNickname != claimed.normalizedNickname
+            guard cache.verifiedFingerprints.contains(fingerprint) else { return false }
+            return !liveNameMismatchLocked(fingerprint)
         }
+    }
+
+    /// A message row shows the sender name frozen at receipt, so asking about
+    /// the peer's CURRENT name is the wrong question: rename away, post, rename
+    /// back, and the live name matches the baseline again while the archived row
+    /// still reads the name it was posted under. Each row is therefore checked
+    /// against its own name, which also makes every row self-consistent — a
+    /// historical "ravi ✓" stays sealed even while that key is currently
+    /// renamed, because that row really was ravi.
+    func sealAppliesToRow(fingerprint: String, renderedSender: String) -> Bool {
+        queue.sync {
+            guard cache.verifiedFingerprints.contains(fingerprint) else { return false }
+            guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty
+            else { return true }                                  // nothing bound: fail open
+            // No petname escape here, unlike the live check: the formatter
+            // renders `message.sender`, never a petname, so a petname does not
+            // stand between the reader and a spoofed name on this row.
+            let shown = renderedSender.withoutCollisionSuffix
+            guard !shown.isEmpty else { return true }
+            return pinned.normalizedNickname == shown.normalizedNickname
+        }
+    }
+
+    /// Requires `queue`.
+    private func liveNameMismatchLocked(_ fingerprint: String) -> Bool {
+        guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty
+        else { return false }
+        let social = cache.socialIdentities[fingerprint]
+        // A local petname outranks the claimed nickname everywhere a LIVE name
+        // is displayed, so there is nothing to spoof and the seal stands.
+        if let petname = social?.localPetname, !petname.isEmpty { return false }
+        guard let claimed = social?.claimedNickname, !claimed.isEmpty else { return false }
+        // NFC, matching `normalizedNickname` everywhere else nicknames are
+        // compared: a decomposed and a precomposed "café" are one name.
+        return pinned.normalizedNickname != claimed.normalizedNickname
     }
     
     func getVerifiedFingerprints() -> Set<String> {

--- a/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat/Identity/SecureIdentityStateManager.swift
@@ -130,9 +130,9 @@ protocol SecureIdentityStateManagerProtocol {
     func setVerified(fingerprint: String, verified: Bool)
     func isVerified(fingerprint: String) -> Bool
     func getVerifiedFingerprints() -> Set<String>
-    /// Whether this peer is now claiming a different nickname than the one its
+    /// Whether this peer now announces a different nickname than the one its
     /// trust was earned under.
-    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool
+    func trustedNicknameMismatch(fingerprint: String) -> Bool
 
     // MARK: Vouching (transitive verification)
     @discardableResult
@@ -151,17 +151,6 @@ protocol SecureIdentityStateManagerProtocol {
     // MARK: Private-media downgrade protection
     func markPrivateMediaCapable(fingerprint: String)
     func hasObservedPrivateMediaCapability(fingerprint: String) -> Bool
-}
-
-extension SecureIdentityStateManagerProtocol {
-    /// `trustedNicknameMismatch` for a name as *rendered* in a message row,
-    /// which may carry a `#abcd` disambiguation suffix that an announced
-    /// nickname never has. Comparing the displayed string verbatim would read
-    /// every suffixed sender as a mismatch.
-    func trustedNicknameMismatch(fingerprint: String, displayedSender: String) -> Bool {
-        trustedNicknameMismatch(fingerprint: fingerprint,
-                                claimedNickname: displayedSender.splitSuffix().0)
-    }
 }
 
 /// Singleton manager for secure identity state persistence and retrieval.
@@ -762,15 +751,31 @@ final class SecureIdentityStateManager: SecureIdentityStateManagerProtocol {
         cache.trustedNicknames = pinned
     }
 
-    /// True only when a baseline exists AND the peer now claims something else.
+    /// True only when a baseline exists AND the peer now announces something
+    /// else.
+    ///
+    /// Deliberately compares announced name to announced name rather than to
+    /// anything on screen. Display strings are decorated: `PeerDisplayNameResolver`
+    /// appends `#abcd` to CONNECTED peers whose nicknames collide — which is
+    /// precisely what happens during this attack — so comparing a rendered name
+    /// would suppress the seal of the peer being impersonated, exactly when it
+    /// matters most.
+    ///
     /// Fails OPEN on a missing baseline on purpose: peers trusted by builds
-    /// before this existed have none, and dropping their badges on upgrade
-    /// would train users to ignore the signal.
-    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool {
+    /// before this existed have none, and dropping their seals on upgrade would
+    /// train users to ignore the signal.
+    func trustedNicknameMismatch(fingerprint: String) -> Bool {
         queue.sync {
-            guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty,
-                  !claimedNickname.isEmpty else { return false }
-            return pinned != claimedNickname
+            guard let pinned = cache.trustedNicknames?[fingerprint], !pinned.isEmpty
+            else { return false }
+            let social = cache.socialIdentities[fingerprint]
+            // A local petname outranks the claimed nickname everywhere it is
+            // displayed, so there is nothing to spoof and the seal stands.
+            if let petname = social?.localPetname, !petname.isEmpty { return false }
+            guard let claimed = social?.claimedNickname, !claimed.isEmpty else { return false }
+            // NFC, matching `normalizedNickname` everywhere else nicknames are
+            // compared: a decomposed and a precomposed "café" are one name.
+            return pinned.normalizedNickname != claimed.normalizedNickname
         }
     }
     

--- a/bitchat/Services/BLE/BLEPeerSenderDisplayName.swift
+++ b/bitchat/Services/BLE/BLEPeerSenderDisplayName.swift
@@ -50,9 +50,16 @@ enum BLEPeerSenderDisplayName {
         localNickname: String,
         peers: [PeerID: BLEPeerInfo]
     ) -> String {
+        // Folded, for the same reason as `PeerDisplayNameResolver`: the suffix
+        // exists to make namesakes distinguishable, so a case variant or a
+        // fullwidth Ｍ has to count as a collision. This is the second place
+        // collisions are counted — it feeds sender names on file transfers —
+        // and it had the same exact-match blind spot.
+        let target = PeerDisplayNameResolver.collisionKey(collisionNickname)
         let hasCollision = peers.values.contains {
-            $0.isConnected && $0.nickname == collisionNickname && $0.peerID != peerID
-        } || localNickname == collisionNickname
+            $0.isConnected && PeerDisplayNameResolver.collisionKey($0.nickname) == target
+                && $0.peerID != peerID
+        } || PeerDisplayNameResolver.collisionKey(localNickname) == target
 
         guard hasCollision else { return displayName }
         return displayName + "#" + String(peerID.id.prefix(4))

--- a/bitchat/Utils/PeerDisplayNameResolver.swift
+++ b/bitchat/Utils/PeerDisplayNameResolver.swift
@@ -3,23 +3,40 @@ import BitFoundation
 
 /// Resolves a stable display name for peers, adding a short suffix when collisions exist.
 struct PeerDisplayNameResolver {
+    /// The form two nicknames are judged to collide in. Never displayed.
+    static func collisionKey(_ nickname: String) -> String {
+        nickname.precomposedStringWithCompatibilityMapping.lowercased()
+    }
+
     /// Computes display names with a `#xxxx` suffix for connected peers when nickname collisions occur.
     /// - Parameters:
     ///   - peers: Array of tuples (peerID, nickname, isConnected).
     ///   - selfNickname: The local user's current nickname, included in collision counts to suffix remotes matching it.
     /// - Returns: Map of peerID -> displayName.
     static func resolve(_ peers: [(peerID: PeerID, nickname: String, isConnected: Bool)], selfNickname: String) -> [PeerID: String] {
-        // Count collisions among connected peers and include our own nickname
+        // Count collisions on a FOLDED key, not the displayed name. The point
+        // of the suffix is to make namesakes distinguishable, so anything that
+        // renders alike has to count as a collision.
+        //
+        // Compatibility mapping plus case folding covers more than it looks:
+        // fullwidth Ｍedic, mathematical 𝐌edic, script ℳedic and roman-numeral
+        // Ⅿedic all fold to "medic", and NFKC subsumes the canonical folding
+        // that Swift's String keys were already giving us for free.
+        //
+        // What it does NOT cover is cross-script homoglyphs — Cyrillic М and
+        // Greek Ο have their own compatibility forms — which needs a UTS #39
+        // confusables table. Suffixing the displayed name is unchanged; only
+        // the collision key folds.
         var counts: [String: Int] = [:]
         for p in peers where p.isConnected {
-            counts[p.nickname, default: 0] += 1
+            counts[Self.collisionKey(p.nickname), default: 0] += 1
         }
-        counts[selfNickname, default: 0] += 1
+        counts[Self.collisionKey(selfNickname), default: 0] += 1
 
         var result: [PeerID: String] = [:]
         for p in peers {
             var name = p.nickname
-            if p.isConnected, (counts[p.nickname] ?? 0) > 1 {
+            if p.isConnected, (counts[Self.collisionKey(p.nickname)] ?? 0) > 1 {
                 name += "#" + String(p.peerID.id.prefix(4))
             }
             result[p.peerID] = name

--- a/bitchat/Utils/String+Nickname.swift
+++ b/bitchat/Utils/String+Nickname.swift
@@ -17,6 +17,21 @@ extension String {
         precomposedStringWithCanonicalMapping
     }
 
+    /// Strips ONLY a trailing `#abcd` collision suffix, leaving everything
+    /// else alone.
+    ///
+    /// Deliberately not `splitSuffix()`: that also removes every `@` in the
+    /// string, which is right for parsing a mention but wrong for comparing a
+    /// nickname — nothing in `validateNickname` forbids `@`, so `ravi@hq`
+    /// would compare unequal to itself.
+    var withoutCollisionSuffix: String {
+        guard count >= 5 else { return self }
+        let tail = suffix(5)
+        guard tail.first == "#",
+              tail.dropFirst().allSatisfy({ $0.isHexDigit }) else { return self }
+        return String(dropLast(5))
+    }
+
     /// Split a nickname into base and a '#abcd' suffix if present
     func splitSuffix() -> (String, String) {
         let name = self.replacingOccurrences(of: "@", with: "")

--- a/bitchat/Utils/String+Nickname.swift
+++ b/bitchat/Utils/String+Nickname.swift
@@ -17,6 +17,22 @@ extension String {
         precomposedStringWithCanonicalMapping
     }
 
+    /// The form two nicknames are compared in to decide whether they are the
+    /// SAME NAME — used for the verified-name binding.
+    ///
+    /// NFC plus a locale-independent case fold, twice normalised because case
+    /// folding can itself emit decomposed sequences (Turkish İ lowercases to
+    /// i + U+0307). Recasing your own nickname is not a rename, so it must not
+    /// break the binding.
+    ///
+    /// Deliberately NFC and not NFKC: a fullwidth `Ｍedic` merely *looks* like
+    /// `Medic`, so it is a different name and must break the binding. Folding
+    /// look-alikes is `PeerDisplayNameResolver.collisionKey`'s job, which is
+    /// asking a different question — whether two peers need telling apart.
+    var nicknameBindingKey: String {
+        normalizedNickname.lowercased().normalizedNickname
+    }
+
     /// Strips ONLY a trailing `#abcd` collision suffix, leaving everything
     /// else alone.
     ///
@@ -27,8 +43,14 @@ extension String {
     var withoutCollisionSuffix: String {
         guard count >= 5 else { return self }
         let tail = suffix(5)
-        guard tail.first == "#",
-              tail.dropFirst().allSatisfy({ $0.isHexDigit }) else { return self }
+        // ASCII hex only, matching how `splitSuffix()` recognises the suffix
+        // this device generates. `Character.isHexDigit` would also accept
+        // fullwidth digits, so a nickname literally ending in "#ＡＢＣＤ"
+        // would be truncated and could then match a baseline it is not.
+        let isAsciiHex: (Character) -> Bool = { c in
+            ("0"..."9").contains(c) || ("a"..."f").contains(c) || ("A"..."F").contains(c)
+        }
+        guard tail.first == "#", tail.dropFirst().allSatisfy(isAsciiHex) else { return self }
         return String(dropLast(5))
     }
 

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -448,7 +448,10 @@ private extension ChatMessageFormatter {
               let fingerprint = viewModel.getFingerprint(for: peerID) else {
             return false
         }
-        return viewModel.peerIdentityStore.isVerified(fingerprint)
+        guard viewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
+        // Bound to the rendered name, for the same reason as the peer list and
+        // the DM seal: the badge attests to a key but is read as a name.
+        return !viewModel.trustedNicknameMismatch(fingerprint, displayedSender: message.sender)
     }
 
     func appendVerifiedSeal(

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -449,9 +449,9 @@ private extension ChatMessageFormatter {
             return false
         }
         guard viewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
-        // Bound to the rendered name, for the same reason as the peer list and
-        // the DM seal: the badge attests to a key but is read as a name.
-        return !viewModel.trustedNicknameMismatch(fingerprint, displayedSender: message.sender)
+        // Bound to the name the key announces, for the same reason as the peer
+        // list and the DM seal: the badge attests to a key but is read as a name.
+        return !viewModel.trustedNicknameMismatch(fingerprint)
     }
 
     func appendVerifiedSeal(

--- a/bitchat/ViewModels/ChatMessageFormatter.swift
+++ b/bitchat/ViewModels/ChatMessageFormatter.swift
@@ -448,10 +448,10 @@ private extension ChatMessageFormatter {
               let fingerprint = viewModel.getFingerprint(for: peerID) else {
             return false
         }
-        guard viewModel.peerIdentityStore.isVerified(fingerprint) else { return false }
-        // Bound to the name the key announces, for the same reason as the peer
-        // list and the DM seal: the badge attests to a key but is read as a name.
-        return !viewModel.trustedNicknameMismatch(fingerprint)
+        // Bound to the name ON THIS ROW, which is frozen at receipt — see
+        // `sealAppliesToRow`. This check feeds the format cache key, so the
+        // cache does not shield it; a single call keeps it to one lock.
+        return viewModel.sealAppliesToRow(fingerprint, renderedSender: message.sender)
     }
 
     func appendVerifiedSeal(

--- a/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
+++ b/bitchat/ViewModels/ChatPeerIdentityCoordinator.swift
@@ -76,6 +76,8 @@ protocol ChatPeerIdentityContext: AnyObject {
     /// falling back to `fallback` when none was stored. Returns the migrated fingerprint.
     func migrateFingerprintMapping(from oldPeerID: PeerID, to newPeerID: PeerID, fallback: String?) -> String?
     func isVerifiedFingerprint(_ fingerprint: String) -> Bool
+    /// Whether the peer renamed itself since its trust was established.
+    func trustedNicknameMismatch(_ fingerprint: String) -> Bool
     func setEncryptionStatus(_ status: EncryptionStatus?, for peerID: PeerID)
     func cachedEncryptionStatus(for peerID: PeerID) -> EncryptionStatus?
     func setCachedEncryptionStatus(_ status: EncryptionStatus, for peerID: PeerID)
@@ -437,7 +439,9 @@ final class ChatPeerIdentityCoordinator {
     @MainActor
     func getEncryptionStatus(for peerID: PeerID) -> EncryptionStatus {
         if let cachedStatus = context.cachedEncryptionStatus(for: peerID) {
-            return cachedStatus
+            // Demote on the cache-hit path too — this is the common one, and
+            // nothing invalidates the cache on a rename.
+            return demotedIfRenamed(cachedStatus, for: peerID)
         }
 
         // The status must reflect the LIVE session, never history. The old
@@ -462,7 +466,26 @@ final class ChatPeerIdentityCoordinator {
         }
 
         context.setCachedEncryptionStatus(status, for: peerID)
-        return status
+        return demotedIfRenamed(status, for: peerID)
+    }
+
+    /// `.noiseVerified` renders the same filled seal as the verified badge, and
+    /// for a CONNECTED peer it is the only thing that draws one — so the name
+    /// binding has to apply here too, or the live impersonation keeps its seal.
+    ///
+    /// Applied on the way out rather than stored: the cached status is only
+    /// invalidated by verification and session changes, never by a rename, so a
+    /// demotion written into the cache would be both stale and sticky. The
+    /// session really is Noise-secured; only the claim about *who* is weakened,
+    /// which is exactly the difference between the two cases. Nothing branches
+    /// on `.noiseVerified` beyond the glyph — every behavioural site treats it
+    /// and `.noiseSecured` alike.
+    @MainActor
+    private func demotedIfRenamed(_ status: EncryptionStatus, for peerID: PeerID) -> EncryptionStatus {
+        guard status == .noiseVerified,
+              let fingerprint = getFingerprint(for: peerID),
+              context.trustedNicknameMismatch(fingerprint) else { return status }
+        return .noiseSecured
     }
 
     @MainActor

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1973,6 +1973,29 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
         identityManager.isVouched(fingerprint: fingerprint)
     }
 
+    /// Whether this peer now claims a different nickname than the one its
+    /// trust was established under. Trust badges are suppressed in that case:
+    /// the seal attests to a key, but it is read next to a name, and a key that
+    /// renamed itself onto a name the user trusts is the impersonation this
+    /// warns about.
+    @MainActor
+    func trustedNicknameMismatch(_ fingerprint: String, claimedNickname: String) -> Bool {
+        identityManager.trustedNicknameMismatch(
+            fingerprint: fingerprint,
+            claimedNickname: claimedNickname
+        )
+    }
+
+    /// The same check for a name as *rendered* in a message row. See the
+    /// `displayedSender` overload on `SecureIdentityStateManagerProtocol`.
+    @MainActor
+    func trustedNicknameMismatch(_ fingerprint: String, displayedSender: String) -> Bool {
+        identityManager.trustedNicknameMismatch(
+            fingerprint: fingerprint,
+            displayedSender: displayedSender
+        )
+    }
+
     // MARK: - BitchatDelegate Methods
 
     // MARK: - Command Handling

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1982,6 +1982,20 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
         identityManager.trustedNicknameMismatch(fingerprint: fingerprint)
     }
 
+    /// The name this key was verified under, for a sheet that needs to say
+    /// which one it was.
+    @MainActor
+    func trustedNickname(_ fingerprint: String) -> String? {
+        identityManager.trustedNickname(fingerprint: fingerprint)
+    }
+
+    /// A seal beside a name frozen on a message row: is THAT name the one this
+    /// key was verified under? See `sealAppliesToRow`.
+    @MainActor
+    func sealAppliesToRow(_ fingerprint: String, renderedSender: String) -> Bool {
+        identityManager.sealAppliesToRow(fingerprint: fingerprint, renderedSender: renderedSender)
+    }
+
     // MARK: - BitchatDelegate Methods
 
     // MARK: - Command Handling

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1973,27 +1973,13 @@ final class ChatViewModel: ObservableObject, BitchatDelegate, SynchronousMessage
         identityManager.isVouched(fingerprint: fingerprint)
     }
 
-    /// Whether this peer now claims a different nickname than the one its
-    /// trust was established under. Trust badges are suppressed in that case:
-    /// the seal attests to a key, but it is read next to a name, and a key that
-    /// renamed itself onto a name the user trusts is the impersonation this
-    /// warns about.
+    /// Whether this peer now announces a different nickname than the one its
+    /// trust was established under. Every seal is suppressed in that case: the
+    /// seal attests to a key, but it is read as a name, and a key that renamed
+    /// itself onto a name the user trusts is the impersonation this catches.
     @MainActor
-    func trustedNicknameMismatch(_ fingerprint: String, claimedNickname: String) -> Bool {
-        identityManager.trustedNicknameMismatch(
-            fingerprint: fingerprint,
-            claimedNickname: claimedNickname
-        )
-    }
-
-    /// The same check for a name as *rendered* in a message row. See the
-    /// `displayedSender` overload on `SecureIdentityStateManagerProtocol`.
-    @MainActor
-    func trustedNicknameMismatch(_ fingerprint: String, displayedSender: String) -> Bool {
-        identityManager.trustedNicknameMismatch(
-            fingerprint: fingerprint,
-            displayedSender: displayedSender
-        )
+    func trustedNicknameMismatch(_ fingerprint: String) -> Bool {
+        identityManager.trustedNicknameMismatch(fingerprint: fingerprint)
     }
 
     // MARK: - BitchatDelegate Methods

--- a/bitchatTests/ChatPeerIdentityCoordinatorContextTests.swift
+++ b/bitchatTests/ChatPeerIdentityCoordinatorContextTests.swift
@@ -144,6 +144,12 @@ private final class MockChatPeerIdentityContext: ChatPeerIdentityContext {
         verifiedFingerprintSet.contains(fingerprint)
     }
 
+    var renamedSinceTrust: Set<String> = []
+
+    func trustedNicknameMismatch(_ fingerprint: String) -> Bool {
+        renamedSinceTrust.contains(fingerprint)
+    }
+
     func setEncryptionStatus(_ status: EncryptionStatus?, for peerID: PeerID) {
         encryptionStatuses[peerID] = status
     }
@@ -329,6 +335,52 @@ struct ChatPeerIdentityCoordinatorContextTests {
         #expect(context.selectedPrivateChatPeer == newPeerID)
         // Unread moved to the new peer, then cleared for the now-open chat.
         #expect(context.unreadPrivateMessages.isEmpty)
+    }
+
+    @Test @MainActor
+    func getEncryptionStatus_demotesToSecuredWhenTheKeyRenamedSinceTrust() async {
+        // `.noiseVerified` renders the same filled seal as the verified badge,
+        // and for a CONNECTED peer it is the only thing that draws one. A
+        // verified key that renames itself onto a trusted name must therefore
+        // lose it here too, or the live impersonation keeps its seal.
+        let context = MockChatPeerIdentityContext()
+        let coordinator = ChatPeerIdentityCoordinator(context: context)
+        let peerID = PeerID(str: "1122334455667788")
+
+        context.noiseSessionStates[peerID] = .established
+        context.fingerprintsByPeerID[peerID] = "fp"
+        context.verifiedFingerprintSet = ["fp"]
+        #expect(coordinator.getEncryptionStatus(for: peerID) == .noiseVerified)
+
+        // The rename lands. Nothing invalidates the encryption cache on a
+        // nickname change, so the demotion has to survive the cached value.
+        context.renamedSinceTrust = ["fp"]
+        #expect(coordinator.getEncryptionStatus(for: peerID) == .noiseSecured,
+                "still encrypted, no longer a claim about who")
+        #expect(context.cachedEncryptionStatuses[peerID] == .noiseVerified,
+                "the demotion is computed on read, never written into the cache")
+
+        // Re-verifying under the new name restores it.
+        context.renamedSinceTrust = []
+        #expect(coordinator.getEncryptionStatus(for: peerID) == .noiseVerified)
+    }
+
+    @Test @MainActor
+    func getEncryptionStatus_leavesUnverifiedStatusesAlone() async {
+        let context = MockChatPeerIdentityContext()
+        let coordinator = ChatPeerIdentityCoordinator(context: context)
+        let peerID = PeerID(str: "1122334455667788")
+
+        // A secured-but-unverified session has no seal to lose, and a rename
+        // must not disturb the lock it does show.
+        context.noiseSessionStates[peerID] = .established
+        context.fingerprintsByPeerID[peerID] = "fp"
+        context.renamedSinceTrust = ["fp"]
+        #expect(coordinator.getEncryptionStatus(for: peerID) == .noiseSecured)
+
+        coordinator.invalidateEncryptionCache(for: peerID)
+        context.noiseSessionStates[peerID] = .handshaking
+        #expect(coordinator.getEncryptionStatus(for: peerID) == .noiseHandshaking)
     }
 
     @Test @MainActor

--- a/bitchatTests/Mocks/MockIdentityManager.swift
+++ b/bitchatTests/Mocks/MockIdentityManager.swift
@@ -98,6 +98,14 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
     
     func setVerified(fingerprint: String, verified: Bool) {}
 
+    var trustedNicknames: [String: String] = [:]
+
+    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool {
+        guard let pinned = trustedNicknames[fingerprint], !pinned.isEmpty,
+              !claimedNickname.isEmpty else { return false }
+        return pinned != claimedNickname
+    }
+
     func isVerified(fingerprint: String) -> Bool {
         true
     }

--- a/bitchatTests/Mocks/MockIdentityManager.swift
+++ b/bitchatTests/Mocks/MockIdentityManager.swift
@@ -100,10 +100,12 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
 
     var trustedNicknames: [String: String] = [:]
 
-    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool {
+    var claimedNicknames: [String: String] = [:]
+
+    func trustedNicknameMismatch(fingerprint: String) -> Bool {
         guard let pinned = trustedNicknames[fingerprint], !pinned.isEmpty,
-              !claimedNickname.isEmpty else { return false }
-        return pinned != claimedNickname
+              let claimed = claimedNicknames[fingerprint], !claimed.isEmpty else { return false }
+        return pinned != claimed
     }
 
     func isVerified(fingerprint: String) -> Bool {

--- a/bitchatTests/Mocks/MockIdentityManager.swift
+++ b/bitchatTests/Mocks/MockIdentityManager.swift
@@ -102,6 +102,8 @@ final class MockIdentityManager: SecureIdentityStateManagerProtocol {
 
     var claimedNicknames: [String: String] = [:]
 
+    func trustedNickname(fingerprint: String) -> String? { trustedNicknames[fingerprint] }
+
     func trustedNicknameMismatch(fingerprint: String) -> Bool {
         guard let pinned = trustedNicknames[fingerprint], !pinned.isEmpty,
               let claimed = claimedNicknames[fingerprint], !claimed.isEmpty else { return false }

--- a/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
@@ -1,13 +1,14 @@
 import Foundation
+import BitFoundation
 import Testing
 
 @testable import bitchat
 
-/// Binds a trust badge to the nickname it was earned under.
+/// Binds a trust seal to the nickname it was earned under.
 ///
 /// `VouchAttestation` signs `voucheeFingerprint | voucheeSigningKey |
 /// timestampMs` and deliberately says nothing about a name — a name-free
-/// attestation is the right wire format. But the badge is *rendered* beside a
+/// attestation is the right wire format. But the seal is *rendered* beside a
 /// self-claimed nickname, so the binding has to live on the receiver, which is
 /// the only party that knows what name the key was presenting when it decided
 /// to trust it. These tests pin that rule.
@@ -37,18 +38,24 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         )
     }
 
+    private func setPetname(_ manager: SecureIdentityStateManager,
+                            _ fingerprint: String,
+                            _ petname: String?) {
+        guard var identity = manager.getSocialIdentity(for: fingerprint) else { return }
+        identity.localPetname = petname
+        manager.updateSocialIdentity(identity)
+    }
+
     // MARK: - The attack this closes
 
     @Test
-    func vouch_pinsTheNicknameItWasEarnedUnder() {
+    func vouchPinsTheNicknameItWasEarnedUnder() {
         let manager = makeManager()
         announce(manager, vouchee, as: "ravi")
         manager.setVerified(fingerprint: voucher, verified: true)
 
         #expect(manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date()))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"))
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
-                "the baseline is pinned: any other name is a mismatch")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     @Test
@@ -58,14 +65,11 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         manager.setVerified(fingerprint: voucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
 
-        // Same key, new self-chosen name — the badge must not follow it.
         announce(manager, vouchee, as: "medic")
 
         #expect(manager.isVouched(fingerprint: vouchee),
                 "the vouch itself is still valid; only its binding to a name broke")
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
-                "the baseline stayed on the name the vouch was earned under")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     @Test
@@ -76,12 +80,10 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
         announce(manager, vouchee, as: "medic")
 
-        // A second vouch arriving after the rename must not launder it.
         manager.setVerified(fingerprint: secondVoucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: secondVoucher, timestamp: Date())
 
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee),
                 "the second vouch did not launder the rename")
     }
 
@@ -95,21 +97,20 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         let manager = makeManager()
         manager.setVerified(fingerprint: voucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
                 "nothing is bound yet, so nothing can mismatch")
 
         announce(manager, vouchee, as: "ravi")
-        announce(manager, vouchee, as: "medic")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
 
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
-                "the first name seen while the vouch stood is the binding")
+        announce(manager, vouchee, as: "medic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     @Test
     func theAnnouncePathDoesNotBindBeforeTrustExists() {
         // Otherwise a peer who renamed BEFORE being vouched would be bound to
-        // the name we happened to see first, and lose a legitimate badge.
+        // the name we happened to see first, and lose a legitimate seal.
         let manager = makeManager()
         announce(manager, vouchee, as: "rav")
         announce(manager, vouchee, as: "ravi")
@@ -117,9 +118,8 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         manager.setVerified(fingerprint: voucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
 
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
                 "bound to the name it was vouched under, not the name seen first")
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "rav"))
     }
 
     @Test
@@ -134,8 +134,65 @@ struct SecureIdentityStateManagerNicknameBindingTests {
 
         announce(manager, vouchee, as: "medic")
 
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
                 "known gap, pinned here so it is explicit rather than a surprise")
+    }
+
+    // MARK: - Not fooled by display decoration
+
+    @Test
+    func theCheckIsUnaffectedByCollisionSuffixes() {
+        // `PeerDisplayNameResolver` renders two CONNECTED peers who both claim
+        // "medic" as "medic#a1b2" and "medic#c3d4" — which is exactly what
+        // happens during this attack. Comparing a rendered name would drop the
+        // real medic's seal at the worst possible moment, so the check reads
+        // announced names only. This pins that the resolver really does
+        // decorate, and that the binding ignores it.
+        let real = PeerDisplayNameResolver.resolve(
+            [(peerID: PeerID(str: "a1b2c3d4"), nickname: "medic", isConnected: true),
+             (peerID: PeerID(str: "c3d4e5f6"), nickname: "medic", isConnected: true)],
+            selfNickname: "me")
+        #expect(real[PeerID(str: "a1b2c3d4")] == "medic#a1b2", "the resolver does decorate")
+
+        let manager = makeManager()
+        announce(manager, vouchee, as: "medic")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        announce(manager, vouchee, as: "medic")   // still "medic" on the wire
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
+                "the impersonated peer keeps its seal while a namesake is connected")
+    }
+
+    @Test
+    func aLocalPetnameKeepsTheSeal() {
+        // A petname outranks the claimed nickname everywhere it is displayed,
+        // so a rename cannot spoof anything and the seal stands.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        announce(manager, vouchee, as: "medic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
+
+        setPetname(manager, vouchee, "my neighbour")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
+
+        setPetname(manager, vouchee, nil)
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
+    }
+
+    @Test
+    func namesAreComparedInCanonicalForm() {
+        // Same rule as `normalizedNickname` everywhere else: a decomposed and a
+        // precomposed "café" are one name, not a rename.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "cafe\u{0301}")        // e + combining acute
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        announce(manager, vouchee, as: "caf\u{00E9}")          // precomposed é
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
+
+        announce(manager, vouchee, as: "cafe")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     // MARK: - Rebinding and clearing
@@ -147,13 +204,12 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         manager.setVerified(fingerprint: voucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
         announce(manager, vouchee, as: "medic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
 
         // The user scanned this key themselves, under the name it shows now.
         manager.setVerified(fingerprint: vouchee, verified: true)
 
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
-                "the baseline moved to the name just checked in person")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     @Test
@@ -162,71 +218,39 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         announce(manager, vouchee, as: "ravi")
 
         manager.setVerified(fingerprint: vouchee, verified: true)
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        announce(manager, vouchee, as: "medic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
+
         manager.setVerified(fingerprint: vouchee, verified: false)
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
                 "with no trust left there is no baseline, so nothing to mismatch")
 
         // With a vouch still standing, the baseline has to survive: it is what
-        // that vouch's badge is bound to.
+        // that vouch's seal is bound to.
+        announce(manager, vouchee, as: "ravi")
         manager.setVerified(fingerprint: voucher, verified: true)
         manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
         manager.setVerified(fingerprint: vouchee, verified: true)
         manager.setVerified(fingerprint: vouchee, verified: false)
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
-                "the vouch's badge still needs the name it was bound to")
-    }
-
-    // MARK: - Names as rendered in a message row
-
-    @Test
-    func aDisambiguationSuffixIsNotMistakenForARename() {
-        // Message senders render as "ravi#a1b2" when nicknames collide; the
-        // announced nickname never carries the suffix.
-        let manager = makeManager()
-        announce(manager, vouchee, as: "ravi")
-        manager.setVerified(fingerprint: vouchee, verified: true)
-
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi#a1b2"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "@ravi#a1b2"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi"))
-    }
-
-    @Test
-    func aRenameIsStillCaughtThroughTheSuffix() {
-        let manager = makeManager()
-        announce(manager, vouchee, as: "ravi")
-        manager.setVerified(fingerprint: vouchee, verified: true)
-
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "medic#a1b2"))
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "medic"))
-    }
-
-    @Test
-    func aNameEndingInSomethingSuffixLikeIsNotTruncated() {
-        // "#abcd" only counts as a suffix when those four characters are hex;
-        // a nickname that merely contains '#' must still compare whole.
-        let manager = makeManager()
-        announce(manager, vouchee, as: "ravi#zzzz")
-        manager.setVerified(fingerprint: vouchee, verified: true)
-
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi#zzzz"))
-        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi"))
+        announce(manager, vouchee, as: "medic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee),
+                "the vouch's seal still needs the name it was bound to")
     }
 
     // MARK: - Failing open
 
     @Test
-    func aMissingBaselineNeverSuppressesABadge() {
+    func aMissingBaselineNeverSuppressesASeal() {
         // Verified before the peer ever announced a name — there is nothing to
         // bind to, and pinning "" would read as a mismatch against every later
         // announce. Peers trusted by builds before this shipped land here too,
-        // so an upgrade must not silently drop their badges.
+        // so an upgrade must not silently drop their seals.
         let manager = makeManager()
         manager.setVerified(fingerprint: vouchee, verified: true)
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
 
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"))
+        announce(manager, vouchee, as: "medic")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     @Test
@@ -234,8 +258,9 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         let manager = makeManager()
         announce(manager, vouchee, as: "ravi")
         manager.setVerified(fingerprint: vouchee, verified: true)
+        announce(manager, vouchee, as: "")
 
-        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: ""))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
     // MARK: - Persistence compatibility

--- a/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
@@ -195,6 +195,91 @@ struct SecureIdentityStateManagerNicknameBindingTests {
         #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
     }
 
+    // MARK: - A seal beside a name frozen on a message row
+
+    @Test
+    func renamingBackDoesNotRestoreTheSealOnARowPostedUnderTheOtherName() {
+        // The hole in checking only the CURRENT name: a message row renders
+        // `message.sender` frozen at receipt, so rename away, post, rename
+        // back, and the live name matches the baseline again while the archived
+        // row still reads the name it was posted under.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        announce(manager, vouchee, as: "medic")          // rename
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
+        announce(manager, vouchee, as: "ravi")           // ...and back
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee),
+                "the live name is bound again, which is why the live check alone is not enough")
+
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "medic"),
+                "the row posted as medic must not be sealed")
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi"),
+                "a row posted as ravi still is — that row really was ravi")
+    }
+
+    @Test
+    func aHistoricalRowKeepsItsSealWhileTheKeyIsCurrentlyRenamed() {
+        // The converse, so the rule is not simply "suppress harder": a row
+        // posted under the verified name stays truthful even once that key has
+        // moved on, otherwise ordinary renames retroactively unseal history.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        announce(manager, vouchee, as: "medic")
+
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee), "live name is unbound")
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi"),
+                "but the archived ravi row is still accurate")
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "medic"))
+    }
+
+    @Test
+    func aRowSenderCarryingACollisionSuffixIsStillMatched() {
+        // Message senders render as "ravi#a1b2" when nicknames collide. Only a
+        // trailing #abcd is stripped — `splitSuffix()` would also remove every
+        // "@", and nothing forbids one in a nickname.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi@hq")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi@hq"))
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi@hq#a1b2"))
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi"))
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "medic#a1b2"))
+    }
+
+    @Test
+    func aRowIsNotSealedForAnUnverifiedKeyAndFailsOpenWithNoBaseline() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "ravi"),
+                "no verification, no seal")
+
+        // Verified before any announce: nothing bound, so rows stay sealed as
+        // they did before this existed.
+        let unbound = makeManager()
+        unbound.setVerified(fingerprint: vouchee, verified: true)
+        #expect(unbound.sealAppliesToRow(fingerprint: vouchee, renderedSender: "anything"))
+    }
+
+    @Test
+    func theCombinedLiveQueryAgreesWithItsParts() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        #expect(!manager.isVerifiedAndNameBound(fingerprint: vouchee), "not verified yet")
+
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        #expect(manager.isVerifiedAndNameBound(fingerprint: vouchee))
+        #expect(manager.trustedNickname(fingerprint: vouchee) == "ravi")
+
+        announce(manager, vouchee, as: "medic")
+        #expect(!manager.isVerifiedAndNameBound(fingerprint: vouchee))
+        #expect(manager.trustedNickname(fingerprint: vouchee) == "ravi",
+                "the baseline is what the sheet needs to name")
+    }
+
     // MARK: - Rebinding and clearing
 
     @Test

--- a/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+
+@testable import bitchat
+
+/// Binds a trust badge to the nickname it was earned under.
+///
+/// `VouchAttestation` signs `voucheeFingerprint | voucheeSigningKey |
+/// timestampMs` and deliberately says nothing about a name — a name-free
+/// attestation is the right wire format. But the badge is *rendered* beside a
+/// self-claimed nickname, so the binding has to live on the receiver, which is
+/// the only party that knows what name the key was presenting when it decided
+/// to trust it. These tests pin that rule.
+///
+/// `@MainActor` for the same reason as `SecureIdentityStateManagerVouchTests`:
+/// the manager's blocking `queue.sync` reads must stay off the Swift
+/// Concurrency cooperative pool, or CI's few-core runners deadlock.
+@MainActor
+struct SecureIdentityStateManagerNicknameBindingTests {
+    private let voucher = String(repeating: "0a", count: 32)
+    private let secondVoucher = String(repeating: "0c", count: 32)
+    private let vouchee = String(repeating: "0b", count: 32)
+
+    private func makeManager() -> SecureIdentityStateManager {
+        SecureIdentityStateManager(MockKeychain())
+    }
+
+    /// Mirrors the announce path: the peer tells us what it calls itself.
+    private func announce(_ manager: SecureIdentityStateManager,
+                          _ fingerprint: String,
+                          as nickname: String) {
+        manager.upsertCryptographicIdentity(
+            fingerprint: fingerprint,
+            noisePublicKey: Data(repeating: 0x01, count: 32),
+            signingPublicKey: nil,
+            claimedNickname: nickname
+        )
+    }
+
+    // MARK: - The attack this closes
+
+    @Test
+    func vouch_pinsTheNicknameItWasEarnedUnder() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: voucher, verified: true)
+
+        #expect(manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date()))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"))
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+                "the baseline is pinned: any other name is a mismatch")
+    }
+
+    @Test
+    func renamingOntoATrustedNameAfterEarningAVouchIsAMismatch() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+
+        // Same key, new self-chosen name — the badge must not follow it.
+        announce(manager, vouchee, as: "medic")
+
+        #expect(manager.isVouched(fingerprint: vouchee),
+                "the vouch itself is still valid; only its binding to a name broke")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "the baseline stayed on the name the vouch was earned under")
+    }
+
+    @Test
+    func aLaterVoucherCannotReanchorTheBaselineToTheNewName() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+        announce(manager, vouchee, as: "medic")
+
+        // A second vouch arriving after the rename must not launder it.
+        manager.setVerified(fingerprint: secondVoucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: secondVoucher, timestamp: Date())
+
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "the second vouch did not launder the rename")
+    }
+
+    // MARK: - Vouches for peers we have not seen yet
+
+    @Test
+    func aVouchForAnUnseenPeerBindsOnTheirFirstAnnounce() {
+        // The usual case: the vouch arrives over Noise from someone else and
+        // the vouchee is not in our announce set yet, so there is no name to
+        // bind to at record time.
+        let manager = makeManager()
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "nothing is bound yet, so nothing can mismatch")
+
+        announce(manager, vouchee, as: "ravi")
+        announce(manager, vouchee, as: "medic")
+
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "the first name seen while the vouch stood is the binding")
+    }
+
+    @Test
+    func theAnnouncePathDoesNotBindBeforeTrustExists() {
+        // Otherwise a peer who renamed BEFORE being vouched would be bound to
+        // the name we happened to see first, and lose a legitimate badge.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "rav")
+        announce(manager, vouchee, as: "ravi")
+
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "bound to the name it was vouched under, not the name seen first")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "rav"))
+    }
+
+    @Test
+    func aFirstAnnounceThatIsAlreadyTheImpersonatingNameIsNotCaught() {
+        // The documented limit of receiver-side binding: if we never saw this
+        // key under its real name, the impersonating name IS the baseline.
+        // Only signing the nickname into the attestation closes this, which is
+        // a wire change and deliberately not attempted here.
+        let manager = makeManager()
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+
+        announce(manager, vouchee, as: "medic")
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+                "known gap, pinned here so it is explicit rather than a surprise")
+    }
+
+    // MARK: - Rebinding and clearing
+
+    @Test
+    func verifyingInPersonRebindsToTheCurrentName() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+        announce(manager, vouchee, as: "medic")
+
+        // The user scanned this key themselves, under the name it shows now.
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"),
+                "the baseline moved to the name just checked in person")
+    }
+
+    @Test
+    func unverifyingClearsTheBaselineOnlyWhenNoVouchRemains() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        manager.setVerified(fingerprint: vouchee, verified: false)
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+                "with no trust left there is no baseline, so nothing to mismatch")
+
+        // With a vouch still standing, the baseline has to survive: it is what
+        // that vouch's badge is bound to.
+        manager.setVerified(fingerprint: voucher, verified: true)
+        manager.recordVouch(voucheeFingerprint: vouchee, voucherFingerprint: voucher, timestamp: Date())
+        manager.setVerified(fingerprint: vouchee, verified: true)
+        manager.setVerified(fingerprint: vouchee, verified: false)
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"),
+                "the vouch's badge still needs the name it was bound to")
+    }
+
+    // MARK: - Names as rendered in a message row
+
+    @Test
+    func aDisambiguationSuffixIsNotMistakenForARename() {
+        // Message senders render as "ravi#a1b2" when nicknames collide; the
+        // announced nickname never carries the suffix.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi#a1b2"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "@ravi#a1b2"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi"))
+    }
+
+    @Test
+    func aRenameIsStillCaughtThroughTheSuffix() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "medic#a1b2"))
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "medic"))
+    }
+
+    @Test
+    func aNameEndingInSomethingSuffixLikeIsNotTruncated() {
+        // "#abcd" only counts as a suffix when those four characters are hex;
+        // a nickname that merely contains '#' must still compare whole.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi#zzzz")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi#zzzz"))
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee, displayedSender: "ravi"))
+    }
+
+    // MARK: - Failing open
+
+    @Test
+    func aMissingBaselineNeverSuppressesABadge() {
+        // Verified before the peer ever announced a name — there is nothing to
+        // bind to, and pinning "" would read as a mismatch against every later
+        // announce. Peers trusted by builds before this shipped land here too,
+        // so an upgrade must not silently drop their badges.
+        let manager = makeManager()
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "medic"))
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: "ravi"))
+    }
+
+    @Test
+    func anEmptyClaimedNicknameIsNotAMismatch() {
+        let manager = makeManager()
+        announce(manager, vouchee, as: "ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee, claimedNickname: ""))
+    }
+
+    // MARK: - Persistence compatibility
+
+    @Test
+    func aCacheWrittenBeforeThisFieldExistedStillLoads() throws {
+        let legacyJSON = Data("""
+        {"socialIdentities":{},"nicknameIndex":{},"verifiedFingerprints":["\(vouchee)"],\
+        "lastInteractions":{},"blockedNostrPubkeys":[],"cryptographicIdentities":{},"version":1}
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(IdentityCache.self, from: legacyJSON)
+
+        #expect(decoded.trustedNicknames == nil)
+        #expect(decoded.verifiedFingerprints.contains(vouchee))
+    }
+
+    @Test
+    func theBaselineSurvivesAnEncodeDecodeRoundTrip() throws {
+        var cache = IdentityCache()
+        cache.trustedNicknames = [vouchee: "ravi"]
+
+        let decoded = try JSONDecoder().decode(IdentityCache.self, from: JSONEncoder().encode(cache))
+
+        #expect(decoded.trustedNicknames?[vouchee] == "ravi")
+    }
+}

--- a/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
+++ b/bitchatTests/Services/SecureIdentityStateManagerNicknameBindingTests.swift
@@ -280,6 +280,54 @@ struct SecureIdentityStateManagerNicknameBindingTests {
                 "the baseline is what the sheet needs to name")
     }
 
+    // MARK: - What counts as the same name
+
+    @Test
+    func recasingYourOwnNicknameIsNotARename() {
+        // Found auditing my own revision: the binding compared NFC only, so
+        // changing "Ravi" to "ravi" broke it and silently dropped the seal.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "Ravi")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        announce(manager, vouchee, as: "ravi")
+        #expect(!manager.trustedNicknameMismatch(fingerprint: vouchee))
+        #expect(manager.isVerifiedAndNameBound(fingerprint: vouchee))
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "RAVI"))
+    }
+
+    @Test
+    func aLookAlikeNameDoesBreakTheBinding() {
+        // The other half of that: the binding key is NFC, deliberately not
+        // NFKC. A fullwidth Ｍ merely LOOKS like M, so it is a different name
+        // and must break the binding — folding look-alikes is the collision
+        // resolver's job, which answers a different question.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "Medic")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        announce(manager, vouchee, as: "\u{FF2D}edic")
+        #expect(manager.trustedNicknameMismatch(fingerprint: vouchee))
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "\u{FF2D}edic"))
+    }
+
+    @Test
+    func onlyAnAsciiCollisionSuffixIsStripped() {
+        // `Character.isHexDigit` also accepts fullwidth digits, so a nickname
+        // literally ending in "#ＡＢＣＤ" was being truncated and could then
+        // match a baseline it is not. ASCII only, like `splitSuffix()`.
+        let manager = makeManager()
+        announce(manager, vouchee, as: "medic")
+        manager.setVerified(fingerprint: vouchee, verified: true)
+
+        #expect(manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "medic#a1b2"))
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee,
+                                          renderedSender: "medic#\u{FF21}\u{FF22}\u{FF23}\u{FF24}"),
+                "a fullwidth tail is part of the name, not a suffix this device generates")
+        #expect(!manager.sealAppliesToRow(fingerprint: vouchee, renderedSender: "medic#zzzz"),
+                "non-hex is part of the name too")
+    }
+
     // MARK: - Rebinding and clearing
 
     @Test

--- a/bitchatTests/Services/UnifiedPeerServiceTests.swift
+++ b/bitchatTests/Services/UnifiedPeerServiceTests.swift
@@ -289,6 +289,10 @@ private final class TestIdentityManager: SecureIdentityStateManagerProtocol {
         verified
     }
 
+    // No name binding is exercised here: these tests drive peer-list assembly,
+    // not trust display.
+    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool { false }
+
     // MARK: Vouching (unused by these tests)
 
     @discardableResult

--- a/bitchatTests/Services/UnifiedPeerServiceTests.swift
+++ b/bitchatTests/Services/UnifiedPeerServiceTests.swift
@@ -291,6 +291,7 @@ private final class TestIdentityManager: SecureIdentityStateManagerProtocol {
 
     // No name binding is exercised here: these tests drive peer-list assembly,
     // not trust display.
+    func trustedNickname(fingerprint: String) -> String? { nil }
     func trustedNicknameMismatch(fingerprint: String) -> Bool { false }
 
     // MARK: Vouching (unused by these tests)

--- a/bitchatTests/Services/UnifiedPeerServiceTests.swift
+++ b/bitchatTests/Services/UnifiedPeerServiceTests.swift
@@ -291,7 +291,7 @@ private final class TestIdentityManager: SecureIdentityStateManagerProtocol {
 
     // No name binding is exercised here: these tests drive peer-list assembly,
     // not trust display.
-    func trustedNicknameMismatch(fingerprint: String, claimedNickname: String) -> Bool { false }
+    func trustedNicknameMismatch(fingerprint: String) -> Bool { false }
 
     // MARK: Vouching (unused by these tests)
 

--- a/bitchatTests/Utils/PeerDisplayNameResolverTests.swift
+++ b/bitchatTests/Utils/PeerDisplayNameResolverTests.swift
@@ -69,6 +69,28 @@ struct PeerDisplayNameResolverTests {
     }
 
     @Test
+    func theSenderDisplayNameResolverFoldsTheSameWay() {
+        // Collisions are counted in TWO places. This one feeds sender names on
+        // file transfers and had the same exact-match blind spot; folding only
+        // the peer-list resolver would have left it behind.
+        let mine = PeerID(str: "cccc3333")
+        func info(_ id: PeerID, _ nickname: String) -> BLEPeerInfo {
+            BLEPeerInfo(peerID: id, nickname: nickname, isConnected: true,
+                        noisePublicKey: nil, signingPublicKey: nil,
+                        isVerifiedNickname: true, lastSeen: Date())
+        }
+        let peers: [PeerID: BLEPeerInfo] = [
+            real: info(real, "Medic"),
+            other: info(other, "\u{FF2D}edic"),
+        ]
+        let name = BLEPeerSenderDisplayName.resolveKnownPeer(
+            peerID: other, localPeerID: mine, localNickname: "me",
+            peers: peers, allowConnectedUnverified: true)
+        #expect(name?.contains("#") == true,
+                "a fullwidth namesake must be suffixed here too")
+    }
+
+    @Test
     func theDisplayedNameIsNeverFolded() {
         // Only the collision KEY folds. What is shown stays as its owner typed
         // it, suffix aside.

--- a/bitchatTests/Utils/PeerDisplayNameResolverTests.swift
+++ b/bitchatTests/Utils/PeerDisplayNameResolverTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import BitFoundation
+import Testing
+
+@testable import bitchat
+
+/// The `#abcd` suffix exists so two peers claiming one nickname are
+/// distinguishable. It is therefore only as good as the notion of "one
+/// nickname" it counts with — anything that renders alike has to collide, or
+/// the guard stays silent exactly when two rows look the same.
+@MainActor
+struct PeerDisplayNameResolverTests {
+    private let real = PeerID(str: "aaaa1111")
+    private let other = PeerID(str: "bbbb2222")
+
+    /// True when the resolver decided these two need telling apart.
+    private func suffixed(_ a: String, _ b: String,
+                          connected: Bool = true, selfNickname: String = "me") -> Bool {
+        let out = PeerDisplayNameResolver.resolve(
+            [(peerID: real, nickname: a, isConnected: true),
+             (peerID: other, nickname: b, isConnected: connected)],
+            selfNickname: selfNickname)
+        return (out[real] ?? "").contains("#") || (out[other] ?? "").contains("#")
+    }
+
+    @Test
+    func namesThatRenderAlikeCollide() {
+        #expect(suffixed("Medic", "Medic"), "exact duplicate")
+        #expect(suffixed("Medic", "medic"), "case alone must not make two peers look distinct")
+        #expect(suffixed("Medic", "\u{FF2D}edic"), "fullwidth Ｍ")
+        #expect(suffixed("Medic", "\u{1D40C}edic"), "mathematical bold 𝐌")
+        #expect(suffixed("Medic", "\u{2133}edic"), "script ℳ")
+        #expect(suffixed("Medic", "\u{216F}edic"), "roman numeral Ⅿ")
+        #expect(suffixed("Jos\u{00E9}", "Jose\u{0301}"), "canonically equivalent spellings")
+    }
+
+    @Test
+    func unrelatedNamesDoNotCollide() {
+        #expect(!suffixed("Medic", "Zebra"))
+        #expect(!suffixed("Medic", "Medic2"))
+        #expect(!suffixed("Medic", ""))
+    }
+
+    @Test
+    func crossScriptHomoglyphsAreStillMissed() {
+        // Cyrillic М and Greek Ο have their own compatibility forms, so
+        // folding cannot reach them — that needs a UTS #39 confusables table.
+        // Pinned as a KNOWN gap so it is explicit rather than a surprise, and
+        // so whoever adds the table has a test to flip.
+        #expect(!suffixed("Medic", "\u{041C}\u{0435}dic"), "Cyrillic М + е: known gap")
+        #expect(!suffixed("Organizer", "\u{039F}rganizer"), "Greek Ο: known gap")
+    }
+
+    @Test
+    func onlyConnectedPeersAreSuffixed() {
+        // Unchanged by the folding: an offline namesake still gets no suffix,
+        // which is its own gap and not one this touches.
+        #expect(!suffixed("Medic", "medic", connected: false))
+    }
+
+    @Test
+    func ourOwnNicknameCountsTowardCollisions() {
+        // A remote peer claiming a folded variant of MY nickname must be
+        // suffixed, or it renders as me.
+        let out = PeerDisplayNameResolver.resolve(
+            [(peerID: other, nickname: "\u{FF2D}edic", isConnected: true)],
+            selfNickname: "Medic")
+        #expect((out[other] ?? "").contains("#"))
+    }
+
+    @Test
+    func theDisplayedNameIsNeverFolded() {
+        // Only the collision KEY folds. What is shown stays as its owner typed
+        // it, suffix aside.
+        let out = PeerDisplayNameResolver.resolve(
+            [(peerID: real, nickname: "Medic", isConnected: true),
+             (peerID: other, nickname: "\u{FF2D}edic", isConnected: true)],
+            selfNickname: "me")
+        #expect(out[real]?.hasPrefix("Medic") == true)
+        #expect(out[other]?.hasPrefix("\u{FF2D}edic") == true, "the fullwidth Ｍ is preserved on screen")
+    }
+}


### PR DESCRIPTION
## The gap

A vouched or verified key can rename itself onto a nickname the user trusts and keep rendering the seal beside the new name.

`VouchAttestation.signableBytes` covers `voucheeFingerprint | voucheeSigningKey | timestampMs` and says nothing about a name — which is right, the attestation should stay name-free. But the seal is *rendered* beside a self-claimed nickname, and nothing binds the two:

1. Eve announces `ravi`, meets someone who verifies her, and earns one legitimate vouch.
2. Eve announces `medic`. The rename is free and silent — the only trace is a `SecureLogger.debug` line in `BLEAnnounceHandler`.
3. Every device that trusts the real medic now shows a second trusted-looking medic.

This is the mirror of #1661 — that one is *same nickname, new key*; this is *same key, new nickname*.

## Where the seal actually comes from

Three sources, all now gated:

| Surface | Draws the seal from |
| --- | --- |
| Peer list, peer **offline** | `showsVerifiedBadgeWhenOffline` / `showsVouchedBadge` in `PeerListModel` |
| Peer list, peer **connected**, and the DM header | `EncryptionStatus.noiseVerified.icon` — the same `checkmark.seal.fill` glyph |
| Public timeline and DM rows | `isVerifiedSender` / `showsVerifiedSeal` |

The connected-peer path is the live impersonation and it is the one that runs through `getEncryptionStatus`, so the binding is applied there: `.noiseVerified` demotes to `.noiseSecured` when the key renamed since trust. The session really is encrypted; only the claim about *who* is withdrawn.

No *behaviour* branches on the distinction — `VerificationModel:33`, `ContentSheetViews:659` and `:760` all treat `.noiseVerified` and `.noiseSecured` alike. Four things the user perceives do, and all four are meant to move: the icon, the status caption, the accessibility description (so VoiceOver stops saying "verified" on a demoted DM header), and the green tint on the nickname at `FingerprintView:87` — the one site that does *not* treat the two statuses identically. An earlier revision of this description claimed "nothing moves"; @RodsF1 showed that was 3-for-4, and it is corrected here and in the code comment that repeated it.

The demotion is computed on read, not stored: the cached status is invalidated by verification and session changes but never by a rename, so a demotion written into the cache would be stale and sticky.

## The binding

`IdentityCache` gains `trustedNicknames` — the nickname a key was announcing when this device decided to trust it. Pinned:

- **On the first vouch only**, never moved by a later one. Otherwise the attacker renames and the next voucher silently re-anchors the seal to the new name.
- **Re-verifying does move it** — the user just checked this key in person, under whatever name it shows now.
- **On the first announce seen while trust already stands.** A vouch normally arrives for a peer we have not seen announce: it comes over Noise from someone else and the vouchee may be hops away, so there is no name to bind to at record time. The announce path deliberately does *not* pin before trust exists — binding to whatever name we happened to see first would suppress the seal of a peer who renamed *before* being vouched.
- **Never on an empty nickname, and a missing baseline never suppresses.** Peers trusted by earlier builds have none, and dropping their seals on upgrade would teach users to ignore the signal.

## Two different questions, two different folds

Getting these backwards is how a vouch for one name comes to cover another, so both are named, both are tested, and neither is reused for the other's job.

| Question | Fold | Used by |
| --- | --- | --- |
| Is this the **same name**? | `nicknameBindingKey` — NFC, case, NFC again | the trust binding |
| Do these two **look alike**? | `PeerDisplayNameResolver.collisionKey` — NFKC + case | the `#abcd` disambiguation suffix |

The binding key is deliberately NFC and **not** NFKC: a fullwidth `Ｍedic` merely *looks* like `Medic`, so it is a different name and must break the binding. It case-folds because recasing your own nickname is not a rename — and it re-normalises after folding, because case folding can itself emit decomposed sequences.

The collision key folds the opposite way, and that is @RodsF1's one-liner from review. Folding the **count** key (never the displayed name) closes five categories for free: case, fullwidth, mathematical bold, script `ℳ` and roman-numeral `Ⅿ`. It also makes explicit the canonical folding Swift's `String` keys were already giving incidentally. Cross-script homoglyphs (Cyrillic `М`, Greek `Ο`) still get through; that needs a UTS #39 confusables table, which is its own conversation and not proposed here. Both gaps are pinned as tests so whoever adds the table has something to flip.

Collisions are counted in **two** places — `PeerDisplayNameResolver` and `BLEPeerSenderDisplayName.collisionResolvedName`, which feeds sender names on file transfers. Both had the same exact-match blind spot; folding only the first would have left the second behind.

## It compares announced names, never rendered ones — except on a row

`peer.nickname` is already collision-resolved: `BLEPeerRegistry.transportSnapshots` runs names through `PeerDisplayNameResolver`, which appends `#` plus four hex of the peerID to **connected** peers whose nicknames collide. That is exactly this attack — two connected peers both claiming `medic` — so comparing the displayed string would turn the real medic into `medic#c3d4`, mismatch the pinned `medic`, and **drop the impersonated peer's seal at the worst possible moment.**

So the live check takes no rendered name at all: it compares the pinned baseline to the peer's own announced nickname. A local petname short-circuits it, since a petname outranks the claimed nickname wherever it is displayed and there is nothing to spoof.

A message row asks a different question, and an earlier revision got it wrong. The row renders `message.sender`, frozen at receipt, while the live check gates on the name announced *now* — so: verified as `ravi` → announce `medic` → post → announce `ravi` again, and the archived row renders `<@medic ✓>`, a seal beside a name the key was never trusted under. `sealAppliesToRow(fingerprint:renderedSender:)` therefore checks each row against its own sender and never consults the live name. Requiring both would have retroactively unsealed accurate history every time anyone changed their nickname: a historical `ravi ✓` stays sealed while that key is currently renamed, because that row really was ravi.

Comparing a rendered name needs the suffix off without `splitSuffix()`'s `@` problem — it strips every `@` in the string, which is right for parsing a mention and wrong for comparing a nickname, since `validateUserString` rejects only control characters and `ravi@hq` would compare unequal to itself. Hence `withoutCollisionSuffix`, which removes only a trailing `#` plus four **ASCII** hex digits: `Character.isHexDigit` is also true for fullwidth digits, so a nickname ending in `#ＡＢＣＤ` would otherwise be truncated into something that could match a baseline it is not.

There is a partial mitigation already in the tree, and it is worth being precise about rather than claiming none exists: `PeerDisplayNameResolver` does disambiguate namesakes — but it counts collisions only among *connected* peers and suffixes only connected ones, so it does nothing when the impersonated peer is offline or out of range, and never applies to offline favourite rows. The hole is exactly where this attack aims.

## Scope, and one thing this is not

No wire change, no protocol change, no new user-facing strings. `trustedNicknames` decodes with `decodeIfPresent` like the other post-v1 fields, so caches written by older builds still load.

**This is display-only, and that is a deliberate boundary rather than an oversight.** A renamed key loses its seals but keeps its authority: `recordVouch` still counts it as a voucher, and it is still advertised in outgoing batches. @RodsF1 argued that should change. The reason it does not is that `trustedNicknameMismatch` fires on **any** rename, not on impersonation — gating authority on it would mean your vouches silently stop counting on every device that verified you the moment you change your nickname, with nothing shown to you or to them. The trigger that would justify revoking authority is the narrow one, *this key renamed onto a name another trusted key already holds*, and BitChat has no cross-peer name comparison to detect it. So the honest statement of the finding is "there is no impersonation detector here, only a rename detector". If you read the false-positive budget the other way, say so and I will implement whichever trigger you want — it is your product.

(I checked my own project rather than only arguing, found the identical boundary there, and fixed it — but there a real impersonation detector exists to trigger it.)

**`UnifiedPeerService.getPeerID(for:)` is a second, separate problem**, and I should correct the first revision of this description, which called this purely a display concern. It matches `displayName` or `nickname`, first match wins, with no trust ranking and no ambiguity error, and it backs `/msg`, `/hug`, `/slap`, `/block`, `/unblock`, `/ping`, `/trace` and `/fav` — so a rename can mis-target a command, and `/fav` shares your Nostr key with whoever it resolves to. @RodsF1 has written that up as #1709; it is out of scope here.

**One surface is deliberately only half covered.** In `FingerprintView` the status *icon* flows through `getEncryptionStatus` and demotes like everywhere else, but the text badge at line 227 reads `fingerprintState.isVerified` directly and still says "verified", in green, a few lines below `peerNickname`. Suppressing that text is the wrong fix: the key *is* verified, the sheet is where that distinction should be explained rather than collapsed, and the same flag drives the verify/unverify toggle. The right fix is copy, and a new key has to ship in all 30 locales to pass `LocalizationCoverageTests` — I am not going to machine-translate a security warning into 30 languages in someone else's product.

@RodsF1 has offered the wording and the locales, and the plumbing is already in: `FingerprintPresentationState` carries `verifiedAsNickname` and `nameChangedSinceVerification`, so the two keys wire up with no further changes. The keys are deliberately **not** referenced from code yet — `everyCodeReferencedKeyExistsInACatalog` would fail until the locale patch lands, and pushing a red CI at the maintainer is worse than waiting. The vouched panel just below is gated rather than explained, for the same reason.

Suppressing the seal is the security fix. **Explaining** it to the user is a follow-up — and I originally wrote that it should hang off the notice plumbing in #1661, which I now think is wrong: that path cannot fire in production today (`migrateNoiseKeyUpdate`'s only non-test caller is gated on `userInfo["isKeyUpdate"]`/`["oldPeerPublicKey"]` and nothing posts either key). A follow-up hung on it would inherit the same deadness, so the notice wants wiring to what the transport layer already detects.

## The known limit

Pinned by a test so it is explicit rather than a surprise: if we never saw the key under its real name, its first announce **is** the baseline, so an impersonating first announce is not caught. Receiver-side binding cannot close that. Signing the nickname into the attestation can — that is a wire change and your call, so this PR does not attempt it.

## Tests

- `SecureIdentityStateManagerNicknameBindingTests`, 23 cases: the rename attack, the second-voucher laundering attempt, the vouch-before-first-announce path and its residual gap, the no-pin-before-trust rule, the rename-back on an archived row, a regression guard asserting `PeerDisplayNameResolver` really does decorate and that the binding ignores it, petname and NFC handling, recasing not breaking the binding while a look-alike does, the `@`-in-nickname and fullwidth-hex suffix cases, rebinding on re-verification, clearing on unverify only when no vouch remains, both fail-open cases, and persistence compatibility each way.
- `PeerDisplayNameResolverTests`, 7 cases, a new file — the resolver had none. Includes both known-gap rows as failing-when-fixed markers, a check that the *displayed* name is never folded, and one that the second collision counter folds the same way.
- `ChatPeerIdentityCoordinatorContextTests`, 2 added: the demotion, that it is *not* written into the cache, and that secured/handshaking states are left alone. The first of these caught the demotion being skipped on the cache-hit path.
- `TestIdentityManager`, `MockIdentityManager` and `MockChatPeerIdentityContext` all conform to the changed protocols and are updated. The mock's mismatch check folds exactly like the real one — a double that compared raw strings would call a recase a rename, and which fold applies is the whole subject of this change.

## How this was verified — please read

**@RodsF1 built and ran this on a simulator host at `a74fa10`: macOS and iOS both build, 2038 tests in 220 suites green in 67s**, including the 34 app-bundle suites I cannot execute. That is the only real-toolchain evidence this PR has. Three commits have landed since, so it wants repeating.

**CI has still never run on this PR.** All commits sit at `action_required` behind the first-time-contributor gate — @jackjackbits, the workflows need approving before any of this counts.

What I can run, on a machine with no Xcode, by supplying swift-testing as a package and stripping `#Preview` blocks in a throwaway copy:

- **201 suites / 1975 tests pass, and every difference from unmodified `main` is an addition.** I run each suite in its own process on `main` and on this branch and diff the results: `ChatPeerIdentityCoordinatorContextTests` 8 → 10, plus the two new suites at 7 and 23. Baseline 1943 → 1975.
- **The 17 XCTest-based suites now run too, which they did not in earlier revisions.** XCTest ships with Xcode, so they were previously skipped outright — including `SecureIdentityStateManagerTests`, which is the suite guarding the file this PR adds most to. A small XCTest surface implemented over swift-testing, plus a generated `@Test` per method, executes 210 of them. That harness is **not** in this branch and is evidence of a lower grade than a real XCTest run; I am citing it as "the assertions execute and pass", nothing stronger.
- **Mutation check:** with `liveNameMismatchLocked` stubbed to `return false`, 11 of the binding cases fail; with the `.noiseVerified` demotion stubbed to the identity, the coordinator's demotion case fails. The tests bite, and the ones that still pass under the first stub are the fail-open and persistence cases that should.
- Two suites are not clean in that harness and neither is a result about this change: `NostrRelayManagerTests` has one test that times out under the shim on `main` and on this branch alike, and `VerificationServiceTests` flaked once across four full sweeps and passes in isolation.

A CI run on the simulator remains the gap that matters.
